### PR TITLE
Add first playable G3–5 module: Data Dash: Sort & Discover

### DIFF
--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -1129,6 +1129,202 @@ async function main() {
   }
   console.log("Seeded activities.");
 
+
+  // ── Grade 3-5 first playable module: Data Dash: Sort & Discover ──
+  const g35DataDashModule = await prisma.module.upsert({
+    where: { slug: "g35-data-dash-sort-discover" },
+    update: {
+      title: "Data Dash: Sort & Discover",
+      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      level: "G3-5",
+      published: true,
+    },
+    create: {
+      slug: "g35-data-dash-sort-discover",
+      title: "Data Dash: Sort & Discover",
+      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      level: "G3-5",
+      published: true,
+    },
+  });
+  console.log("Created module:", g35DataDashModule.slug);
+
+  let g35DataDashUnit = await prisma.unit.findFirst({
+    where: { moduleId: g35DataDashModule.id, title: "Unit 1: Greenhouse Data Lab" },
+  });
+  if (!g35DataDashUnit) {
+    g35DataDashUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Greenhouse Data Lab",
+        order: 1,
+        Module: { connect: { id: g35DataDashModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
+  }
+
+  let g35DataDashLesson = await prisma.lesson.findFirst({
+    where: { unitId: g35DataDashUnit.id, title: "Lesson 1: Sort, Infer, Explain" },
+  });
+  if (!g35DataDashLesson) {
+    g35DataDashLesson = await prisma.lesson.create({
+      data: {
+        title: "Lesson 1: Sort, Infer, Explain",
+        order: 1,
+        Unit: { connect: { id: g35DataDashUnit.id } },
+      },
+    });
+  }
+
+  const dataDashStoryContent = JSON.stringify({
+    type: "story_quiz",
+    slides: [
+      {
+        id: "dd-s1",
+        text: {
+          en: "Mission Briefing: Greenhouse Data Drop. A science team sent plant cards from three beds. Your job is to organize the data and report what the patterns show.",
+          es: "Informe de misión: Entrega de datos del invernadero. Un equipo de ciencias envió tarjetas de plantas de tres camas. Tu trabajo es organizar los datos e informar qué patrones muestran.",
+        },
+        icon: "🛰️",
+      },
+      {
+        id: "dd-s2",
+        text: {
+          en: "How scientists classify: They group by shared attributes like sunlight need, water need, leaf type, seed type, or growth speed. One clear rule keeps the data fair.",
+          es: "Cómo clasifican los científicos: Agrupan por atributos compartidos como necesidad de luz solar, necesidad de agua, tipo de hoja, tipo de semilla o velocidad de crecimiento. Una regla clara mantiene los datos justos.",
+        },
+        icon: "🧪",
+      },
+      {
+        id: "dd-s3",
+        text: {
+          en: "Evidence first: A good claim uses observations and counts, not guesses. Chart bars and totals are evidence you can point to.",
+          es: "Evidencia primero: Una buena afirmación usa observaciones y conteos, no suposiciones. Las barras y los totales del gráfico son evidencia que puedes señalar.",
+        },
+        icon: "📌",
+      },
+      {
+        id: "dd-s4",
+        text: {
+          en: "From sort to pattern: Once cards are sorted, patterns become visible. Then you can explain what is common, what is different, and what to test next.",
+          es: "Del orden al patrón: Una vez ordenadas las tarjetas, los patrones se vuelven visibles. Luego puedes explicar qué es común, qué es diferente y qué probar después.",
+        },
+        icon: "📊",
+      },
+    ],
+    questions: [
+      {
+        id: "dd-q1",
+        prompt: { en: "Which choice is a classification rule (not just one observation)?", es: "¿Qué opción es una regla de clasificación (no solo una observación)?" },
+        choices: [
+          { en: "Group plants by seed type", es: "Agrupar plantas por tipo de semilla" },
+          { en: "This fern needs high water", es: "Este helecho necesita mucha agua" },
+          { en: "Plant bed A has three plants", es: "La cama de plantas A tiene tres plantas" }
+        ],
+        answerIndex: 0,
+        hint: { en: "A rule can be used on every card.", es: "Una regla puede usarse en cada tarjeta." }
+      },
+      {
+        id: "dd-q2",
+        prompt: { en: "If two cards both have cone seeds, what is true?", es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?" },
+        choices: [
+          { en: "They match on seed type", es: "Coinciden en tipo de semilla" },
+          { en: "They must be in the same plant bed", es: "Deben estar en la misma cama de plantas" },
+          { en: "They must need the same water", es: "Deben necesitar la misma agua" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Look only at the named attribute.", es: "Mira solo el atributo nombrado." }
+      },
+      {
+        id: "dd-q3",
+        prompt: { en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?", es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?" },
+        choices: [
+          { en: "Most plants need full sunlight", es: "La mayoría de las plantas necesitan luz solar completa" },
+          { en: "All plants need shade", es: "Todas las plantas necesitan sombra" },
+          { en: "No plants need partial sunlight", es: "Ninguna planta necesita luz solar parcial" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Choose the claim that matches the largest count.", es: "Elige la afirmación que coincide con el mayor conteo." }
+      },
+      {
+        id: "dd-q4",
+        prompt: { en: "What is the strongest evidence for your claim?", es: "¿Cuál es la evidencia más fuerte para tu afirmación?" },
+        choices: [
+          { en: "The full-sun bar is tallest", es: "La barra de sol completo es la más alta" },
+          { en: "I like full-sun plants", es: "Me gustan las plantas de sol completo" },
+          { en: "My friend chose that answer", es: "Mi amigo eligió esa respuesta" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Evidence comes from measured data.", es: "La evidencia proviene de datos medidos." }
+      },
+      {
+        id: "dd-q5",
+        prompt: { en: "Why is multi-attribute sorting useful?", es: "¿Por qué es útil clasificar por múltiples atributos?" },
+        choices: [
+          { en: "It helps find deeper patterns and better explanations", es: "Ayuda a encontrar patrones más profundos y mejores explicaciones" },
+          { en: "It makes data random", es: "Hace los datos aleatorios" },
+          { en: "It removes the need for evidence", es: "Elimina la necesidad de evidencia" }
+        ],
+        answerIndex: 0,
+        hint: { en: "More than one attribute can reveal hidden structure.", es: "Más de un atributo puede revelar estructura oculta." }
+      }
+    ],
+  });
+
+  const g35StoryActivity = await prisma.activity.findFirst({
+    where: { lessonId: g35DataDashLesson.id, kind: INFO, order: 1 },
+  });
+  if (g35StoryActivity) {
+    await prisma.activity.update({
+      where: { id: g35StoryActivity.id },
+      data: {
+        title: "Mission Briefing: Greenhouse Data Drop",
+        content: dataDashStoryContent,
+      },
+    });
+  } else {
+    await prisma.activity.create({
+      data: {
+        title: "Mission Briefing: Greenhouse Data Drop",
+        kind: INFO,
+        order: 1,
+        content: dataDashStoryContent,
+        Lesson: { connect: { id: g35DataDashLesson.id } },
+      },
+    });
+  }
+
+  const dataDashGameContent = JSON.stringify({
+    type: "game",
+    activityId: "data-dash-sort-discover",
+    gameKey: "data_dash_sort_discover",
+    title: "Data Dash: Sort & Discover",
+    rounds: 3,
+  });
+
+  const g35GameActivity = await prisma.activity.findFirst({
+    where: { lessonId: g35DataDashLesson.id, kind: INTERACT, order: 2 },
+  });
+  if (g35GameActivity) {
+    await prisma.activity.update({
+      where: { id: g35GameActivity.id },
+      data: {
+        title: "Data Dash: Sort & Discover",
+        content: dataDashGameContent,
+      },
+    });
+  } else {
+    await prisma.activity.create({
+      data: {
+        title: "Data Dash: Sort & Discover",
+        kind: INTERACT,
+        order: 2,
+        content: dataDashGameContent,
+        Lesson: { connect: { id: g35DataDashLesson.id } },
+      },
+    });
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Module Families & Variants (grade-banded content system)
   // ═══════════════════════════════════════════════════════════════════════════

--- a/docs/upper-elementary-mvp.md
+++ b/docs/upper-elementary-mvp.md
@@ -128,7 +128,10 @@ npx prisma db seed
 - `Boost's Lost Steps` (`lost-steps` / `k2-stem-sequencing`) is retained only as legacy/archived content and is not part of live canonical gating.
 - Set 2 canon is exactly 5 public Exploration games: Maze Maps & Smart Paths, Move, Measure & Improve, Sky Shield Patterns, Fast Lane Signals, Qualify, Tune, Race.
 - Grade 3-5 adaptation planning mirrors the canonical 5-game Set 1 families above.
-- The grade-band infrastructure is implemented and seed-ready, but full playable grade 3-5 React game experiences are not yet complete.
+- The grade-band infrastructure is implemented and seed-ready.
+- **First playable G3-5 module is now live:** `Data Dash: Sort & Discover` (`g35-data-dash-sort-discover`) as a concrete Module → Unit → Lesson → Activity experience.
+- Other G3-5 variants remain planning-only configs in `ModuleVariant.contentConfig` and are not yet playable React games.
+- Variant-native teacher assignment UI and full assigned-modules player flow remain future work.
 
 ## Localization Coverage Note
 
@@ -138,7 +141,7 @@ npx prisma db seed
 
 ## Known Follow-Up Items
 
-1. **G3-5 game implementations** — The 5 g3_5 content configs describe game mechanics but the actual game components need to be built (Data Dash, Variable Quest, Motion Mission, Design Under Pressure, Quantum Mission)
+1. **Remaining G3-5 game implementations** — Four variants are still planning/config-only and need playable React game components (Variable Quest, Motion Mission, Design Under Pressure, Quantum Mission). Data Dash is now playable as the first concrete G3-5 module.
 2. **Module assignment UI** — Teacher-facing UI for browsing catalog and assigning/reordering modules. Currently only the band selector is in the UI; assignment management is API-ready but needs a dedicated component.
 3. **Student assigned-modules view** — A student dashboard section that shows class-assigned modules. Currently the `/api/student/assigned-modules` endpoint exists but no frontend component consumes it.
 4. **Per-grade tuning** — The `g3_5` band is one shared profile. Future work: separate g3, g4, g5 difficulty curves.

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -1129,6 +1129,202 @@ async function main() {
   }
   console.log("Seeded activities.");
 
+
+  // ── Grade 3-5 first playable module: Data Dash: Sort & Discover ──
+  const g35DataDashModule = await prisma.module.upsert({
+    where: { slug: "g35-data-dash-sort-discover" },
+    update: {
+      title: "Data Dash: Sort & Discover",
+      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      level: "G3-5",
+      published: true,
+    },
+    create: {
+      slug: "g35-data-dash-sort-discover",
+      title: "Data Dash: Sort & Discover",
+      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      level: "G3-5",
+      published: true,
+    },
+  });
+  console.log("Created module:", g35DataDashModule.slug);
+
+  let g35DataDashUnit = await prisma.unit.findFirst({
+    where: { moduleId: g35DataDashModule.id, title: "Unit 1: Greenhouse Data Lab" },
+  });
+  if (!g35DataDashUnit) {
+    g35DataDashUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Greenhouse Data Lab",
+        order: 1,
+        Module: { connect: { id: g35DataDashModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
+  }
+
+  let g35DataDashLesson = await prisma.lesson.findFirst({
+    where: { unitId: g35DataDashUnit.id, title: "Lesson 1: Sort, Infer, Explain" },
+  });
+  if (!g35DataDashLesson) {
+    g35DataDashLesson = await prisma.lesson.create({
+      data: {
+        title: "Lesson 1: Sort, Infer, Explain",
+        order: 1,
+        Unit: { connect: { id: g35DataDashUnit.id } },
+      },
+    });
+  }
+
+  const dataDashStoryContent = JSON.stringify({
+    type: "story_quiz",
+    slides: [
+      {
+        id: "dd-s1",
+        text: {
+          en: "Mission Briefing: Greenhouse Data Drop. A science team sent plant cards from three beds. Your job is to organize the data and report what the patterns show.",
+          es: "Informe de misión: Entrega de datos del invernadero. Un equipo de ciencias envió tarjetas de plantas de tres camas. Tu trabajo es organizar los datos e informar qué patrones muestran.",
+        },
+        icon: "🛰️",
+      },
+      {
+        id: "dd-s2",
+        text: {
+          en: "How scientists classify: They group by shared attributes like sunlight need, water need, leaf type, seed type, or growth speed. One clear rule keeps the data fair.",
+          es: "Cómo clasifican los científicos: Agrupan por atributos compartidos como necesidad de luz solar, necesidad de agua, tipo de hoja, tipo de semilla o velocidad de crecimiento. Una regla clara mantiene los datos justos.",
+        },
+        icon: "🧪",
+      },
+      {
+        id: "dd-s3",
+        text: {
+          en: "Evidence first: A good claim uses observations and counts, not guesses. Chart bars and totals are evidence you can point to.",
+          es: "Evidencia primero: Una buena afirmación usa observaciones y conteos, no suposiciones. Las barras y los totales del gráfico son evidencia que puedes señalar.",
+        },
+        icon: "📌",
+      },
+      {
+        id: "dd-s4",
+        text: {
+          en: "From sort to pattern: Once cards are sorted, patterns become visible. Then you can explain what is common, what is different, and what to test next.",
+          es: "Del orden al patrón: Una vez ordenadas las tarjetas, los patrones se vuelven visibles. Luego puedes explicar qué es común, qué es diferente y qué probar después.",
+        },
+        icon: "📊",
+      },
+    ],
+    questions: [
+      {
+        id: "dd-q1",
+        prompt: { en: "Which choice is a classification rule (not just one observation)?", es: "¿Qué opción es una regla de clasificación (no solo una observación)?" },
+        choices: [
+          { en: "Group plants by seed type", es: "Agrupar plantas por tipo de semilla" },
+          { en: "This fern needs high water", es: "Este helecho necesita mucha agua" },
+          { en: "Plant bed A has three plants", es: "La cama de plantas A tiene tres plantas" }
+        ],
+        answerIndex: 0,
+        hint: { en: "A rule can be used on every card.", es: "Una regla puede usarse en cada tarjeta." }
+      },
+      {
+        id: "dd-q2",
+        prompt: { en: "If two cards both have cone seeds, what is true?", es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?" },
+        choices: [
+          { en: "They match on seed type", es: "Coinciden en tipo de semilla" },
+          { en: "They must be in the same plant bed", es: "Deben estar en la misma cama de plantas" },
+          { en: "They must need the same water", es: "Deben necesitar la misma agua" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Look only at the named attribute.", es: "Mira solo el atributo nombrado." }
+      },
+      {
+        id: "dd-q3",
+        prompt: { en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?", es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?" },
+        choices: [
+          { en: "Most plants need full sunlight", es: "La mayoría de las plantas necesitan luz solar completa" },
+          { en: "All plants need shade", es: "Todas las plantas necesitan sombra" },
+          { en: "No plants need partial sunlight", es: "Ninguna planta necesita luz solar parcial" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Choose the claim that matches the largest count.", es: "Elige la afirmación que coincide con el mayor conteo." }
+      },
+      {
+        id: "dd-q4",
+        prompt: { en: "What is the strongest evidence for your claim?", es: "¿Cuál es la evidencia más fuerte para tu afirmación?" },
+        choices: [
+          { en: "The full-sun bar is tallest", es: "La barra de sol completo es la más alta" },
+          { en: "I like full-sun plants", es: "Me gustan las plantas de sol completo" },
+          { en: "My friend chose that answer", es: "Mi amigo eligió esa respuesta" }
+        ],
+        answerIndex: 0,
+        hint: { en: "Evidence comes from measured data.", es: "La evidencia proviene de datos medidos." }
+      },
+      {
+        id: "dd-q5",
+        prompt: { en: "Why is multi-attribute sorting useful?", es: "¿Por qué es útil clasificar por múltiples atributos?" },
+        choices: [
+          { en: "It helps find deeper patterns and better explanations", es: "Ayuda a encontrar patrones más profundos y mejores explicaciones" },
+          { en: "It makes data random", es: "Hace los datos aleatorios" },
+          { en: "It removes the need for evidence", es: "Elimina la necesidad de evidencia" }
+        ],
+        answerIndex: 0,
+        hint: { en: "More than one attribute can reveal hidden structure.", es: "Más de un atributo puede revelar estructura oculta." }
+      }
+    ],
+  });
+
+  const g35StoryActivity = await prisma.activity.findFirst({
+    where: { lessonId: g35DataDashLesson.id, kind: INFO, order: 1 },
+  });
+  if (g35StoryActivity) {
+    await prisma.activity.update({
+      where: { id: g35StoryActivity.id },
+      data: {
+        title: "Mission Briefing: Greenhouse Data Drop",
+        content: dataDashStoryContent,
+      },
+    });
+  } else {
+    await prisma.activity.create({
+      data: {
+        title: "Mission Briefing: Greenhouse Data Drop",
+        kind: INFO,
+        order: 1,
+        content: dataDashStoryContent,
+        Lesson: { connect: { id: g35DataDashLesson.id } },
+      },
+    });
+  }
+
+  const dataDashGameContent = JSON.stringify({
+    type: "game",
+    activityId: "data-dash-sort-discover",
+    gameKey: "data_dash_sort_discover",
+    title: "Data Dash: Sort & Discover",
+    rounds: 3,
+  });
+
+  const g35GameActivity = await prisma.activity.findFirst({
+    where: { lessonId: g35DataDashLesson.id, kind: INTERACT, order: 2 },
+  });
+  if (g35GameActivity) {
+    await prisma.activity.update({
+      where: { id: g35GameActivity.id },
+      data: {
+        title: "Data Dash: Sort & Discover",
+        content: dataDashGameContent,
+      },
+    });
+  } else {
+    await prisma.activity.create({
+      data: {
+        title: "Data Dash: Sort & Discover",
+        kind: INTERACT,
+        order: 2,
+        content: dataDashGameContent,
+        Lesson: { connect: { id: g35DataDashLesson.id } },
+      },
+    });
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Module Families & Variants (grade-banded content system)
   // ═══════════════════════════════════════════════════════════════════════════

--- a/src/components/games/DataDashSortDiscoverGame.tsx
+++ b/src/components/games/DataDashSortDiscoverGame.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from "react";
+import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type GameProps = {
+  config?: any;
+  onComplete?: (result: GameResult) => void;
+};
+
+export type DataCard = {
+  id: string;
+  name: string;
+  plantBed: "A" | "B" | "C";
+  sunlightNeed: "full" | "partial" | "shade";
+  waterNeed: "low" | "medium" | "high";
+  leafType: "broad" | "needle" | "frond";
+  seedType: "pod" | "cone" | "spore";
+  growthSpeed: "slow" | "medium" | "fast";
+};
+
+export type SortRuleKey = "sunlightNeed" | "waterNeed" | "leafType";
+
+export const DATA_DASH_CARDS: DataCard[] = [
+  { id: "bean", name: "Bean", plantBed: "A", sunlightNeed: "full", waterNeed: "medium", leafType: "broad", seedType: "pod", growthSpeed: "fast" },
+  { id: "fern", name: "Fern", plantBed: "B", sunlightNeed: "shade", waterNeed: "high", leafType: "frond", seedType: "spore", growthSpeed: "medium" },
+  { id: "pine", name: "Pine", plantBed: "C", sunlightNeed: "full", waterNeed: "low", leafType: "needle", seedType: "cone", growthSpeed: "slow" },
+  { id: "pea", name: "Pea", plantBed: "A", sunlightNeed: "full", waterNeed: "medium", leafType: "broad", seedType: "pod", growthSpeed: "fast" },
+  { id: "moss", name: "Moss", plantBed: "B", sunlightNeed: "shade", waterNeed: "high", leafType: "frond", seedType: "spore", growthSpeed: "slow" },
+  { id: "spruce", name: "Spruce", plantBed: "C", sunlightNeed: "partial", waterNeed: "low", leafType: "needle", seedType: "cone", growthSpeed: "medium" },
+  { id: "sunflower", name: "Sunflower", plantBed: "A", sunlightNeed: "full", waterNeed: "medium", leafType: "broad", seedType: "pod", growthSpeed: "fast" },
+  { id: "hosta", name: "Hosta", plantBed: "B", sunlightNeed: "shade", waterNeed: "high", leafType: "broad", seedType: "pod", growthSpeed: "medium" },
+];
+
+export const SORT_RULES: Record<SortRuleKey, { label: string; values: string[] }> = {
+  sunlightNeed: { label: "Sunlight need", values: ["full", "partial", "shade"] },
+  waterNeed: { label: "Water need", values: ["low", "medium", "high"] },
+  leafType: { label: "Leaf type", values: ["broad", "needle", "frond"] },
+};
+
+export function evaluateSortAssignment(cards: DataCard[], assignments: Record<string, string>, rule: SortRuleKey) {
+  const correct = cards.filter((card) => assignments[card.id] === card[rule]).length;
+  return { correct, total: cards.length };
+}
+
+export function buildChartCounts(cards: DataCard[], rule: SortRuleKey) {
+  return SORT_RULES[rule].values.map((value) => ({ label: value, count: cards.filter((card) => card[rule] === value).length }));
+}
+
+export function checkChartAnswer(correctIndex: number, selectedIndex: number | null) {
+  return selectedIndex === correctIndex;
+}
+
+export function calculateDataDashScore(input: { sortCorrect: number; sortTotal: number; inferredRuleCorrect: boolean; chartCorrect: number; chartTotal: number; hintsUsed: number }) {
+  const total = input.sortTotal + 1 + input.chartTotal;
+  const score = input.sortCorrect + (input.inferredRuleCorrect ? 1 : 0) + input.chartCorrect;
+  const accuracy = Math.round((score / total) * 100);
+  const evidenceScore = Math.round((input.chartCorrect / input.chartTotal) * 100);
+  return { score, total, accuracy, evidenceScore };
+}
+
+export function buildCompletionPayload(input: { sortCorrect: number; sortTotal: number; inferredRuleCorrect: boolean; chartCorrect: number; chartTotal: number; hintsUsed: number; roundsCompleted: number }) {
+  const calc = calculateDataDashScore(input);
+  return {
+    gameKey: "data_dash_sort_discover",
+    score: calc.score,
+    total: calc.total,
+    streakMax: 0,
+    roundsCompleted: input.roundsCompleted,
+    accuracy: calc.accuracy,
+    evidenceScore: calc.evidenceScore,
+    hintsUsed: input.hintsUsed,
+  };
+}
+
+const BRIEFING: MissionBriefing = {
+  title: "Data Dash: Sort & Discover",
+  story: "Your greenhouse team sent a data drop. Sort plant cards, infer hidden rules, and use chart evidence to support a claim.",
+  icon: "📊",
+  tips: ["Use one attribute per sort rule", "Look for what all cards in a group share", "Use chart counts as evidence"],
+  chapterLabel: "Life Science Data",
+  themeColor: "emerald",
+};
+
+function DataDashPlayfield({ onFinish }: { onFinish: (result: GameResult) => void }) {
+  const [phase, setPhase] = useState<"sort" | "infer" | "chart">("sort");
+  const [rule] = useState<SortRuleKey>("sunlightNeed");
+  const [assignments, setAssignments] = useState<Record<string, string>>({});
+  const [selectedCard, setSelectedCard] = useState<string | null>(null);
+  const [hintsUsed, setHintsUsed] = useState(0);
+  const [sortResult, setSortResult] = useState<{ correct: number; total: number } | null>(null);
+
+  const inferRule: SortRuleKey = "seedType" as unknown as SortRuleKey;
+  const inferOptions = ["sunlightNeed", "waterNeed", "seedType", "growthSpeed"];
+  const [inferChoice, setInferChoice] = useState<string | null>(null);
+
+  const chartQuestions = [
+    {
+      prompt: "Which claim is best supported by the chart?",
+      choices: ["Most plants need full sunlight.", "Most plants need shade.", "All plants need partial sunlight."],
+      answerIndex: 0,
+    },
+    {
+      prompt: "What evidence best supports your claim?",
+      choices: ["The full-sun bar is tallest.", "Fern has frond leaves.", "Plant bed A has three cards."],
+      answerIndex: 0,
+    },
+  ];
+  const [chartAnswers, setChartAnswers] = useState<Record<number, number>>({});
+
+  const chartData = useMemo(() => buildChartCounts(DATA_DASH_CARDS, rule), [rule]);
+
+  const allSorted = DATA_DASH_CARDS.every((card) => Boolean(assignments[card.id]));
+
+  const groupedForInfer = useMemo(() => {
+    const groups = ["pod", "cone", "spore"].map((label) => ({
+      label,
+      cards: DATA_DASH_CARDS.filter((card) => card.seedType === label),
+    }));
+    return groups;
+  }, []);
+
+  const submitSort = () => {
+    const result = evaluateSortAssignment(DATA_DASH_CARDS, assignments, rule);
+    setSortResult(result);
+    setPhase("infer");
+  };
+
+  const finishGame = () => {
+    const chartCorrect = chartQuestions.filter((q, i) => checkChartAnswer(q.answerIndex, chartAnswers[i] ?? null)).length;
+    const payload = buildCompletionPayload({
+      sortCorrect: sortResult?.correct ?? 0,
+      sortTotal: sortResult?.total ?? DATA_DASH_CARDS.length,
+      inferredRuleCorrect: inferChoice === inferRule,
+      chartCorrect,
+      chartTotal: chartQuestions.length,
+      hintsUsed,
+      roundsCompleted: 3,
+    });
+
+    onFinish(payload as GameResult);
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Phase {phase === "sort" ? "A" : phase === "infer" ? "B" : "C"}: {phase === "sort" ? "Sort by Attribute" : phase === "infer" ? "Infer the Rule" : "Read the Chart"}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {phase === "sort" && (
+            <>
+              <p className="text-sm text-slate-600">Rule: Sort all cards by <strong>{SORT_RULES[rule].label}</strong>.</p>
+              <div className="grid md:grid-cols-2 gap-3">
+                {DATA_DASH_CARDS.map((card) => (
+                  <button key={card.id} className={`border rounded-lg p-2 text-left ${selectedCard === card.id ? "border-emerald-500" : "border-slate-200"}`} onClick={() => setSelectedCard(card.id)}>
+                    <div className="font-semibold">{card.name}</div>
+                    <div className="text-xs text-slate-500">Bed {card.plantBed} • Sun: {card.sunlightNeed} • Water: {card.waterNeed} • Leaf: {card.leafType} • Seed: {card.seedType} • Growth: {card.growthSpeed}</div>
+                    <div className="text-xs mt-1">Assigned bin: <strong>{assignments[card.id] ?? "—"}</strong></div>
+                  </button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {SORT_RULES[rule].values.map((value) => (
+                  <Button key={value} variant="outline" onClick={() => selectedCard && setAssignments((prev) => ({ ...prev, [selectedCard]: value }))} disabled={!selectedCard}>
+                    Place in "{value}" bin
+                  </Button>
+                ))}
+                <Button variant="secondary" onClick={() => setHintsUsed((v) => v + 1)}>Hint</Button>
+              </div>
+              <Button disabled={!allSorted} onClick={submitSort}>Submit Phase A</Button>
+            </>
+          )}
+
+          {phase === "infer" && (
+            <>
+              <p className="text-sm text-slate-600">Scientists grouped these cards with a hidden rule. Which attribute did they use?</p>
+              <div className="grid md:grid-cols-3 gap-3">
+                {groupedForInfer.map((group) => (
+                  <div key={group.label} className="border rounded-lg p-3 bg-slate-50">
+                    <div className="font-semibold mb-2">Group {group.label}</div>
+                    <ul className="text-sm list-disc ml-4">
+                      {group.cards.map((card) => <li key={card.id}>{card.name}</li>)}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {inferOptions.map((option) => (
+                  <Button key={option} variant={inferChoice === option ? "default" : "outline"} onClick={() => setInferChoice(option)}>{option}</Button>
+                ))}
+                <Button variant="secondary" onClick={() => setHintsUsed((v) => v + 1)}>Hint</Button>
+              </div>
+              <Button disabled={!inferChoice} onClick={() => setPhase("chart")}>Submit Phase B</Button>
+            </>
+          )}
+
+          {phase === "chart" && (
+            <>
+              <p className="text-sm text-slate-600">Chart from your Phase A sort ({SORT_RULES[rule].label}):</p>
+              <div className="space-y-2">
+                {chartData.map((row) => (
+                  <div key={row.label}>
+                    <div className="text-sm">{row.label}: {row.count}</div>
+                    <div className="h-3 bg-slate-100 rounded"><div className="h-3 bg-emerald-500 rounded" style={{ width: `${row.count * 20}%` }} /></div>
+                  </div>
+                ))}
+              </div>
+              {chartQuestions.map((q, i) => (
+                <div key={q.prompt} className="border rounded-lg p-3 space-y-2">
+                  <div className="font-medium">{q.prompt}</div>
+                  <div className="flex flex-col gap-2">
+                    {q.choices.map((choice, idx) => (
+                      <Button key={choice} variant={chartAnswers[i] === idx ? "default" : "outline"} onClick={() => setChartAnswers((prev) => ({ ...prev, [i]: idx }))}>{choice}</Button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+              <Button variant="secondary" onClick={() => setHintsUsed((v) => v + 1)}>Hint</Button>
+              <Button onClick={finishGame} disabled={Object.keys(chartAnswers).length < chartQuestions.length}>Complete Mission</Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function DataDashSortDiscoverGame({ onComplete }: GameProps) {
+  return (
+    <GameShell
+      gameKey="data_dash_sort_discover"
+      title="Data Dash: Sort & Discover"
+      briefing={BRIEFING}
+      onComplete={(result) => onComplete?.(result)}
+    >
+      {({ onFinish }) => <DataDashPlayfield onFinish={onFinish} />}
+    </GameShell>
+  );
+}

--- a/src/components/games/__tests__/DataDashSortDiscover.test.ts
+++ b/src/components/games/__tests__/DataDashSortDiscover.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  DATA_DASH_CARDS,
+  buildChartCounts,
+  buildCompletionPayload,
+  calculateDataDashScore,
+  checkChartAnswer,
+  evaluateSortAssignment,
+} from "../DataDashSortDiscoverGame";
+
+describe("Data Dash utilities", () => {
+  it("evaluates sort assignments against a rule", () => {
+    const assignments = Object.fromEntries(
+      DATA_DASH_CARDS.map((card) => [card.id, card.sunlightNeed]),
+    );
+    const result = evaluateSortAssignment(DATA_DASH_CARDS, assignments, "sunlightNeed");
+    expect(result.correct).toBe(DATA_DASH_CARDS.length);
+    expect(result.total).toBe(DATA_DASH_CARDS.length);
+  });
+
+  it("builds chart counts by rule", () => {
+    const chart = buildChartCounts(DATA_DASH_CARDS, "sunlightNeed");
+    expect(chart.find((r) => r.label === "full")?.count).toBeGreaterThan(0);
+    expect(chart.reduce((sum, row) => sum + row.count, 0)).toBe(DATA_DASH_CARDS.length);
+  });
+
+  it("checks chart question answers", () => {
+    expect(checkChartAnswer(2, 2)).toBe(true);
+    expect(checkChartAnswer(2, 1)).toBe(false);
+  });
+
+  it("calculates score and evidence score", () => {
+    const score = calculateDataDashScore({
+      sortCorrect: 7,
+      sortTotal: 8,
+      inferredRuleCorrect: true,
+      chartCorrect: 1,
+      chartTotal: 2,
+      hintsUsed: 0,
+    });
+    expect(score.score).toBe(9);
+    expect(score.total).toBe(11);
+    expect(score.accuracy).toBe(82);
+    expect(score.evidenceScore).toBe(50);
+  });
+
+  it("builds completion payload with required fields", () => {
+    const payload = buildCompletionPayload({
+      sortCorrect: 8,
+      sortTotal: 8,
+      inferredRuleCorrect: true,
+      chartCorrect: 2,
+      chartTotal: 2,
+      hintsUsed: 1,
+      roundsCompleted: 3,
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "data_dash_sort_discover",
+      score: 11,
+      total: 11,
+      roundsCompleted: 3,
+      accuracy: 100,
+      evidenceScore: 100,
+      hintsUsed: 1,
+    });
+  });
+
+  it("is registered in game registry", async () => {
+    const { GAME_COMPONENTS } = await import("../gameRegistry");
+    expect(GAME_COMPONENTS.data_dash_sort_discover).toBeDefined();
+  });
+});

--- a/src/components/games/gameRegistry.ts
+++ b/src/components/games/gameRegistry.ts
@@ -13,6 +13,7 @@ import FastLaneGame from "./FastLaneGame";
 import QualifyTuneRaceGame from "./QualifyTuneRaceGame";
 import TankTrekGame from "./TankTrekGame";
 import QuantumQuestGame from "./QuantumQuestGame";
+import DataDashSortDiscoverGame from "./DataDashSortDiscoverGame";
 
 type GameProps = {
   config?: any;
@@ -32,6 +33,7 @@ export const GAME_COMPONENTS: Record<string, ComponentType<GameProps>> = {
   gotcha_gears_unity: GotchaGearsGame,         // "Gotcha Gears" (now React)
   tank_trek: TankTrekGame,                     // "Tank Trek" (Set 1)
   quantum_quest: QuantumQuestGame,             // "Quantum Quest"
+  data_dash_sort_discover: DataDashSortDiscoverGame, // "Data Dash: Sort & Discover" (G3-5)
 
   // ── Set 2 keys ──
   maze_maps: MazeMapsGame,                      // "Maze Maps & Smart Paths" (Set 2)


### PR DESCRIPTION
### Motivation
- Provide a concrete, playable Grade 3–5 experience that extends the K–2 Bounce & Buds concept into multi-attribute classification, rule inference, and chart-backed claims. 
- Use the faster Module → Unit → Lesson → Activity path so the module is playable immediately without building the full g3_5 assignment/variant UI. 

### Description
- Added a pure React game component `src/components/games/DataDashSortDiscoverGame.tsx` implementing a three-phase loop: Phase A (sort by attribute), Phase B (infer the hidden rule), and Phase C (read generated chart and answer claim/evidence questions), and it builds a completion payload with `gameKey`, `score`, `total`, `roundsCompleted`, `accuracy`, `evidenceScore`, and `hintsUsed`.
- Registered the game in the registry under `data_dash_sort_discover` so `ActivityPlayer` will dispatch it via the existing `GAME_COMPONENTS` mapping and render via the current INTERACT flow.
- Exported small utilities and evaluators (`evaluateSortAssignment`, `buildChartCounts`, `checkChartAnswer`, `calculateDataDashScore`, `buildCompletionPayload`) and added unit tests for them (`src/components/games/__tests__/DataDashSortDiscover.test.ts`).
- Seeded a concrete Module→Unit→Lesson→Activity structure in both `prisma/seed.cjs` and `backend/prisma/seed.cjs` (module slug `g35-data-dash-sort-discover`) with an INFO `story_quiz` (4 slides) and an INTERACT activity that references `gameKey: data_dash_sort_discover`; seeds are written idempotently.
- Updated `docs/upper-elementary-mvp.md` to mark Data Dash as the first playable G3–5 module and clarify remaining G3–5 work and assignment UI as future tasks.

### Testing
- Ran targeted unit tests: `npm run test -- src/components/games/__tests__/DataDashSortDiscover.test.ts src/components/games/__tests__/BounceBuds.test.ts src/components/games/__tests__/MazeMaps.test.ts`, and all test files and their tests passed.
- Ran type checking with `npm run typecheck` (TS compiler) with no errors.
- The new utilities tests verify rule evaluation, chart-building, answer checking, score calculation, completion payload fields, and registration presence in the game registry (all successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeeafbb9fc832581b81cde96e62eee)