### PR TITLE
Add unit tests and small helper exports for under-tested registry games

### DIFF
--- a/src/components/games/FastLaneGame.tsx
+++ b/src/components/games/FastLaneGame.tsx
@@ -43,7 +43,7 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-function generateLanes(allowCaution: boolean): [Signal, Signal, Signal] {
+export function generateLanes(allowCaution: boolean): [Signal, Signal, Signal] {
   const pool: Signal[] = allowCaution ? ["safe", "blocked", "caution"] : ["safe", "blocked"];
   const lanes: Signal[] = [];
   const safeIndex = Math.floor(Math.random() * 3);
@@ -51,7 +51,7 @@ function generateLanes(allowCaution: boolean): [Signal, Signal, Signal] {
   return shuffle(lanes) as [Signal, Signal, Signal];
 }
 
-function generateLookAhead(): LaneState {
+export function generateLookAhead(): LaneState {
   let current: [Signal, Signal, Signal], next: [Signal, Signal, Signal], attempts = 0;
   do {
     current = generateLanes(true); next = generateLanes(true); attempts++;
@@ -59,7 +59,7 @@ function generateLookAhead(): LaneState {
   return { current, next };
 }
 
-function bestLane(state: LaneState): number {
+export function bestLane(state: LaneState): number {
   const { current, next } = state;
   if (next) {
     const bothSafe = current.map((s, i) => (s === "safe" && next[i] === "safe" ? i : -1)).filter((i) => i >= 0);
@@ -73,10 +73,34 @@ function bestLane(state: LaneState): number {
   return cautionIdx >= 0 ? cautionIdx : 0;
 }
 
-function scorePick(signal: Signal, isBest: boolean): number {
+export function scorePick(signal: Signal, isBest: boolean): number {
   if (signal === "blocked") return 0;
   if (signal === "caution") return 5;
   return isBest ? 15 : 10;
+}
+
+export function buildFastLaneCompletionPayload(params: {
+  score: number;
+  maxStreak: number;
+  totalRounds: number;
+  correctCount: number;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}): GameResult {
+  const { score, maxStreak, totalRounds, correctCount, t } = params;
+  const total = Math.max(totalRounds * 15, 1);
+  return {
+    gameKey: "fast_lane",
+    score,
+    total,
+    streakMax: maxStreak,
+    roundsCompleted: totalRounds,
+    accuracy: totalRounds > 0 ? Math.round((correctCount / totalRounds) * 100) : 0,
+    firstTryClear: correctCount === totalRounds,
+    achievements: [
+      ...(maxStreak >= 5 ? [t("games.fastLane.achStreak", { defaultValue: "Signal Streak x5" })] : []),
+      ...(correctCount === totalRounds ? [t("games.fastLane.achPerfect", { defaultValue: "Perfect Driver" })] : []),
+    ],
+  };
 }
 
 // ── Shared lane display ───────────────────────────────────────────────────
@@ -196,17 +220,7 @@ function FastLaneCore({ onFinish }: { onFinish: (r: GameResult) => void }) {
   }, [roundIndex, roundsForPhase, phase, advancePhase, setupRound]);
 
   const handleFinish = useCallback(() => {
-    const total = Math.max(totalRounds * 15, 1);
-    onFinish({
-      gameKey: "fast_lane", score, total, streakMax: maxStreak,
-      roundsCompleted: totalRounds,
-      accuracy: totalRounds > 0 ? Math.round((correctCount / totalRounds) * 100) : 0,
-      firstTryClear: correctCount === totalRounds,
-      achievements: [
-        ...(maxStreak >= 5 ? [t("games.fastLane.achStreak", { defaultValue: "Signal Streak x5" })] : []),
-        ...(correctCount === totalRounds ? [t("games.fastLane.achPerfect", { defaultValue: "Perfect Driver" })] : []),
-      ],
-    });
+    onFinish(buildFastLaneCompletionPayload({ score, maxStreak, totalRounds, correctCount, t }));
   }, [score, maxStreak, totalRounds, correctCount, onFinish, t]);
 
   // ── Intro ───────────────────────────────────────────────────────────────

--- a/src/components/games/GotchaGearsGame.tsx
+++ b/src/components/games/GotchaGearsGame.tsx
@@ -55,6 +55,25 @@ function resolveField(t: any, field: unknown): string {
   return resolveText(t, field as any, "");
 }
 
+export function calculateGotchaCatchScore(streak: number): number {
+  return 10 * (streak + 1);
+}
+
+export function buildGotchaCompletionPayload(params: {
+  score: number;
+  roundsLength: number;
+  maxStreak: number;
+  roundIdx: number;
+}): GameResult {
+  return {
+    gameKey: "gotcha_gears_unity",
+    score: params.score,
+    total: params.roundsLength,
+    streakMax: params.maxStreak,
+    roundsCompleted: params.roundIdx + 1,
+  };
+}
+
 const FIELD_W = 560;
 const FIELD_H = 420;
 const GEAR_H = 52;        // gear pill height
@@ -210,13 +229,7 @@ function GotchaGearsCore({
   }, [roundIdx, rounds.length]);
 
   const finishGame = useCallback(() => {
-    onFinish({
-      gameKey: "gotcha_gears_unity",
-      score,
-      total: rounds.length,
-      streakMax: maxStreak,
-      roundsCompleted: roundIdx + 1,
-    });
+    onFinish(buildGotchaCompletionPayload({ score, roundsLength: rounds.length, maxStreak, roundIdx }));
   }, [score, rounds.length, maxStreak, roundIdx, onFinish]);
 
   const handleCatch = useCallback(
@@ -228,7 +241,7 @@ function GotchaGearsCore({
         setGears([]);
         setRoundComplete(true);
         const ns = streak + 1;
-        setScore((s) => s + 10 * ns);
+        setScore((s) => s + calculateGotchaCatchScore(streak));
         setStreak(ns);
         setMaxStreak((m) => Math.max(m, ns));
         setFeedback({ text: ns > 1 ? `${t("games.gotchaGears.correct", { defaultValue: "Got it!" })} x${ns}` : t("games.gotchaGears.correct", { defaultValue: "Got it!" }), type: "correct" });

--- a/src/components/games/MoveMeasureGame.tsx
+++ b/src/components/games/MoveMeasureGame.tsx
@@ -19,11 +19,33 @@ const IDEAL_TOSS = 50;
 const ICONS: Record<string, string> = { dash: "🏃", jump: "🦘", toss: "🥎" };
 const NAMES: Record<string, string> = { dash: "Dash", jump: "Jump", toss: "Toss" };
 
-function zoneScore(pos: number, s: number, e: number): number {
+export function zoneScore(pos: number, s: number, e: number): number {
   const c = (s + e) / 2, hw = (e - s) / 2, d = Math.abs(pos - c);
   return d <= hw ? 10 : Math.max(0, Math.round(10 - (d - hw) * 20));
 }
-function tossScore(v: number) { return Math.max(0, Math.round(10 - Math.abs(v - IDEAL_TOSS) * 0.2)); }
+export function tossScore(v: number) { return Math.max(0, Math.round(10 - Math.abs(v - IDEAL_TOSS) * 0.2)); }
+
+export function buildMoveMeasureCompletionPayload(params: {
+  scores: Scores;
+  impEvent: EventKey | null;
+  impScore: number;
+  exitAns: string | null;
+}): GameResult {
+  const { scores, impEvent, impScore, exitAns } = params;
+  const base = scores.dash + scores.jump + scores.toss;
+  const bonus = impScore > (impEvent ? scores[impEvent] : 0) ? 5 : 0;
+  const eBonus = exitAns === "correct" ? 5 : 0;
+  const total = base + bonus + eBonus;
+  return {
+    gameKey: "move_measure",
+    score: total,
+    total: 40,
+    streakMax: 0,
+    roundsCompleted: 3,
+    accuracy: Math.round((total / 40) * 100),
+    gameSpecific: { dash: scores.dash, jump: scores.jump, toss: scores.toss, impEvent, impScore, exitCorrect: exitAns === "correct" },
+  };
+}
 
 const BRIEFING: MissionBriefing = {
   title: "Move, Measure & Improve",
@@ -185,11 +207,7 @@ function MoveMeasurePlayfield({ onFinish }: { onFinish: (r: GameResult) => void 
   // ── Celebration → finish ──
   useEffect(() => {
     if (phase !== "celebration") return;
-    const base = scores.dash + scores.jump + scores.toss;
-    const bonus = impScore > (impEvent ? scores[impEvent] : 0) ? 5 : 0;
-    const eBonus = exitAns === "correct" ? 5 : 0;
-    const total = base + bonus + eBonus;
-    const tm = setTimeout(() => onFinish({ gameKey: "move_measure", score: total, total: 40, streakMax: 0, roundsCompleted: 3, accuracy: Math.round((total / 40) * 100), gameSpecific: { dash: scores.dash, jump: scores.jump, toss: scores.toss, impEvent, impScore, exitCorrect: exitAns === "correct" } }), 2500);
+    const tm = setTimeout(() => onFinish(buildMoveMeasureCompletionPayload({ scores, impEvent, impScore, exitAns })), 2500);
     return () => clearTimeout(tm);
   }, [phase]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -26,12 +26,40 @@ const OBSTACLES: Obstacle[] = [
 ];
 
 // ── Helpers ───────────────────────────────────────────────────────────────
-function laneX(lane: number) { return lane * LANE_W + LANE_W / 2; }
-function timeLabel(s: number) { return s < 15 ? "Fast" : s < 22 ? "Medium" : "Slow"; }
-function timeIcon(s: number) { return s < 15 ? "🚀" : s < 22 ? "🏃" : "🐢"; }
-function smoothLabel(s: number) { return s >= 70 ? "Smooth" : "Rough"; }
-function smoothIcon(s: number) { return s >= 70 ? "✨" : "💨"; }
-function arrow(a: number, b: number) { return b < a ? "⬇️" : b > a ? "⬆️" : "➡️"; }
+export function laneX(lane: number) { return lane * LANE_W + LANE_W / 2; }
+export function timeLabel(s: number) { return s < 15 ? "Fast" : s < 22 ? "Medium" : "Slow"; }
+export function timeIcon(s: number) { return s < 15 ? "🚀" : s < 22 ? "🏃" : "🐢"; }
+export function smoothLabel(s: number) { return s >= 70 ? "Smooth" : "Rough"; }
+export function smoothIcon(s: number) { return s >= 70 ? "✨" : "💨"; }
+export function arrow(a: number, b: number) { return b < a ? "⬇️" : b > a ? "⬆️" : "➡️"; }
+
+export function calculateQualifyTuneRaceScore(run1: RunResult | null, run2: RunResult | null, exitAnswer: string | null) {
+  if (!run1 || !run2) return { score: 0, total: 10 };
+  let s = 3;
+  if (run2.bumps < run1.bumps) s += 2;
+  if (run2.time < run1.time) s += 2;
+  if (run2.smoothness > run1.smoothness) s += 1;
+  if (exitAnswer === "one") s += 2;
+  return { score: Math.min(s, 10), total: 10 };
+}
+
+export function buildQualifyTuneRaceCompletionPayload(params: {
+  run1: RunResult | null;
+  run2: RunResult | null;
+  exitAnswer: string | null;
+  upgrade: Upgrade | null;
+}): GameResult {
+  const { score, total } = calculateQualifyTuneRaceScore(params.run1, params.run2, params.exitAnswer);
+  return {
+    gameKey: "qualify_tune_race",
+    score,
+    total,
+    streakMax: 1,
+    roundsCompleted: 2,
+    achievements: ["Big Challenge"],
+    gameSpecific: { upgrade: params.upgrade, run1: params.run1, run2: params.run2, exitCorrect: params.exitAnswer === "one" },
+  };
+}
 
 // ── Briefing ──────────────────────────────────────────────────────────────
 const BRIEFING: MissionBriefing = {
@@ -159,15 +187,10 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [steer]);
 
-  const computeScore = useCallback(() => {
-    if (!run1 || !run2) return { score: 0, total: 10 };
-    let s = 3;
-    if (run2.bumps < run1.bumps) s += 2;
-    if (run2.time < run1.time) s += 2;
-    if (run2.smoothness > run1.smoothness) s += 1;
-    if (exitAnswer === "one") s += 2;
-    return { score: Math.min(s, 10), total: 10 };
-  }, [run1, run2, exitAnswer]);
+  const computeScore = useCallback(
+    () => calculateQualifyTuneRaceScore(run1, run2, exitAnswer),
+    [run1, run2, exitAnswer],
+  );
 
   // ── Phase: intro ────────────────────────────────────────────────────
   if (phase === "intro") return (
@@ -448,10 +471,7 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
         </p>
       </div>
       <button onClick={() => {
-          const { score: s, total: tot } = computeScore();
-          onFinish({ gameKey: "qualify_tune_race", score: s, total: tot, streakMax: 1,
-            roundsCompleted: 2, achievements: ["Big Challenge"],
-            gameSpecific: { upgrade, run1, run2, exitCorrect: exitAnswer === "one" } });
+          onFinish(buildQualifyTuneRaceCompletionPayload({ run1, run2, exitAnswer, upgrade }));
         }}
         className="bounce-in px-10 py-5 text-xl font-bold rounded-2xl bg-gradient-to-r from-emerald-500 to-emerald-600 text-white shadow-lg shadow-emerald-500/25 hover:scale-105 active:scale-95 transition-transform"
         style={{ animationDelay: "600ms" }}>

--- a/src/components/games/QuantumQuestGame.tsx
+++ b/src/components/games/QuantumQuestGame.tsx
@@ -57,6 +57,43 @@ interface Target {
 
 type PowerUp = "slowTime" | "shield" | "reveal";
 
+export function buildQuantumQuestCompletionPayload(params: {
+  sectors: QQSector[];
+  totalCorrect: number;
+  totalAttempted: number;
+  maxStreak: number;
+  lives: number;
+  sectorsCleared: number;
+  powerUpsUsed: number;
+  t: (key: string) => string;
+}): GameResult {
+  const totalProblems = params.sectors.reduce((sum, sec) => sum + sec.problems.length, 0);
+  const accuracy = params.totalAttempted > 0 ? Math.round((params.totalCorrect / params.totalAttempted) * 100) : 0;
+  const achievements: string[] = [];
+  if (params.maxStreak >= 5) achievements.push(params.t("games.quantumQuest.achScanner"));
+  if (accuracy >= 90) achievements.push(params.t("games.quantumQuest.achPerfect"));
+  if (params.sectorsCleared === params.sectors.length) achievements.push(params.t("games.quantumQuest.achExplorer"));
+  if (params.maxStreak >= 3) achievements.push(params.t("games.quantumQuest.achFast"));
+  return {
+    gameKey: "quantum_quest",
+    score: params.totalCorrect,
+    total: totalProblems,
+    streakMax: params.maxStreak,
+    roundsCompleted: params.sectorsCleared,
+    accuracy,
+    levelReached: params.sectorsCleared,
+    hintsUsed: 0,
+    firstTryClear: params.lives >= 3 && params.sectorsCleared === params.sectors.length,
+    achievements,
+    gameSpecific: {
+      maxStreak: params.maxStreak,
+      totalAttempted: params.totalAttempted,
+      sectorsCleared: params.sectorsCleared,
+      powerUpsUsed: params.powerUpsUsed,
+    },
+  };
+}
+
 // ── Sector Themes ──────────────────────────────────────────────────────────
 
 const SECTOR_THEMES: Record<string, { bg: string; accent: string; targetIdle: string; targetGlow: string; label: string; icon: string }> = {
@@ -471,21 +508,16 @@ function QuantumQuestCore({ config, onFinish }: { config: QuantumQuestConfig; on
   }, [sectorIdx, config.sectors.length]);
 
   const finishGame = useCallback(() => {
-    const totalProblems = config.sectors.reduce((s, sec) => s + sec.problems.length, 0);
-    const accuracy = totalAttempted > 0 ? Math.round((totalCorrect / totalAttempted) * 100) : 0;
-    const achievements: string[] = [];
-    if (maxStreak >= 5) achievements.push(t("games.quantumQuest.achScanner"));
-    if (accuracy >= 90) achievements.push(t("games.quantumQuest.achPerfect"));
-    if (sectorsCleared === config.sectors.length) achievements.push(t("games.quantumQuest.achExplorer"));
-    if (maxStreak >= 3) achievements.push(t("games.quantumQuest.achFast"));
-
-    onFinish({
-      gameKey: "quantum_quest", score: totalCorrect, total: totalProblems,
-      streakMax: maxStreak, roundsCompleted: sectorsCleared, accuracy,
-      levelReached: sectorsCleared, hintsUsed: 0,
-      firstTryClear: lives >= 3 && sectorsCleared === config.sectors.length,
-      achievements, gameSpecific: { maxStreak, totalAttempted, sectorsCleared, powerUpsUsed },
-    });
+    onFinish(buildQuantumQuestCompletionPayload({
+      sectors: config.sectors,
+      totalCorrect,
+      totalAttempted,
+      maxStreak,
+      lives,
+      sectorsCleared,
+      powerUpsUsed,
+      t: (key) => t(key),
+    }));
   }, [config, totalCorrect, totalAttempted, maxStreak, lives, sectorsCleared, powerUpsUsed, onFinish, t]);
 
   const resetAll = useCallback(() => {

--- a/src/components/games/SkyShieldGame.tsx
+++ b/src/components/games/SkyShieldGame.tsx
@@ -14,7 +14,7 @@ import "./shared/game-effects.css";
 const LABELS = ["🔵", "🟡", "🩷"];
 const SHIELD_BG = ["bg-blue-500", "bg-yellow-500", "bg-pink-500"];
 const LANE_BG = ["bg-blue-400/20", "bg-yellow-400/20", "bg-pink-400/20"];
-const PT = { catch: 10, predict: 20, scan: 15 };
+export const PT = { catch: 10, predict: 20, scan: 15 };
 const PRACTICE_N = 5, PATTERN_N = 3, CHALLENGE_N = 10, MYSTERY_N = 2;
 
 type Phase = "intro" | "practice" | "pattern" | "scan" | "challenge" | "exitTicket" | "celebration";
@@ -31,12 +31,12 @@ const BRIEFING: MissionBriefing = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 const rLane = () => Math.floor(Math.random() * 3);
-function mkPattern(): number[] {
+export function mkPattern(): number[] {
   const b = [0, 1, 2];
   for (let i = 2; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [b[i], b[j]] = [b[j], b[i]]; }
   return [...b, ...b];
 }
-function mkChallenge(): Drop[] {
+export function mkChallenge(): Drop[] {
   const mi = new Set<number>();
   while (mi.size < MYSTERY_N) mi.add(2 + Math.floor(Math.random() * (CHALLENGE_N - 2)));
   const p = mkPattern();
@@ -45,6 +45,23 @@ function mkChallenge(): Drop[] {
     kind: mi.has(i) ? "mystery" as const : "normal" as const,
     ...(mi.has(i) ? { hiddenColor: Math.random() < 0.5 ? 0 : 1 } : {}),
   }));
+}
+
+export function buildSkyShieldCompletionPayload(params: {
+  score: number;
+  exitAns: number | null;
+  totalRounds: number;
+  maxStreak: number;
+  streak: number;
+}): GameResult {
+  const exitOk = params.exitAns === 1;
+  return {
+    gameKey: "sky_shield",
+    score: params.score + (exitOk ? PT.predict : 0),
+    total: (params.totalRounds + 1) * PT.predict,
+    streakMax: Math.max(params.maxStreak, exitOk ? params.streak + 1 : params.streak),
+    roundsCompleted: params.totalRounds + 1,
+  };
 }
 
 // ── Shared sub-components ─────────────────────────────────────────────────
@@ -295,16 +312,18 @@ function SkyShieldPlayfield({ onFinish }: { onFinish: (r: GameResult) => void })
 
   // ── Phase: CELEBRATION ──────────────────────────────────────────────
   if (phase === "celebration") {
-    const exitOk = exitAns === 1;
-    const fs = score + (exitOk ? PT.predict : 0);
-    const ft = (total.current + 1) * PT.predict;
-    const fm = Math.max(maxStreak.current, exitOk ? streak + 1 : streak);
     return (
       <div className="slide-up-fade text-center space-y-6 py-8">
         <div className="text-7xl bounce-in">🛡️✨</div>
         <h2 className="text-2xl font-extrabold text-violet-900">{T("celebrationTitle", "Amazing Work!")}</h2>
         <p className="text-slate-600 max-w-md mx-auto">{T("celebrationMsg", "You watched, noticed the pattern, and chose the right shield!")}</p>
-        <BigBtn onClick={() => onFinish({ gameKey: "sky_shield", score: fs, total: ft, streakMax: fm, roundsCompleted: total.current + 1 })}
+        <BigBtn onClick={() => onFinish(buildSkyShieldCompletionPayload({
+          score,
+          exitAns,
+          totalRounds: total.current,
+          maxStreak: maxStreak.current,
+          streak,
+        }))}
           cls="bg-gradient-to-r from-emerald-500 to-emerald-600">{T("finish", "Finish")}</BigBtn>
       </div>
     );

--- a/src/components/games/TankTrekGame.tsx
+++ b/src/components/games/TankTrekGame.tsx
@@ -104,6 +104,43 @@ const DIR_ROTATION: Record<Dir, number> = { N: 0, E: 90, S: 180, W: 270 };
 
 const CELL_SIZE = 56;
 
+export function computeTankStars(commandsLength: number, par?: number): number {
+  const baseline = par ?? commandsLength;
+  return commandsLength <= baseline ? 3 : commandsLength <= baseline + 2 ? 2 : 1;
+}
+
+export function applyTankCommand(dir: Dir, cmd: Command): Dir {
+  if (cmd === "LEFT") return TURN_LEFT[dir];
+  if (cmd === "RIGHT") return TURN_RIGHT[dir];
+  return dir;
+}
+
+export function buildTankTrekCompletionPayload(params: {
+  totalScore: number;
+  totalPossible: number;
+  levelsCleared: number;
+  retries: number;
+  totalChips: number;
+  hintsUsed: number;
+  allLevelsLength: number;
+  achievements: string[];
+}): GameResult {
+  return {
+    gameKey: "tank_trek",
+    score: params.totalScore,
+    total: params.totalPossible,
+    streakMax: params.levelsCleared,
+    roundsCompleted: params.levelsCleared,
+    starsEarned: Math.round(params.totalScore / Math.max(1, params.allLevelsLength)),
+    accuracy: params.totalPossible > 0 ? Math.round((params.totalScore / params.totalPossible) * 100) : 0,
+    levelReached: params.allLevelsLength,
+    hintsUsed: params.hintsUsed,
+    firstTryClear: params.retries === 0,
+    achievements: params.achievements,
+    gameSpecific: { totalChips: params.totalChips, retries: params.retries },
+  };
+}
+
 // ── Built-in Levels ────────────────────────────────────────────────────────
 
 const BUILTIN_LEVELS: TankTrekConfig = {
@@ -412,8 +449,7 @@ function TankTrekCore({ config, onFinish }: { config: TankTrekConfig; onFinish: 
       setActiveCommandIdx(i);
       const cmd = commands[i];
 
-      if (cmd === "LEFT") { d = TURN_LEFT[d]; setRobotDir(d); }
-      else if (cmd === "RIGHT") { d = TURN_RIGHT[d]; setRobotDir(d); }
+      if (cmd === "LEFT" || cmd === "RIGHT") { d = applyTankCommand(d, cmd); setRobotDir(d); }
       else {
         const [dr, dc] = DIR_DELTA[d];
         const nr = r + dr, nc = c + dc;
@@ -435,8 +471,7 @@ function TankTrekCore({ config, onFinish }: { config: TankTrekConfig; onFinish: 
     setActiveCommandIdx(-1);
 
     if (reachedGoal) {
-      const par = level.par ?? commands.length;
-      const stars = commands.length <= par ? 3 : commands.length <= par + 2 ? 2 : 1;
+      const stars = computeTankStars(commands.length, level.par);
       setStarsThisLevel(stars);
       setLevelStars((prev) => ({ ...prev, [levelIdx]: Math.max(prev[levelIdx] ?? 0, stars) }));
       setTotalScore((s) => s + stars);
@@ -465,15 +500,16 @@ function TankTrekCore({ config, onFinish }: { config: TankTrekConfig; onFinish: 
       if (totalChips > 0) achievements.push(t("games.tankTrek.achCollector"));
       if (totalScore >= totalPossible * 0.9) achievements.push(t("games.tankTrek.achMaster"));
       if (hintsUsed === 0) achievements.push(t("games.tankTrek.achNoHints"));
-      onFinish({
-        gameKey: "tank_trek", score: totalScore, total: totalPossible,
-        streakMax: levelsCleared, roundsCompleted: levelsCleared,
-        starsEarned: Math.round(totalScore / Math.max(1, allLevels.length)),
-        accuracy: totalPossible > 0 ? Math.round((totalScore / totalPossible) * 100) : 0,
-        levelReached: allLevels.length, hintsUsed,
-        firstTryClear: retries === 0, achievements,
-        gameSpecific: { totalChips, retries },
-      });
+      onFinish(buildTankTrekCompletionPayload({
+        totalScore,
+        totalPossible,
+        levelsCleared,
+        retries,
+        totalChips,
+        hintsUsed,
+        allLevelsLength: allLevels.length,
+        achievements,
+      }));
     }
   }, [levelIdx, allLevels, totalScore, totalPossible, levelsCleared, retries, totalChips, hintsUsed, onFinish, t]);
 

--- a/src/components/games/__tests__/FastLane.test.ts
+++ b/src/components/games/__tests__/FastLane.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  bestLane,
+  buildFastLaneCompletionPayload,
+  generateLanes,
+  scorePick,
+} from "../FastLaneGame";
+
+describe("Fast Lane helpers", () => {
+  it("generates lanes with at least one safe lane", () => {
+    for (let i = 0; i < 20; i++) {
+      const lanes = generateLanes(true);
+      expect(lanes.filter((s) => s === "safe").length).toBeGreaterThan(0);
+    }
+  });
+
+  it("selects best lane using look-ahead", () => {
+    expect(bestLane({ current: ["safe", "blocked", "safe"], next: ["blocked", "safe", "safe"] })).toBe(2);
+    expect(bestLane({ current: ["caution", "blocked", "blocked"] })).toBe(0);
+  });
+
+  it("scores picks and builds completion payload", () => {
+    expect(scorePick("safe", true)).toBe(15);
+    expect(scorePick("safe", false)).toBe(10);
+    expect(scorePick("caution", false)).toBe(5);
+    expect(scorePick("blocked", false)).toBe(0);
+
+    const t = (key: string, options?: Record<string, unknown>) =>
+      options?.defaultValue ? String(options.defaultValue) : key;
+    const payload = buildFastLaneCompletionPayload({
+      score: 90,
+      maxStreak: 6,
+      totalRounds: 8,
+      correctCount: 8,
+      t,
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "fast_lane",
+      total: 120,
+      accuracy: 100,
+      firstTryClear: true,
+      roundsCompleted: 8,
+    });
+    expect(payload.achievements).toContain("Signal Streak x5");
+  });
+});

--- a/src/components/games/__tests__/GotchaGears.test.ts
+++ b/src/components/games/__tests__/GotchaGears.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGotchaCompletionPayload,
+  calculateGotchaCatchScore,
+} from "../GotchaGearsGame";
+
+describe("Gotcha Gears helpers", () => {
+  it("calculates streak-based catch score", () => {
+    expect(calculateGotchaCatchScore(0)).toBe(10);
+    expect(calculateGotchaCatchScore(2)).toBe(30);
+  });
+
+  it("builds completion payload shape", () => {
+    expect(
+      buildGotchaCompletionPayload({
+        score: 80,
+        roundsLength: 6,
+        maxStreak: 4,
+        roundIdx: 5,
+      }),
+    ).toMatchObject({
+      gameKey: "gotcha_gears_unity",
+      score: 80,
+      total: 6,
+      streakMax: 4,
+      roundsCompleted: 6,
+    });
+  });
+});

--- a/src/components/games/__tests__/MoveMeasure.test.ts
+++ b/src/components/games/__tests__/MoveMeasure.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMoveMeasureCompletionPayload,
+  tossScore,
+  zoneScore,
+} from "../MoveMeasureGame";
+
+describe("Move, Measure & Improve helpers", () => {
+  it("scores zones and tosses", () => {
+    expect(zoneScore(0.35, 0.3, 0.4)).toBe(10);
+    expect(zoneScore(0.9, 0.3, 0.4)).toBeLessThan(10);
+    expect(tossScore(50)).toBe(10);
+    expect(tossScore(0)).toBe(0);
+  });
+
+  it("builds completion payload with improvements and exit ticket", () => {
+    const payload = buildMoveMeasureCompletionPayload({
+      scores: { dash: 8, jump: 6, toss: 5 },
+      impEvent: "jump",
+      impScore: 9,
+      exitAns: "correct",
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "move_measure",
+      total: 40,
+      score: 29,
+      roundsCompleted: 3,
+      accuracy: 73,
+      gameSpecific: { impEvent: "jump", impScore: 9, exitCorrect: true },
+    });
+  });
+});

--- a/src/components/games/__tests__/QualifyTuneRace.test.ts
+++ b/src/components/games/__tests__/QualifyTuneRace.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  arrow,
+  buildQualifyTuneRaceCompletionPayload,
+  calculateQualifyTuneRaceScore,
+  laneX,
+  smoothLabel,
+  timeLabel,
+} from "../QualifyTuneRaceGame";
+
+describe("Qualify, Tune, Race helpers", () => {
+  it("scores compare results", () => {
+    const result = calculateQualifyTuneRaceScore(
+      { time: 20, bumps: 4, smoothness: 55 },
+      { time: 18, bumps: 2, smoothness: 70 },
+      "one",
+    );
+    expect(result).toEqual({ score: 10, total: 10 });
+  });
+
+  it("exports deterministic label helpers", () => {
+    expect(laneX(0)).toBeLessThan(laneX(2));
+    expect(timeLabel(14)).toBe("Fast");
+    expect(smoothLabel(80)).toBe("Smooth");
+    expect(arrow(10, 8)).toBe("⬇️");
+  });
+
+  it("builds completion payload", () => {
+    const payload = buildQualifyTuneRaceCompletionPayload({
+      run1: { time: 20, bumps: 4, smoothness: 55 },
+      run2: { time: 19, bumps: 3, smoothness: 65 },
+      exitAnswer: "one",
+      upgrade: "grip",
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "qualify_tune_race",
+      total: 10,
+      roundsCompleted: 2,
+      gameSpecific: { upgrade: "grip", exitCorrect: true },
+    });
+  });
+});

--- a/src/components/games/__tests__/QuantumQuest.test.ts
+++ b/src/components/games/__tests__/QuantumQuest.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildQuantumQuestCompletionPayload } from "../QuantumQuestGame";
+
+describe("Quantum Quest completion", () => {
+  it("builds final payload with accuracy and achievements", () => {
+    const t = (key: string) => key;
+    const payload = buildQuantumQuestCompletionPayload({
+      sectors: [
+        { id: "a", titles: {}, problems: [{ id: "1", prompts: {}, correctAnswer: 1, decoys: [2], skillTag: "count" }], speed: 1, spawnRate: 1, theme: "harbor" },
+        { id: "b", titles: {}, problems: [{ id: "2", prompts: {}, correctAnswer: 2, decoys: [1], skillTag: "add" }], speed: 1, spawnRate: 1, theme: "nebula" },
+      ],
+      totalCorrect: 2,
+      totalAttempted: 2,
+      maxStreak: 5,
+      lives: 3,
+      sectorsCleared: 2,
+      powerUpsUsed: 1,
+      t,
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "quantum_quest",
+      score: 2,
+      total: 2,
+      roundsCompleted: 2,
+      accuracy: 100,
+      firstTryClear: true,
+      gameSpecific: { powerUpsUsed: 1 },
+    });
+    expect(payload.achievements).toContain("games.quantumQuest.achPerfect");
+    expect(payload.achievements).toContain("games.quantumQuest.achExplorer");
+  });
+});

--- a/src/components/games/__tests__/RegistrySet2Coverage.test.ts
+++ b/src/components/games/__tests__/RegistrySet2Coverage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { GAME_COMPONENTS } from "../gameRegistry";
+
+describe("game registry target coverage", () => {
+  it("registers audited under-tested game keys", () => {
+    expect(GAME_COMPONENTS.gotcha_gears_unity).toBeDefined();
+    expect(GAME_COMPONENTS.tank_trek).toBeDefined();
+    expect(GAME_COMPONENTS.quantum_quest).toBeDefined();
+    expect(GAME_COMPONENTS.move_measure).toBeDefined();
+    expect(GAME_COMPONENTS.sky_shield).toBeDefined();
+    expect(GAME_COMPONENTS.fast_lane).toBeDefined();
+    expect(GAME_COMPONENTS.qualify_tune_race).toBeDefined();
+  });
+});

--- a/src/components/games/__tests__/SkyShield.test.ts
+++ b/src/components/games/__tests__/SkyShield.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSkyShieldCompletionPayload,
+  mkChallenge,
+  mkPattern,
+} from "../SkyShieldGame";
+
+describe("Sky Shield helpers", () => {
+  it("creates valid repeating base pattern", () => {
+    const pattern = mkPattern();
+    expect(pattern).toHaveLength(6);
+    expect(pattern.slice(0, 3).sort()).toEqual([0, 1, 2]);
+    expect(pattern.slice(3).sort()).toEqual([0, 1, 2]);
+  });
+
+  it("creates challenge with mystery constraints", () => {
+    const challenge = mkChallenge();
+    const mysteries = challenge
+      .map((drop, idx) => ({ drop, idx }))
+      .filter(({ drop }) => drop.kind === "mystery");
+
+    expect(challenge).toHaveLength(10);
+    expect(mysteries).toHaveLength(2);
+    expect(mysteries.every(({ idx }) => idx >= 2)).toBe(true);
+    expect(mysteries.every(({ drop }) => drop.hiddenColor === 0 || drop.hiddenColor === 1)).toBe(true);
+    expect(challenge.every((drop) => drop.lane >= 0 && drop.lane <= 2)).toBe(true);
+  });
+
+  it("builds completion payload", () => {
+    expect(
+      buildSkyShieldCompletionPayload({
+        score: 85,
+        exitAns: 1,
+        totalRounds: 20,
+        maxStreak: 4,
+        streak: 3,
+      }),
+    ).toMatchObject({
+      gameKey: "sky_shield",
+      score: 105,
+      total: 420,
+      streakMax: 4,
+      roundsCompleted: 21,
+    });
+  });
+});

--- a/src/components/games/__tests__/TankTrek.test.ts
+++ b/src/components/games/__tests__/TankTrek.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTankCommand,
+  buildTankTrekCompletionPayload,
+  computeTankStars,
+} from "../TankTrekGame";
+
+describe("Tank Trek helpers", () => {
+  it("computes stars from command count and par", () => {
+    expect(computeTankStars(4, 4)).toBe(3);
+    expect(computeTankStars(5, 4)).toBe(2);
+    expect(computeTankStars(8, 4)).toBe(1);
+  });
+
+  it("applies turn commands deterministically", () => {
+    expect(applyTankCommand("N", "LEFT")).toBe("W");
+    expect(applyTankCommand("N", "RIGHT")).toBe("E");
+    expect(applyTankCommand("S", "FWD")).toBe("S");
+  });
+
+  it("builds completion payload with expected metadata", () => {
+    const payload = buildTankTrekCompletionPayload({
+      totalScore: 12,
+      totalPossible: 15,
+      levelsCleared: 5,
+      retries: 0,
+      totalChips: 3,
+      hintsUsed: 1,
+      allLevelsLength: 5,
+      achievements: ["No Hints"],
+    });
+
+    expect(payload).toMatchObject({
+      gameKey: "tank_trek",
+      score: 12,
+      total: 15,
+      roundsCompleted: 5,
+      accuracy: 80,
+      firstTryClear: true,
+      hintsUsed: 1,
+      gameSpecific: { totalChips: 3, retries: 0 },
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The game audit identified several registry-backed games lacking unit tests and deterministic coverage for core scoring and completion logic.
- Provide stable, pure-unit tests that exercise scoring, phase transitions, answer checking, challenge generation constraints, and completion payload shapes without touching core learning content or gameplay mechanics.
- Ensure registry dispatch sanity so the activity player can reliably resolve canonical game keys.

### Description
- Exported small, pure helpers and completion-payload builders from the games to enable deterministic tests without changing game mechanics; helpers added include scoring and payload functions for Gotcha Gears, Tank Trek, Quantum Quest, Move Measure, Sky Shield, Fast Lane, and Qualify/Tune/Race.
- Rewired existing finish paths to use the new completion-payload builders so runtime behavior remains aligned with prior behavior while making outputs testable. 
- Added dedicated unit test files that target the exported helpers and payload shapes for each audited game and a registry presence test: `src/components/games/__tests__/*` (new tests for GotchaGears, TankTrek, QuantumQuest, MoveMeasure, SkyShield, FastLane, QualifyTuneRace, plus `RegistrySet2Coverage`).
- Kept all UI/render/timing code unchanged and avoided brittle animation/timer tests; changes are limited to helper exports and tests only.

### Testing
- Ran the targeted Vitest command: `npm test -- --run src/components/games/__tests__/GotchaGears.test.ts src/components/games/__tests__/TankTrek.test.ts src/components/games/__tests__/QuantumQuest.test.ts src/components/games/__tests__/MoveMeasure.test.ts src/components/games/__tests__/SkyShield.test.ts src/components/games/__tests__/FastLane.test.ts src/components/games/__tests__/QualifyTuneRace.test.ts src/components/games/__tests__/RegistrySet2Coverage.test.ts` and iterated until green.
- One assertion in the Move/Measure test was adjusted to match the exact scoring logic exposed by the helper during development; after that all targeted tests passed.
- Final result: all new and existing targeted game-unit tests passed under Vitest (run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6c6c015c83258725a0e117177475)