### PR TITLE
docs: refresh Set 2 status, note locale fallbacks, and add G3-5 boost-path keys

### DIFF
--- a/docs/k2-set2-expansion.md
+++ b/docs/k2-set2-expansion.md
@@ -71,9 +71,10 @@ npx prisma db seed
 
 ## Follow-Up Items
 
-1. **Game implementations** — The 5 Set 2 game components need to be built. Currently they fall through to ActivityPlayer's "unsupported" fallback. Each needs a React game component registered in `gameRegistry.ts`.
-2. **Upper-elementary (g3-5) expansion** — The `gradeBand` field on Course and band-filtered module variants are implemented and seeded for planning/demo use, but playable g3-5 React game implementations are still pending.
-3. **Analytics events** — Add `pack_2_locked_viewed`, `pack_2_unlocked`, `module_started`, `module_completed` events when an analytics system is adopted.
-4. **Teacher preview** — Allow teachers to preview Set 2 modules regardless of their own progress (role-based override).
-5. **Feature flag** — Wrap Set 2 behind `brightboost_k2_set2` flag once a flag system is added.
-6. **Set 3 activation** — Replace Set 3 placeholder IDs with real modules when ready.
+1. **Set 2 gameplay status** — All 5 Set 2 game keys (`maze_maps`, `move_measure`, `sky_shield`, `fast_lane`, `qualify_tune_race`) are implemented and registered in `src/components/games/gameRegistry.ts`; they should no longer hit the unsupported fallback for valid Set 2 content.
+2. **Localization gap for Set 2 story/quiz payloads** — Seeded Set 2 narrative and quiz blocks in `prisma/seed.cjs` / `backend/prisma/seed.cjs` currently include only `{ en, es }`. For `vi` and `zh-CN`, the app falls back to English via localized-content resolution at runtime.
+3. **Upper-elementary (g3-5) expansion** — The `gradeBand` field on Course and band-filtered module variants are implemented and seeded for planning/demo use, but playable g3-5 React game implementations are still pending.
+4. **Analytics events** — Add `pack_2_locked_viewed`, `pack_2_unlocked`, `module_started`, `module_completed` events when an analytics system is adopted.
+5. **Teacher preview** — Allow teachers to preview Set 2 modules regardless of their own progress (role-based override).
+6. **Feature flag** — Wrap Set 2 behind `brightboost_k2_set2` flag once a flag system is added.
+7. **Set 3 activation** — Replace Set 3 placeholder IDs with real modules when ready.

--- a/docs/set-2-games-audit.md
+++ b/docs/set-2-games-audit.md
@@ -42,11 +42,10 @@ The shared React component `src/components/unity/UnityWebGL.tsx`:
 2. Parses `activity.content` as JSON
 3. Routes by `activity.kind`:
    - `INFO` → Story slides + quiz questions
-   - `INTERACT` → Dispatches by `content.gameKey`:
-     - `sequence_drag_drop` → `SequenceDragDropGame` (pure React)
-     - `rhyme_ride_unity` → `RhymeRideUnityActivity`
-     - `bounce_buds_unity` → `BounceBudsUnityActivity`
-     - `gotcha_gears_unity` → `GotchaGearsUnityActivity`
+   - `INTERACT` → Dispatches by `content.gameKey` through `GAME_COMPONENTS` in `src/components/games/gameRegistry.ts`
+     - Set 1 keys include legacy Unity wrappers plus React implementations
+     - Set 2 keys are fully registered (`maze_maps`, `move_measure`, `sky_shield`, `fast_lane`, `qualify_tune_race`)
+     - Unknown keys still fall through to ActivityPlayer's unsupported fallback
 
 Each Unity wrapper:
 - Generates a `sessionId` via `crypto.randomUUID()`
@@ -90,11 +89,11 @@ Backend flow:
 
 ## 6. Localization
 
-- `react-i18next` with `en` and `es` bundles in `src/locales/{lang}/common.json`
-- `LocalizedField` type: `string | { en: string; es: string } | { i18nKey: string }`
-- `resolveText(t, field)` utility resolves any of these forms
-- Activity content uses `i18nKey` references for game round data
-- Unity games receive pre-resolved strings; localization happens React-side
+- `react-i18next` runtime bundles are present for `en`, `es`, `vi`, and `zh-CN` in `src/locales/{lang}/common.json`
+- Seeded Set 2 story/quiz payloads in `prisma/seed.cjs` and `backend/prisma/seed.cjs` currently provide only `{ en, es }` localized objects
+- `LocalizedField` type supports these localized object forms and `i18nKey` references
+- For `vi`/`zh-CN`, Set 2 story/quiz text falls back to English when a locale-specific value is unavailable
+- TODO: add reviewed human translations for Set 2 narrative + quiz blocks in Vietnamese and Simplified Chinese (avoid bulk machine translation commits)
 
 ## 7. UI / Gamification Conventions
 

--- a/docs/upper-elementary-mvp.md
+++ b/docs/upper-elementary-mvp.md
@@ -126,8 +126,15 @@ npx prisma db seed
 
 - K-2 Set 1 canon is exactly 5 public Foundation games: Bounce & Buds, Gotcha Gears, Rhyme & Ride, Tank Trek, Quantum Quest.
 - `Boost's Lost Steps` (`lost-steps` / `k2-stem-sequencing`) is retained only as legacy/archived content and is not part of live canonical gating.
+- Set 2 canon is exactly 5 public Exploration games: Maze Maps & Smart Paths, Move, Measure & Improve, Sky Shield Patterns, Fast Lane Signals, Qualify, Tune, Race.
 - Grade 3-5 adaptation planning mirrors the canonical 5-game Set 1 families above.
 - The grade-band infrastructure is implemented and seed-ready, but full playable grade 3-5 React game experiences are not yet complete.
+
+## Localization Coverage Note
+
+- Set 2 seed narrative/quiz content currently stores `{ en, es }` localized fields in both `prisma/seed.cjs` and `backend/prisma/seed.cjs`.
+- Vietnamese (`vi`) and Simplified Chinese (`zh-CN`) users currently receive English fallback for those Set 2 narrative/quiz strings at runtime.
+- TODO: complete editorial translation review for Set 2 narrative + quiz content in `vi` and `zh-CN` before claiming full parity.
 
 ## Known Follow-Up Items
 

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1320,7 +1320,11 @@
       "vocabPlan": "plan",
       "vocabSequence": "secuencia",
       "vocabTurn": "giro",
-      "vocabGoal": "meta"
+      "vocabGoal": "meta",
+      "g35level1": "Navega el laberinto del algoritmo",
+      "g35level2": "Depura la ruta dañada",
+      "g35level3": "Optimiza el camino con obstáculos",
+      "g35level4": "Recoge todos los chips con eficiencia"
     },
     "shared": {
       "tips": "Consejos",

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -1319,7 +1319,11 @@
       "vocabPlan": "kế hoạch",
       "vocabSequence": "trình tự",
       "vocabTurn": "rẽ",
-      "vocabGoal": "đích"
+      "vocabGoal": "đích",
+      "g35level1": "Đi qua mê cung thuật toán",
+      "g35level2": "Sửa lỗi tuyến đường bị hỏng",
+      "g35level3": "Tối ưu đường đi có chướng ngại vật",
+      "g35level4": "Thu thập tất cả chip thật hiệu quả"
     },
     "shared": {
       "tips": "Mẹo",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -1319,7 +1319,11 @@
       "vocabPlan": "计划",
       "vocabSequence": "顺序",
       "vocabTurn": "转弯",
-      "vocabGoal": "目标"
+      "vocabGoal": "目标",
+      "g35level1": "穿越算法迷宫",
+      "g35level2": "调试损坏的路线",
+      "g35level3": "在障碍中优化路径",
+      "g35level4": "高效收集所有芯片"
     },
     "shared": {
       "tips": "小贴士",


### PR DESCRIPTION
### Motivation
- Remove stale audit language that claimed Set 2 React games were missing and align documentation with the implemented registry and canonical counts from PR #551. 
- Surface localization gaps discovered during the gameplay/content audit so product teams know which seeded story/quiz blocks lack `vi`/`zh-CN` translations. 
- Add the missing Grade 3–5 Boost Path level labels to non-English locale bundles so UI labels do not appear missing for `es/vi/zh-CN`.

### Description
- Updated documentation to state that Set 2 contains exactly 5 Exploration games, that the 5 Set 2 game keys are registered in `src/components/games/gameRegistry.ts`, and that `lost-steps`/`k2-stem-sequencing` remains legacy/archived. 
- Documented localization coverage: seed narrative/quiz blocks in `prisma/seed.cjs` and `backend/prisma/seed.cjs` are authored as `{ en, es }`, and `vi`/`zh-CN` currently fall back to English at runtime, with a TODO to add reviewed translations (no machine-translation bulk commits). 
- Added the following keys to locale bundles for Spanish, Vietnamese, and Simplified Chinese under `games.boostPath`: `g35level1`, `g35level2`, `g35level3`, and `g35level4`. 
- Files changed: `docs/k2-set2-expansion.md`, `docs/set-2-games-audit.md`, `docs/upper-elementary-mvp.md`, `src/locales/es/common.json`, `src/locales/vi/common.json`, `src/locales/zh-CN/common.json`.

### Testing
- Verified modified locale JSON files parse successfully with `node` which confirms no syntax/regression in the locale bundles. (Succeeded.)
- Ran the canonical set unit tests (`src/constants/__tests__/stemSets.test.ts`) via Vitest and observed all tests passed (7 tests). (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee3de067c8325b47e89811f41d3f4)