### PR TITLE
⚡ Bolt: Parallelize avatar update and ability fetch

### DIFF
--- a/backend/src/services/game.ts
+++ b/backend/src/services/game.ts
@@ -33,18 +33,23 @@ export async function checkUnlocks(
   let newAbilitiesCount = 0;
 
   if (newLevel > avatar.level) {
-    avatar = await prisma.avatar.update({
-      where: { id: avatar.id },
-      data: { level: newLevel, xp: { increment: 100 } },
-    });
+    // ⚡ Bolt Optimization: Parallelize avatar update and ability fetch
+    // These operations are independent (ability fetch uses avatar.archetype from existing avatar object)
+    // This saves ~1 DB round trip latency during level-up events.
+    const [updatedAvatar, eligibleAbilities] = await Promise.all([
+      prisma.avatar.update({
+        where: { id: avatar.id },
+        data: { level: newLevel, xp: { increment: 100 } },
+      }),
+      prisma.ability.findMany({
+        where: { archetype: avatar.archetype, reqLevel: { lte: newLevel } },
+      }),
+    ]);
+
+    avatar = updatedAvatar;
 
     // Capture avatarId for use in closures (TS can't narrow `let` across callbacks)
     const avatarId = avatar.id;
-
-    // Batch fetch & create to avoid N+1 query
-    const eligibleAbilities = await prisma.ability.findMany({
-      where: { archetype: avatar.archetype, reqLevel: { lte: newLevel } },
-    });
 
     if (eligibleAbilities.length > 0) {
       const existingUnlocks = await prisma.unlockedAbility.findMany({


### PR DESCRIPTION
⚡ Bolt: Parallelize avatar update and ability fetch

💡 What:
Refactored `checkUnlocks` in `backend/src/services/game.ts` to execute `prisma.avatar.update` and `prisma.ability.findMany` concurrently using `Promise.all` during the level-up logic.

🎯 Why:
Previously, these two database operations were executed sequentially. Since the ability fetch depends on the `avatar.archetype` (available from the initial state) and the `newLevel` (calculated locally), it does not need to wait for the avatar update to complete. Parallelizing them reduces the total latency of the level-up transaction by the duration of the faster operation (saving ~1 DB round trip).

📊 Impact:
- Reduces latency for the "level up" flow.
- Minimal code change (< 20 lines modified).
- Safe optimization with no change to logic or data integrity.

🔬 Measurement:
- `backend/src/services/game.test.ts` passes (verifies correctness).
- All backend tests passed.

---
*PR created automatically by Jules for task [3948163616733491911](https://jules.google.com/task/3948163616733491911) started by @BrightBoost-Tech*