### PR TITLE
Diya local setup

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,5 @@ VITE_AWS_API_URL=https://t6gymccrfg.execute-api.us-east-1.amazonaws.com/prod
 DATABASE_SECRET_ARN=arn:aws:secretsmanager:region:account:secret:name
 JWT_SECRET=your_jwt_secret_key_here
 WEBSITE_NODE_DEFAULT_VERSION=18
+
+NODE_ENV=local

--- a/.env
+++ b/.env
@@ -5,5 +5,3 @@ VITE_AWS_API_URL=https://t6gymccrfg.execute-api.us-east-1.amazonaws.com/prod
 DATABASE_SECRET_ARN=arn:aws:secretsmanager:region:account:secret:name
 JWT_SECRET=your_jwt_secret_key_here
 WEBSITE_NODE_DEFAULT_VERSION=18
-
-NODE_ENV=local

--- a/.env.local-be
+++ b/.env.local-be
@@ -1,0 +1,2 @@
+# AWS API Gateway URL for production API calls
+VITE_AWS_API_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 *storybook.log
 .env
+.aws-sam

--- a/README_LOCAL.md
+++ b/README_LOCAL.md
@@ -1,0 +1,100 @@
+# BrightBoost Local Setup Guide
+This guide will help you run BrightBoost locally with a temporary database. 
+
+## Prerequisites / Installations
+- Node.js installed 
+- npm installed globally
+- Docker Desktop installed (download from https://www.docker.com/products/docker-desktop/)
+    - You will have to open the app for it to finish installation/initialization.
+- PostgreSQL
+- Git
+
+## AWS Installations:
+- Globally: install AWS SAM CLI 
+    - For MacOS: 
+    ```
+    brew tap aws/tap
+    brew install aws-sam-cli
+    ```
+    - For Linux: `chmod +x sam-install.sh && ./sam-install.sh`
+    - For Windows: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
+    For issues, check docs: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
+- Navigate to `src/lambda`:
+    - Run `npm install aws-lambda @aws-sdk/client-secrets-manager pg bcryptjs jsonwebtoken`
+
+## Step 1: Clone the Repository
+    ```
+    git clone <YOUR_GIT_URL> # Replace <YOUR_GIT_URL> with the actual Git URL of this project
+    cd brightboost 
+    ```
+
+## Step 2: Spin up a Postgres container
+- Run:
+    ```
+    docker compose -f docker-compose-pg.yml up -d
+    ```
+- You should see something like:
+    ```
+    Network brightboost-pg_default   Created
+    Container brightboost-pg-db-1    Started
+    ```
+- The db is accessible through localhost:5435
+
+## Step 3: Build AWS SAM
+- Run the following code:
+    ```
+    cd src/lambda
+    npm run build
+    cd ../..
+    sam build
+    ```
+- Start the local Lambda API:
+    ```
+    sam local start-api --parameter-overrides ParameterKey=Environment,ParameterValue=local
+    ```
+
+## Step 4: Test it
+- In a new terminal, in the root directory:
+    ```
+    curl -X POST http://localhost:3000/api/signup/student \
+    -H "Content-Type: application/json" \
+    -d '{
+        "name": "Test User",
+        "email": "test@test.com",
+        "password": "12345678"
+    }'
+    ```
+- The output should be something like the following:
+    ```
+    {"message":"Student account created successfully","user":{"id":1,"name":"Test User","email":"test@test.com","role":"STUDENT","createdAt":"2025-06-14T00:59:05.430Z"},"token":"<jwt_token>"}
+    ```
+
+## Step 5: Run Frontend
+- While in the root of the repo, run
+    ```
+    npm run local
+    ```
+- This will use the locally run Lambda API from step 3, assuming it's available on localhost:3000 as it is by default
+
+## Tearing Down
+- To stop the local frontend, go to the terminal in which it is running and hit Ctrl+C
+- Similarly for the Lambda API, go to its terminal and hit Ctrl+C
+- For the DB container, go to the root of the repo and run
+    ```
+    docker compose -f docker-compose-pg.yml down
+    ```
+
+## Tips:
+- Anytime you edit files in `src/lambda`:
+    ```
+    cd src/lambda && npm run build
+    cd ../.. && sam build
+    sam local start-api
+    ```
+- You do not need Docker for Lambda itself; SAM uses Docker under the hood
+- You do need Docker running for both SAM and the local Postgres container
+- If you don't need to test backend changes,
+  you can skip these tests and run 'npm run dev' as usual to use the deployed dev backend
+- If you want to change the frontend's API URL from localhost:3000, change the value in .env.local-be
+- After restarting the DB docker container, the data in the DB will not persist.
+  Each time you start the DB, you have to sign up a user before being able to test login

--- a/README_LOCAL.md
+++ b/README_LOCAL.md
@@ -1,96 +1,107 @@
 # BrightBoost Local Setup Guide
-This guide will help you run BrightBoost locally with a temporary database. 
+
+This guide will help you run BrightBoost locally with a temporary database.
 
 ## Prerequisites / Installations
-- Node.js installed 
+
+- Node.js installed
 - npm installed globally
 - Docker Desktop installed (download from https://www.docker.com/products/docker-desktop/)
-    - You will have to open the app for it to finish installation/initialization.
+  - You will have to open the app for it to finish installation/initialization.
 - PostgreSQL
 - Git
 
 ## AWS Installations:
-- Globally: install AWS SAM CLI 
-    - For MacOS: 
-    ```
-    brew tap aws/tap
-    brew install aws-sam-cli
-    ```
-    - For Linux: `chmod +x sam-install.sh && ./sam-install.sh`
-    - For Windows: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
+
+- Globally: install AWS SAM CLI
+  - For MacOS:
+  ```
+  brew tap aws/tap
+  brew install aws-sam-cli
+  ```
+
+  - For Linux: `chmod +x sam-install.sh && ./sam-install.sh`
+  - For Windows: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
     For issues, check docs: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
 - Navigate to `src/lambda`:
-    - Run `npm install aws-lambda @aws-sdk/client-secrets-manager pg bcryptjs jsonwebtoken`
+  - Run `npm install aws-lambda @aws-sdk/client-secrets-manager pg bcryptjs jsonwebtoken`
 
 ## Step 1: Clone the Repository
+
     ```
     git clone <YOUR_GIT_URL> # Replace <YOUR_GIT_URL> with the actual Git URL of this project
-    cd brightboost 
+    cd brightboost
     ```
 
 ## Step 2: Spin up a Postgres container
+
 - Run:
-    ```
-    docker compose -f docker-compose-pg.yml up -d
-    ```
+  ```
+  docker compose -f docker-compose-pg.yml up -d
+  ```
 - You should see something like:
-    ```
-    Network brightboost-pg_default   Created
-    Container brightboost-pg-db-1    Started
-    ```
+  ```
+  Network brightboost-pg_default   Created
+  Container brightboost-pg-db-1    Started
+  ```
 - The db is accessible through localhost:5435
 
 ## Step 3: Build AWS SAM
+
 - Run the following code:
-    ```
-    cd src/lambda
-    npm run build
-    cd ../..
-    sam build
-    ```
+  ```
+  cd src/lambda
+  npm run build
+  cd ../..
+  sam build
+  ```
 - Start the local Lambda API:
-    ```
-    sam local start-api --parameter-overrides ParameterKey=Environment,ParameterValue=local
-    ```
+  ```
+  sam local start-api --parameter-overrides ParameterKey=Environment,ParameterValue=local
+  ```
 
 ## Step 4: Test it
+
 - In a new terminal, in the root directory:
-    ```
-    curl -X POST http://localhost:3000/api/signup/student \
-    -H "Content-Type: application/json" \
-    -d '{
-        "name": "Test User",
-        "email": "test@test.com",
-        "password": "12345678"
-    }'
-    ```
+  ```
+  curl -X POST http://localhost:3000/api/signup/student \
+  -H "Content-Type: application/json" \
+  -d '{
+      "name": "Test User",
+      "email": "test@test.com",
+      "password": "12345678"
+  }'
+  ```
 - The output should be something like the following:
-    ```
-    {"message":"Student account created successfully","user":{"id":1,"name":"Test User","email":"test@test.com","role":"STUDENT","createdAt":"2025-06-14T00:59:05.430Z"},"token":"<jwt_token>"}
-    ```
+  ```
+  {"message":"Student account created successfully","user":{"id":1,"name":"Test User","email":"test@test.com","role":"STUDENT","createdAt":"2025-06-14T00:59:05.430Z"},"token":"<jwt_token>"}
+  ```
 
 ## Step 5: Run Frontend
+
 - While in the root of the repo, run
-    ```
-    npm run local
-    ```
+  ```
+  npm run local
+  ```
 - This will use the locally run Lambda API from step 3, assuming it's available on localhost:3000 as it is by default
 
 ## Tearing Down
+
 - To stop the local frontend, go to the terminal in which it is running and hit Ctrl+C
 - Similarly for the Lambda API, go to its terminal and hit Ctrl+C
 - For the DB container, go to the root of the repo and run
-    ```
-    docker compose -f docker-compose-pg.yml down
-    ```
+  ```
+  docker compose -f docker-compose-pg.yml down
+  ```
 
 ## Tips:
+
 - Anytime you edit files in `src/lambda`:
-    ```
-    cd src/lambda && npm run build
-    cd ../.. && sam build
-    sam local start-api
-    ```
+  ```
+  cd src/lambda && npm run build
+  cd ../.. && sam build
+  sam local start-api
+  ```
 - You do not need Docker for Lambda itself; SAM uses Docker under the hood
 - You do need Docker running for both SAM and the local Postgres container
 - If you don't need to test backend changes,

--- a/docker-compose-pg.yml
+++ b/docker-compose-pg.yml
@@ -1,0 +1,11 @@
+name: brightboost-pg
+
+services:
+  db:
+    image: postgres
+    ports:
+      - "127.0.0.1:5435:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=brightboostpass
+      - POSTGRES_DB=brightboost

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "local": "vite --mode local-be",
     "build": "tsc && vite build && node copy-static-config.js",
     "build:dev": "vite build --mode development",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",

--- a/src/lambda/login.ts
+++ b/src/lambda/login.ts
@@ -24,7 +24,6 @@ let dbPool: Pool | null = null;
 const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 
 async function getDbConnection(): Promise<Pool> {
-  console.log('env', process.env);
   if (!dbPool) {
     console.log("Creating new database connection pool...");
     let secret: DatabaseSecret;
@@ -50,10 +49,10 @@ async function getDbConnection(): Promise<Pool> {
       }
 
       secret = JSON.parse(secretResult.SecretString);
-      console.log(
-        `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
-      );
     }
+    console.log(
+      `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
+    );
 
     dbPool = new Pool({
       host: secret.host,

--- a/src/lambda/login.ts
+++ b/src/lambda/login.ts
@@ -24,24 +24,36 @@ let dbPool: Pool | null = null;
 const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 
 async function getDbConnection(): Promise<Pool> {
+  console.log('env', process.env);
   if (!dbPool) {
     console.log("Creating new database connection pool...");
-    const secretArn = process.env.DATABASE_SECRET_ARN;
-    if (!secretArn) {
-      throw new Error("DATABASE_SECRET_ARN environment variable not set");
-    }
+    let secret: DatabaseSecret;
+    if (process.env.NODE_ENV === "local") {
+      secret = {
+        host: "host.docker.internal",
+        port: 5435,
+        dbname: "brightboost",
+        username: "postgres",
+        password: "brightboostpass",
+      };
+    } else {
+      const secretArn = process.env.DATABASE_SECRET_ARN;
+      if (!secretArn) {
+        throw new Error("DATABASE_SECRET_ARN environment variable not set");
+      }
 
-    console.log("Fetching database secret from Secrets Manager...");
-    const command = new GetSecretValueCommand({ SecretId: secretArn });
-    const secretResult = await secretsManager.send(command);
-    if (!secretResult.SecretString) {
-      throw new Error("Failed to retrieve database secret");
-    }
+      console.log("Fetching database secret from Secrets Manager...");
+      const command = new GetSecretValueCommand({ SecretId: secretArn });
+      const secretResult = await secretsManager.send(command);
+      if (!secretResult.SecretString) {
+        throw new Error("Failed to retrieve database secret");
+      }
 
-    const secret: DatabaseSecret = JSON.parse(secretResult.SecretString);
-    console.log(
-      `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
-    );
+      secret = JSON.parse(secretResult.SecretString);
+      console.log(
+        `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
+      );
+    }
 
     dbPool = new Pool({
       host: secret.host,
@@ -49,7 +61,7 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: {
+      ssl: process.env.NODE_ENV === "local" ? false : {
         rejectUnauthorized: false,
       },
       max: 5,

--- a/src/lambda/login.ts
+++ b/src/lambda/login.ts
@@ -60,9 +60,12 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: process.env.NODE_ENV === "local" ? false : {
-        rejectUnauthorized: false,
-      },
+      ssl:
+        process.env.NODE_ENV === "local"
+          ? false
+          : {
+              rejectUnauthorized: false,
+            },
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 25000,

--- a/src/lambda/student-dashboard.ts
+++ b/src/lambda/student-dashboard.ts
@@ -54,9 +54,12 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: process.env.NODE_ENV === "local" ? false : {
-        rejectUnauthorized: false,
-      },
+      ssl:
+        process.env.NODE_ENV === "local"
+          ? false
+          : {
+              rejectUnauthorized: false,
+            },
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 25000,
@@ -81,7 +84,8 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   const headers = {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "https://brave-bay-0bfacc110-production.centralus.6.azurestaticapps.net",
+    "Access-Control-Allow-Origin":
+      "https://brave-bay-0bfacc110-production.centralus.6.azurestaticapps.net",
     "Access-Control-Allow-Headers": "Content-Type,Authorization,x-api-key",
     "Access-Control-Allow-Methods": "GET,OPTIONS",
   };
@@ -100,8 +104,9 @@ export const handler = async (
       };
     }
 
-    const authHeader = event.headers.Authorization || event.headers.authorization;
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const authHeader =
+      event.headers.Authorization || event.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return {
         statusCode: 401,
         headers,
@@ -111,7 +116,7 @@ export const handler = async (
 
     const token = authHeader.substring(7);
     const jwtSecret = process.env.JWT_SECRET || "fallback-secret-key";
-    
+
     let decoded;
     try {
       decoded = jwt.verify(token, jwtSecret) as any;
@@ -123,7 +128,7 @@ export const handler = async (
       };
     }
 
-    if (decoded.role !== 'STUDENT') {
+    if (decoded.role !== "STUDENT") {
       return {
         statusCode: 403,
         headers,
@@ -142,29 +147,29 @@ export const handler = async (
           id: "course-1",
           name: "Math 101",
           grade: "A",
-          teacher: "Ms. Johnson"
+          teacher: "Ms. Johnson",
         },
         {
-          id: "course-2", 
+          id: "course-2",
           name: "Science 202",
           grade: "B+",
-          teacher: "Mr. Smith"
-        }
+          teacher: "Mr. Smith",
+        },
       ],
       assignments: [
         {
           id: "assignment-1",
           title: "Math Homework",
           dueDate: "2024-01-15",
-          status: "pending"
+          status: "pending",
         },
         {
           id: "assignment-2",
-          title: "Science Project", 
+          title: "Science Project",
           dueDate: "2024-01-10",
-          status: "completed"
-        }
-      ]
+          status: "completed",
+        },
+      ],
     };
 
     return {

--- a/src/lambda/student-dashboard.ts
+++ b/src/lambda/student-dashboard.ts
@@ -20,19 +20,30 @@ const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 async function getDbConnection(): Promise<Pool> {
   if (!dbPool) {
     console.log("Creating new database connection pool...");
-    const secretArn = process.env.DATABASE_SECRET_ARN;
-    if (!secretArn) {
-      throw new Error("DATABASE_SECRET_ARN environment variable not set");
-    }
+    let secret: DatabaseSecret;
+    if (process.env.NODE_ENV === "local") {
+      secret = {
+        host: "host.docker.internal",
+        port: 5435,
+        dbname: "brightboost",
+        username: "postgres",
+        password: "brightboostpass",
+      };
+    } else {
+      const secretArn = process.env.DATABASE_SECRET_ARN;
+      if (!secretArn) {
+        throw new Error("DATABASE_SECRET_ARN environment variable not set");
+      }
 
-    console.log("Fetching database secret from Secrets Manager...");
-    const command = new GetSecretValueCommand({ SecretId: secretArn });
-    const secretResult = await secretsManager.send(command);
-    if (!secretResult.SecretString) {
-      throw new Error("Failed to retrieve database secret");
-    }
+      console.log("Fetching database secret from Secrets Manager...");
+      const command = new GetSecretValueCommand({ SecretId: secretArn });
+      const secretResult = await secretsManager.send(command);
+      if (!secretResult.SecretString) {
+        throw new Error("Failed to retrieve database secret");
+      }
 
-    const secret: DatabaseSecret = JSON.parse(secretResult.SecretString);
+      secret = JSON.parse(secretResult.SecretString);
+    }
     console.log(
       `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
     );
@@ -43,7 +54,7 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: {
+      ssl: process.env.NODE_ENV === "local" ? false : {
         rejectUnauthorized: false,
       },
       max: 5,

--- a/src/lambda/student-signup.ts
+++ b/src/lambda/student-signup.ts
@@ -27,22 +27,34 @@ const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 async function getDbConnection(): Promise<Pool> {
   if (!dbPool) {
     console.log("Creating new database connection pool...");
-    const secretArn = process.env.DATABASE_SECRET_ARN;
-    if (!secretArn) {
-      throw new Error("DATABASE_SECRET_ARN environment variable not set");
-    }
+    let secret: DatabaseSecret;
+    console.log("node env", process.env.NODE_ENV);
+    if (process.env.NODE_ENV === "local") {
+      secret = {
+        host: "host.docker.internal",
+        port: 5435,
+        dbname: "brightboost",
+        username: "postgres",
+        password: "brightboostpass",
+      };
+    } else {
+      const secretArn = process.env.DATABASE_SECRET_ARN;
+      if (!secretArn) {
+        throw new Error("DATABASE_SECRET_ARN environment variable not set");
+      }
 
-    console.log("Fetching database secret from Secrets Manager...");
-    const command = new GetSecretValueCommand({ SecretId: secretArn });
-    const secretResult = await secretsManager.send(command);
-    if (!secretResult.SecretString) {
-      throw new Error("Failed to retrieve database secret");
-    }
+      console.log("Fetching database secret from Secrets Manager...");
+      const command = new GetSecretValueCommand({ SecretId: secretArn });
+      const secretResult = await secretsManager.send(command);
+      if (!secretResult.SecretString) {
+        throw new Error("Failed to retrieve database secret");
+      }
 
-    const secret: DatabaseSecret = JSON.parse(secretResult.SecretString);
-    console.log(
-      `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
-    );
+      secret = JSON.parse(secretResult.SecretString);
+      console.log(
+        `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
+      );
+    }
 
     dbPool = new Pool({
       host: secret.host,
@@ -50,7 +62,7 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: {
+      ssl: process.env.NODE_ENV === "local" ? false : {
         rejectUnauthorized: false,
       },
       max: 5,

--- a/src/lambda/student-signup.ts
+++ b/src/lambda/student-signup.ts
@@ -61,9 +61,12 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: process.env.NODE_ENV === "local" ? false : {
-        rejectUnauthorized: false,
-      },
+      ssl:
+        process.env.NODE_ENV === "local"
+          ? false
+          : {
+              rejectUnauthorized: false,
+            },
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 25000,

--- a/src/lambda/student-signup.ts
+++ b/src/lambda/student-signup.ts
@@ -28,7 +28,6 @@ async function getDbConnection(): Promise<Pool> {
   if (!dbPool) {
     console.log("Creating new database connection pool...");
     let secret: DatabaseSecret;
-    console.log("node env", process.env.NODE_ENV);
     if (process.env.NODE_ENV === "local") {
       secret = {
         host: "host.docker.internal",
@@ -51,10 +50,10 @@ async function getDbConnection(): Promise<Pool> {
       }
 
       secret = JSON.parse(secretResult.SecretString);
-      console.log(
-        `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
-      );
     }
+    console.log(
+      `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
+    );
 
     dbPool = new Pool({
       host: secret.host,

--- a/src/lambda/teacher-dashboard.ts
+++ b/src/lambda/teacher-dashboard.ts
@@ -20,19 +20,30 @@ const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 async function getDbConnection(): Promise<Pool> {
   if (!dbPool) {
     console.log("Creating new database connection pool...");
-    const secretArn = process.env.DATABASE_SECRET_ARN;
-    if (!secretArn) {
-      throw new Error("DATABASE_SECRET_ARN environment variable not set");
-    }
+    let secret: DatabaseSecret;
+    if (process.env.NODE_ENV === "local") {
+      secret = {
+        host: "host.docker.internal",
+        port: 5435,
+        dbname: "brightboost",
+        username: "postgres",
+        password: "brightboostpass",
+      };
+    } else {
+      const secretArn = process.env.DATABASE_SECRET_ARN;
+      if (!secretArn) {
+        throw new Error("DATABASE_SECRET_ARN environment variable not set");
+      }
 
-    console.log("Fetching database secret from Secrets Manager...");
-    const command = new GetSecretValueCommand({ SecretId: secretArn });
-    const secretResult = await secretsManager.send(command);
-    if (!secretResult.SecretString) {
-      throw new Error("Failed to retrieve database secret");
-    }
+      console.log("Fetching database secret from Secrets Manager...");
+      const command = new GetSecretValueCommand({ SecretId: secretArn });
+      const secretResult = await secretsManager.send(command);
+      if (!secretResult.SecretString) {
+        throw new Error("Failed to retrieve database secret");
+      }
 
-    const secret: DatabaseSecret = JSON.parse(secretResult.SecretString);
+      secret = JSON.parse(secretResult.SecretString);
+    }
     console.log(
       `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
     );
@@ -43,7 +54,7 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: {
+      ssl: process.env.NODE_ENV === "local" ? false : {
         rejectUnauthorized: false,
       },
       max: 5,

--- a/src/lambda/teacher-dashboard.ts
+++ b/src/lambda/teacher-dashboard.ts
@@ -54,9 +54,12 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: process.env.NODE_ENV === "local" ? false : {
-        rejectUnauthorized: false,
-      },
+      ssl:
+        process.env.NODE_ENV === "local"
+          ? false
+          : {
+              rejectUnauthorized: false,
+            },
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 25000,
@@ -81,7 +84,8 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   const headers = {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "https://brave-bay-0bfacc110-production.centralus.6.azurestaticapps.net",
+    "Access-Control-Allow-Origin":
+      "https://brave-bay-0bfacc110-production.centralus.6.azurestaticapps.net",
     "Access-Control-Allow-Headers": "Content-Type,Authorization,x-api-key",
     "Access-Control-Allow-Methods": "GET,OPTIONS",
   };
@@ -100,8 +104,9 @@ export const handler = async (
       };
     }
 
-    const authHeader = event.headers.Authorization || event.headers.authorization;
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const authHeader =
+      event.headers.Authorization || event.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return {
         statusCode: 401,
         headers,
@@ -111,7 +116,7 @@ export const handler = async (
 
     const token = authHeader.substring(7);
     const jwtSecret = process.env.JWT_SECRET || "fallback-secret-key";
-    
+
     let decoded;
     try {
       decoded = jwt.verify(token, jwtSecret) as any;
@@ -123,7 +128,7 @@ export const handler = async (
       };
     }
 
-    if (decoded.role !== 'TEACHER') {
+    if (decoded.role !== "TEACHER") {
       return {
         statusCode: 403,
         headers,
@@ -147,14 +152,14 @@ export const handler = async (
           id: "course-1",
           name: "Math 101",
           grade: "A",
-          teacher: "Stub Teacher"
+          teacher: "Stub Teacher",
         },
         {
-          id: "course-2", 
+          id: "course-2",
           name: "Science 202",
           grade: "B+",
-          teacher: "Stub Teacher"
-        }
+          teacher: "Stub Teacher",
+        },
       ],
       notifications: [],
       lessons: [

--- a/src/lambda/teacher-signup.ts
+++ b/src/lambda/teacher-signup.ts
@@ -63,9 +63,12 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: process.env.NODE_ENV === "local" ? false : {
-        rejectUnauthorized: false,
-      },
+      ssl:
+        process.env.NODE_ENV === "local"
+          ? false
+          : {
+              rejectUnauthorized: false,
+            },
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 25000,

--- a/src/lambda/teacher-signup.ts
+++ b/src/lambda/teacher-signup.ts
@@ -29,19 +29,30 @@ const secretsManager = new SecretsManagerClient({ region: "us-east-1" });
 async function getDbConnection(): Promise<Pool> {
   if (!dbPool) {
     console.log("Creating new database connection pool...");
-    const secretArn = process.env.DATABASE_SECRET_ARN;
-    if (!secretArn) {
-      throw new Error("DATABASE_SECRET_ARN environment variable not set");
-    }
+    let secret: DatabaseSecret;
+    if (process.env.NODE_ENV === "local") {
+      secret = {
+        host: "host.docker.internal",
+        port: 5435,
+        dbname: "brightboost",
+        username: "postgres",
+        password: "brightboostpass",
+      };
+    } else {
+      const secretArn = process.env.DATABASE_SECRET_ARN;
+      if (!secretArn) {
+        throw new Error("DATABASE_SECRET_ARN environment variable not set");
+      }
 
-    console.log("Fetching database secret from Secrets Manager...");
-    const command = new GetSecretValueCommand({ SecretId: secretArn });
-    const secretResult = await secretsManager.send(command);
-    if (!secretResult.SecretString) {
-      throw new Error("Failed to retrieve database secret");
-    }
+      console.log("Fetching database secret from Secrets Manager...");
+      const command = new GetSecretValueCommand({ SecretId: secretArn });
+      const secretResult = await secretsManager.send(command);
+      if (!secretResult.SecretString) {
+        throw new Error("Failed to retrieve database secret");
+      }
 
-    const secret: DatabaseSecret = JSON.parse(secretResult.SecretString);
+      secret = JSON.parse(secretResult.SecretString);
+    }
     console.log(
       `Database config: host=${secret.host}, port=${secret.port}, dbname=${secret.dbname}`,
     );
@@ -52,7 +63,7 @@ async function getDbConnection(): Promise<Pool> {
       database: secret.dbname,
       user: secret.username,
       password: secret.password,
-      ssl: {
+      ssl: process.env.NODE_ENV === "local" ? false : {
         rejectUnauthorized: false,
       },
       max: 5,

--- a/template.yaml
+++ b/template.yaml
@@ -173,7 +173,7 @@ Resources:
             Path: /api/student/dashboard
             Method: get
             RestApiId: !Ref AuthApi
-  
+
   TeacherDashboardFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -250,7 +250,7 @@ Outputs:
   StudentDashboardFunctionArn:
     Description: "Student Dashboard Lambda Function ARN"
     Value: !GetAtt StudentDashboardFunction.Arn
-  
+
   TeacherDashboardApiUrl:
     Description: "API Gateway endpoint URL for Teacher Dashboard function"
     Value: !Sub "https://${AuthApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/api/teacher/dashboard"

--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@ Parameters:
   Environment:
     Type: String
     Default: dev
-    AllowedValues: [dev, staging, prod]
+    AllowedValues: [dev, staging, prod, local]
 
   DatabaseSecretArn:
     Type: String

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => ({
     proxy: {
       "/api": {
         target:
-          process.env.AWS_API_URL ||
+          loadEnv(mode, process.cwd()).VITE_AWS_API_URL ||
           "https://t6gymccrfg.execute-api.us-east-1.amazonaws.com/prod",
         changeOrigin: true,
         secure: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => ({
     proxy: {
       "/api": {
         target:
-          process.env.VITE_AWS_API_URL ||
+          process.env.AWS_API_URL ||
           "https://t6gymccrfg.execute-api.us-east-1.amazonaws.com/prod",
         changeOrigin: true,
         secure: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(({ mode }) => ({
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
- For lambda handlers, add an option to set the NODE_ENV to "local". In each handler, check if this NODE_ENV == "local" to determine if we should try accessing the deployed dev database or a local one.
- For frontend, dynamically set the API URL in vite.config.ts based on an environment variable and a new mode option "local-be". Also added a command in package.json to run with this new mode
- For the db, added a docker compose file to run the container from Diya's original README