### PR TITLE
Add shared reduced-effects (low-performance) mode for games

### DIFF
--- a/docs/game-audit.md
+++ b/docs/game-audit.md
@@ -131,3 +131,24 @@ Scoring scale: 1 (poor) to 5 (excellent). Scores are based on static code review
 4. Add automated a11y checks for game views (axe + keyboard path smoke tests).
 5. Add mobile snapshot tests for command-heavy games (Tank Trek / Qualify Tune Race).
 
+## 6) Reduced-effects mode rollout (April 27, 2026)
+
+A shared reduced-effects system is now implemented for React game wrappers.
+
+- Shared hook: `useReducedGameEffects` reads OS/browser `prefers-reduced-motion`, supports manual override, and persists selection in localStorage key `brightboost.reducedGameEffects`.
+- Shared UI: `ReducedEffectsToggle` appears in both `GameShell` and `LearningGameFrame` with accessible wording:
+  - **Label**: “Reduced effects”
+  - **Description**: “Reduces motion, particles, and visual intensity for smoother play.”
+- Shared DOM state: wrappers expose `data-reduced-effects="true|false"` so games inherit consistent animation reductions via shared CSS.
+- Shared CSS behavior: decorative animations (`sparkle`, `streak-fire`, shake/bounce/pulse, etc.) are reduced/disabled under reduced-effects mode while preserving core game feedback.
+
+### Priority game coverage delivered
+
+- **Bounce & Buds (`buddy_garden_sort`)**: decorative sparkle bursts are disabled in reduced-effects mode; scoring/physics unchanged.
+- **Quantum Quest (`quantum_quest`)**: decorative starfield and hit-burst effects are reduced/disabled; gameplay logic unchanged.
+- **Qualify, Tune, Race (`qualify_tune_race`)**: wobble/shake impact visuals are reduced in reduced-effects mode; collision/scoring unchanged.
+- **Rhyme & Ride (`rhymo_rhyme_rocket`)**: now consumes shared reduced-effects state rather than only system media query, keeping behavior consistent with manual toggle and persistence.
+
+### Light-touch inheritance checks
+
+Games already using shared wrappers (including Fast Lane, Sky Shield, Maze Maps, and Data Dash) inherit wrapper-level reduced-effects behavior via shared CSS without learning/scoring changes.

--- a/src/components/games/BounceBudsGame.tsx
+++ b/src/components/games/BounceBudsGame.tsx
@@ -88,6 +88,9 @@ function shuffleArray<T>(arr: T[]): T[] {
 function clamp(v: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, v));
 }
+export function shouldRenderBounceSparkles(reducedEffects: boolean) {
+  return !reducedEffects;
+}
 
 /** Returns [left, right] pixel ranges for each of the three gates. */
 function gateRanges(): Array<{ left: number; right: number }> {
@@ -128,9 +131,11 @@ const BRIEFING: MissionBriefing = {
 function BouncePlayfield({
   onFinish,
   config,
+  reducedEffects,
 }: {
   onFinish: (result: GameResult) => void;
   config?: any;
+  reducedEffects: boolean;
 }) {
   const { t } = useTranslation();
   const band = getGradeBand(config);
@@ -278,7 +283,7 @@ function BouncePlayfield({
     setPhase("resolved");
     setFeedback({ text: message, correct });
 
-    if (correct) {
+    if (correct && shouldRenderBounceSparkles(reducedEffects)) {
       const bx = ball.current.x;
       const by = ball.current.y;
       const sp = Array.from({ length: 8 }, () => ({
@@ -611,7 +616,7 @@ function BouncePlayfield({
             Score: {score}/{ROUNDS.length}
           </div>
           {streak >= 2 && (
-            <div className="streak-fire text-amber-600 tabular-nums">
+            <div className={`${reducedEffects ? "" : "streak-fire"} text-amber-600 tabular-nums`}>
               {streak}x combo
             </div>
           )}
@@ -712,7 +717,7 @@ function BouncePlayfield({
             </div>
 
             {/* ── Sparkles ── */}
-            {sparkles.map((s) => (
+            {shouldRenderBounceSparkles(reducedEffects) && sparkles.map((s) => (
               <div
                 key={s.id}
                 className="absolute w-3 h-3 rounded-full bg-yellow-300 hit-burst pointer-events-none"
@@ -814,7 +819,9 @@ export default function BounceBudsGame({
       briefing={BRIEFING}
       onComplete={onComplete ?? (() => {})}
     >
-      {({ onFinish }) => <BouncePlayfield onFinish={onFinish} config={config} />}
+      {({ onFinish, reducedEffects }) => (
+        <BouncePlayfield onFinish={onFinish} config={config} reducedEffects={reducedEffects} />
+      )}
     </GameShell>
   );
 }

--- a/src/components/games/DataDashSortDiscoverGame.tsx
+++ b/src/components/games/DataDashSortDiscoverGame.tsx
@@ -234,7 +234,7 @@ export default function DataDashSortDiscoverGame({ onComplete }: GameProps) {
       briefing={BRIEFING}
       onComplete={(result) => onComplete?.(result)}
     >
-      {({ onFinish }) => <DataDashPlayfield onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <DataDashPlayfield onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/FastLaneGame.tsx
+++ b/src/components/games/FastLaneGame.tsx
@@ -355,7 +355,7 @@ export default function FastLaneGame({ onComplete }: {
 }) {
   return (
     <GameShell gameKey="fast_lane" title="Fast Lane Signals" briefing={BRIEFING} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <FastLaneCore onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <FastLaneCore onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/GotchaGearsGame.tsx
+++ b/src/components/games/GotchaGearsGame.tsx
@@ -361,7 +361,7 @@ export default function GotchaGearsGame({
       briefing={briefing}
       onComplete={onComplete!}
     >
-      {({ onFinish }) => (
+      {({ onFinish, reducedEffects: _reducedEffects }) => (
         <GotchaGearsCore config={gameConfig} onFinish={onFinish} />
       )}
     </GameShell>

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -661,7 +661,7 @@ export default function MazeMapsGame({
       briefing={BRIEFING}
       onComplete={onComplete ?? (() => {})}
     >
-      {({ onFinish }) => <MazeMapsCore onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <MazeMapsCore onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/MoveMeasureGame.tsx
+++ b/src/components/games/MoveMeasureGame.tsx
@@ -432,7 +432,7 @@ function MoveMeasurePlayfield({ onFinish }: { onFinish: (r: GameResult) => void 
 export default function MoveMeasureGame({ onComplete }: { config?: unknown; onComplete?: (result: GameResult) => void }) {
   return (
     <GameShell gameKey="move_measure" title="Move, Measure & Improve" briefing={BRIEFING} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <MoveMeasurePlayfield onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <MoveMeasurePlayfield onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -88,7 +88,7 @@ function MetricCard({ icon, value, label, sub, color }: {
 // ═══════════════════════════════════════════════════════════════════════════
 // RacePlayfield
 // ═══════════════════════════════════════════════════════════════════════════
-function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
+function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult) => void; reducedEffects: boolean }) {
   const { t } = useTranslation();
   const [phase, setPhase] = useState<Phase>("intro");
   const [carLane, setCarLane] = useState(1);
@@ -158,7 +158,9 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
         if (Math.abs(carX - laneX(obs.lane)) < bumpZone &&
             Math.abs(carY - (obs.y - scrollRef.current + TRACK_H - 100)) < bumpZone) {
           hitSet.current.add(i); bumpsRef.current += 1; setBumps(bumpsRef.current);
-          setWobble(true); setTimeout(() => setWobble(false), 400);
+          if (!reducedEffects) {
+            setWobble(true); setTimeout(() => setWobble(false), 400);
+          }
         }
       }
       if (scrollRef.current >= TRACK_LENGTH) { finishRef.current(); return; }
@@ -166,7 +168,7 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
     };
     rafId.current = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(rafId.current);
-  }, [phase, speedMult, bumpZone]);
+  }, [phase, speedMult, bumpZone, reducedEffects]);
 
   useEffect(() => () => cancelAnimationFrame(rafId.current), []);
 
@@ -186,11 +188,6 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [steer]);
-
-  const computeScore = useCallback(
-    () => calculateQualifyTuneRaceScore(run1, run2, exitAnswer),
-    [run1, run2, exitAnswer],
-  );
 
   // ── Phase: intro ────────────────────────────────────────────────────
   if (phase === "intro") return (
@@ -256,7 +253,7 @@ function RacePlayfield({ onFinish }: { onFinish: (r: GameResult) => void }) {
                   </div>
                 );
               })}
-              <div className={`absolute transition-all duration-150 ease-out ${wobble ? "shake" : ""}`}
+              <div className={`absolute transition-all duration-150 ease-out ${wobble && !reducedEffects ? "shake" : ""}`}
                 style={{ left: laneX(carLane) - CAR_W / 2, top: TRACK_H - 100 - CAR_H / 2,
                   width: CAR_W, height: CAR_H, fontSize: 40, textAlign: "center", lineHeight: `${CAR_H}px` }}>
                 🏎️
@@ -492,7 +489,7 @@ export default function QualifyTuneRaceGame({ onComplete }: {
   return (
     <GameShell gameKey="qualify_tune_race" title="Qualify, Tune, Race"
       briefing={BRIEFING} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <RacePlayfield onFinish={onFinish} />}
+      {({ onFinish, reducedEffects }) => <RacePlayfield onFinish={onFinish} reducedEffects={reducedEffects} />}
     </GameShell>
   );
 }

--- a/src/components/games/QuantumQuestGame.tsx
+++ b/src/components/games/QuantumQuestGame.tsx
@@ -166,9 +166,12 @@ const BUILTIN_CONFIG: QuantumQuestConfig = {
 const FIELD_W = 600;
 const FIELD_H = 380;
 const TARGET_PAD = 8; // safe padding from edges so targets never clip
+export function getQuantumQuestStarCount(reducedEffects: boolean) {
+  return reducedEffects ? 12 : 40;
+}
 
 function TargetField({
-  targets, onHit, sectorTheme, streak, hitEffects, slowActive,
+  targets, onHit, sectorTheme, streak, hitEffects, slowActive, reducedEffects,
 }: {
   targets: Target[];
   onHit: (id: string) => void;
@@ -176,6 +179,7 @@ function TargetField({
   streak: number;
   hitEffects: { id: string; x: number; y: number; correct: boolean }[];
   slowActive: boolean;
+  reducedEffects: boolean;
 }) {
   // Responsive scaling — same approach as Bounce & Buds
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -194,7 +198,7 @@ function TargetField({
 
   // Stable starfield
   const stars = useMemo(() =>
-    Array.from({ length: 40 }, (_, i) => ({
+    Array.from({ length: getQuantumQuestStarCount(reducedEffects) }, (_, i) => ({
       id: i,
       x: Math.random() * 100,
       y: Math.random() * 100,
@@ -202,7 +206,7 @@ function TargetField({
       opacity: Math.random() * 0.6 + 0.15,
       twinkle: 2 + Math.random() * 3,
     })),
-  []);
+  [reducedEffects]);
 
   return (
     <div ref={wrapperRef} className="mx-auto" style={{ maxWidth: FIELD_W }}>
@@ -220,7 +224,7 @@ function TargetField({
           }}
         >
           {/* Starfield */}
-          {stars.map((s) => (
+          {!reducedEffects && stars.map((s) => (
             <div
               key={s.id}
               className="absolute rounded-full bg-white"
@@ -235,7 +239,7 @@ function TargetField({
           ))}
 
           {/* Hit effect bursts */}
-          {hitEffects.map((e) => (
+          {!reducedEffects && hitEffects.map((e) => (
             <div
               key={e.id}
               className="absolute pointer-events-none hit-burst rounded-full"
@@ -278,7 +282,7 @@ function TargetField({
 
           {/* Streak fire overlay */}
           {streak >= 3 && (
-            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full bg-gradient-to-r from-orange-500 to-red-500 text-white text-sm font-extrabold streak-fire shadow-lg">
+            <div className={`absolute bottom-2 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full bg-gradient-to-r from-orange-500 to-red-500 text-white text-sm font-extrabold shadow-lg ${reducedEffects ? "" : "streak-fire"}`}>
               🔥 {streak}x STREAK
             </div>
           )}
@@ -357,7 +361,15 @@ function QQHud({
 
 // ── Core Game ──────────────────────────────────────────────────────────────
 
-function QuantumQuestCore({ config, onFinish }: { config: QuantumQuestConfig; onFinish: (result: GameResult) => void }) {
+function QuantumQuestCore({
+  config,
+  onFinish,
+  reducedEffects,
+}: {
+  config: QuantumQuestConfig;
+  onFinish: (result: GameResult) => void;
+  reducedEffects: boolean;
+}) {
   const { t } = useTranslation();
 
   const [sectorIdx, setSectorIdx] = useState(0);
@@ -453,7 +465,9 @@ function QuantumQuestCore({ config, onFinish }: { config: QuantumQuestConfig; on
     const tgt = targets.find((t) => t.id === targetId);
     if (!tgt || tgt.hit || tgt.missed) return;
     setTotalAttempted((a) => a + 1);
-    setHitEffects([{ id: targetId, x: tgt.x, y: tgt.y, correct: tgt.correct }]);
+    if (!reducedEffects) {
+      setHitEffects([{ id: targetId, x: tgt.x, y: tgt.y, correct: tgt.correct }]);
+    }
 
     if (tgt.correct) {
       setTargets((prev) => prev.map((t) => t.id === targetId ? { ...t, hit: true } : { ...t, missed: true }));
@@ -481,7 +495,7 @@ function QuantumQuestCore({ config, onFinish }: { config: QuantumQuestConfig; on
         setFeedback({ text: t("games.quantumQuest.tryAgain"), type: "wrong" });
       }
     }
-  }, [targets, streak, advanceProblem, t, shieldActive]);
+  }, [targets, streak, advanceProblem, t, shieldActive, reducedEffects]);
 
   const usePower = useCallback((p: PowerUp) => {
     if (powerUps[p] <= 0) return;
@@ -587,7 +601,7 @@ function QuantumQuestCore({ config, onFinish }: { config: QuantumQuestConfig; on
       />
       <TargetField
         targets={targets} onHit={handleHit} sectorTheme={sectorTheme}
-        streak={streak} hitEffects={hitEffects} slowActive={slowActive}
+        streak={streak} hitEffects={hitEffects} slowActive={slowActive} reducedEffects={reducedEffects}
       />
       {feedback && (
         <div className={`text-center py-2 rounded-xl font-bold text-sm ${
@@ -627,7 +641,9 @@ export default function QuantumQuestGame({ config, onComplete }: QuantumQuestGam
 
   return (
     <GameShell gameKey="quantum_quest" title={t("games.quantumQuest.title")} briefing={briefing} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <QuantumQuestCore config={gameConfig} onFinish={onFinish} />}
+      {({ onFinish, reducedEffects }) => (
+        <QuantumQuestCore config={gameConfig} onFinish={onFinish} reducedEffects={reducedEffects} />
+      )}
     </GameShell>
   );
 }

--- a/src/components/games/RhymeRideGame.tsx
+++ b/src/components/games/RhymeRideGame.tsx
@@ -11,7 +11,7 @@
  * Touch:    tap the lane
  * Accessibility: reduced-motion mode, non-color cues, large targets
  */
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { GameResult, MissionBriefing } from "./shared/GameShell";
 import { cn } from "@/lib/utils";
@@ -336,12 +336,14 @@ function RhymeHUD({
 // Core game component
 // ═══════════════════════════════════════════════════════════════════════════
 
-function RhymeRideCore({ onFinish }: { onFinish: (result: GameResult) => void }) {
+function RhymeRideCore({
+  onFinish,
+  reducedEffects,
+}: {
+  onFinish: (result: GameResult) => void;
+  reducedEffects: boolean;
+}) {
   const { t } = useTranslation();
-  const prefersReducedMotion = useMemo(
-    () => typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches,
-    [],
-  );
 
   // ── State ──
   const [worldIdx, setWorldIdx] = useState(0);
@@ -863,7 +865,7 @@ function RhymeRideCore({ onFinish }: { onFinish: (result: GameResult) => void })
         cards={cards}
         onLaneTap={handleLaneTap}
         worldTheme={world.theme}
-        reducedMotion={prefersReducedMotion}
+        reducedMotion={reducedEffects}
         combo={combo}
       />
 
@@ -927,7 +929,9 @@ export default function RhymeRideGame({
       briefing={briefing}
       onComplete={onComplete!}
     >
-      {({ onFinish }) => <RhymeRideCore onFinish={onFinish} />}
+      {({ onFinish, reducedEffects }) => (
+        <RhymeRideCore onFinish={onFinish} reducedEffects={reducedEffects} />
+      )}
     </GameShell>
   );
 }

--- a/src/components/games/SkyShieldGame.tsx
+++ b/src/components/games/SkyShieldGame.tsx
@@ -335,7 +335,7 @@ function SkyShieldPlayfield({ onFinish }: { onFinish: (r: GameResult) => void })
 export default function SkyShieldGame({ onComplete }: { config?: unknown; onComplete?: (result: GameResult) => void }) {
   return (
     <GameShell gameKey="sky_shield" title="Sky Shield Patterns" briefing={BRIEFING} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <SkyShieldPlayfield onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <SkyShieldPlayfield onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/TankTrekGame.tsx
+++ b/src/components/games/TankTrekGame.tsx
@@ -645,7 +645,7 @@ export default function TankTrekGame({ config, onComplete }: TankTrekGameProps) 
 
   return (
     <GameShell gameKey="tank_trek" title={t("games.tankTrek.title")} briefing={briefing} onComplete={onComplete ?? (() => {})}>
-      {({ onFinish }) => <TankTrekCore config={gameConfig} onFinish={onFinish} />}
+      {({ onFinish, reducedEffects: _reducedEffects }) => <TankTrekCore config={gameConfig} onFinish={onFinish} />}
     </GameShell>
   );
 }

--- a/src/components/games/__tests__/BounceBuds.test.ts
+++ b/src/components/games/__tests__/BounceBuds.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { shouldRenderBounceSparkles } from "../BounceBudsGame";
 
 /**
  * Bounce & Buds round data validation.
@@ -37,5 +38,10 @@ describe("BounceBuds game data", () => {
     expect(GAME_COMPONENTS.buddy_garden_sort).toBe(
       GAME_COMPONENTS.bounce_buds_unity,
     );
+  });
+
+  it("disables decorative sparkles in reduced-effects mode", () => {
+    expect(shouldRenderBounceSparkles(false)).toBe(true);
+    expect(shouldRenderBounceSparkles(true)).toBe(false);
   });
 });

--- a/src/components/games/__tests__/GameShellReducedEffects.test.tsx
+++ b/src/components/games/__tests__/GameShellReducedEffects.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import GameShell from "../shared/GameShell";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/activities/ActivityHeader", () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/hooks/usePersonalBest", () => ({
+  usePersonalBest: () => null,
+}));
+
+describe("GameShell reduced effects integration", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+  });
+
+  it("renders reduced-effects toggle and applies reduced-effects data attribute", async () => {
+    const user = userEvent.setup();
+    render(
+      <GameShell gameKey="test" title="Test" onComplete={() => {}}>
+        {({ onFinish, reducedEffects }) => (
+          <button type="button" onClick={() => onFinish({
+            gameKey: "test",
+            score: 1,
+            total: 1,
+            streakMax: 1,
+            roundsCompleted: 1,
+          })}>
+            child-{reducedEffects ? "on" : "off"}
+          </button>
+        )}
+      </GameShell>,
+    );
+
+    expect(screen.getByRole("button", { name: /reduced effects: off/i })).toBeInTheDocument();
+    const shell = screen.getByRole("button", { name: "child-off" }).closest("[data-reduced-effects]");
+    expect(shell).toHaveAttribute("data-reduced-effects", "false");
+
+    await user.click(screen.getByRole("button", { name: /reduced effects: off/i }));
+    expect(screen.getByRole("button", { name: "child-on" })).toBeInTheDocument();
+    expect(shell).toHaveAttribute("data-reduced-effects", "true");
+  });
+});

--- a/src/components/games/__tests__/LearningGameFrame.test.tsx
+++ b/src/components/games/__tests__/LearningGameFrame.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { LearningGameFrame } from "../shared/LearningGameFrame";
 
@@ -7,6 +8,27 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("LearningGameFrame", () => {
+  it("shows a reduced-effects toggle with accessible description", async () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    const user = userEvent.setup();
+
+    render(
+      <LearningGameFrame title="Game" objective="Obj">
+        <div>Body</div>
+      </LearningGameFrame>,
+    );
+
+    const toggle = screen.getByRole("button", { name: /reduced effects: off/i });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText(/reduces motion, particles, and visual intensity for smoother play/i)).toBeInTheDocument();
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("announces progress and feedback with polite status regions", () => {
     render(
       <LearningGameFrame

--- a/src/components/games/__tests__/QuantumQuest.test.ts
+++ b/src/components/games/__tests__/QuantumQuest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildQuantumQuestCompletionPayload } from "../QuantumQuestGame";
+import { buildQuantumQuestCompletionPayload, getQuantumQuestStarCount } from "../QuantumQuestGame";
 
 describe("Quantum Quest completion", () => {
   it("builds final payload with accuracy and achievements", () => {
@@ -29,5 +29,10 @@ describe("Quantum Quest completion", () => {
     });
     expect(payload.achievements).toContain("games.quantumQuest.achPerfect");
     expect(payload.achievements).toContain("games.quantumQuest.achExplorer");
+  });
+
+  it("reduces decorative starfield count when reduced effects is enabled", () => {
+    expect(getQuantumQuestStarCount(false)).toBe(40);
+    expect(getQuantumQuestStarCount(true)).toBe(12);
   });
 });

--- a/src/components/games/__tests__/useReducedGameEffects.test.tsx
+++ b/src/components/games/__tests__/useReducedGameEffects.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useReducedGameEffects, REDUCED_EFFECTS_STORAGE_KEY } from "../shared/useReducedGameEffects";
+
+function HookHarness() {
+  const { reducedEffects, source, setReducedEffects, clearReducedEffectsPreference } = useReducedGameEffects();
+  return (
+    <div>
+      <div data-testid="state">{reducedEffects ? "on" : "off"}:{source}</div>
+      <button type="button" onClick={() => setReducedEffects(true)}>set-on</button>
+      <button type="button" onClick={() => setReducedEffects(false)}>set-off</button>
+      <button type="button" onClick={clearReducedEffectsPreference}>clear</button>
+    </div>
+  );
+}
+
+describe("useReducedGameEffects", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to system reduced-motion when no manual preference is stored", () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    render(<HookHarness />);
+    expect(screen.getByTestId("state")).toHaveTextContent("on:system");
+  });
+
+  it("supports manual override and persistence", async () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    const user = userEvent.setup();
+
+    render(<HookHarness />);
+    await user.click(screen.getByRole("button", { name: "set-off" }));
+
+    expect(screen.getByTestId("state")).toHaveTextContent("off:manual");
+    expect(window.localStorage.getItem(REDUCED_EFFECTS_STORAGE_KEY)).toBe("false");
+  });
+
+  it("clears manual override back to system/default source", async () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    const user = userEvent.setup();
+
+    render(<HookHarness />);
+    await user.click(screen.getByRole("button", { name: "set-on" }));
+    expect(screen.getByTestId("state")).toHaveTextContent("on:manual");
+
+    await user.click(screen.getByRole("button", { name: "clear" }));
+    expect(screen.getByTestId("state")).toHaveTextContent("off:default");
+    expect(window.localStorage.getItem(REDUCED_EFFECTS_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy } from "lucide-react";
 import ActivityHeader from "@/components/activities/ActivityHeader";
 import { usePersonalBest } from "@/hooks/usePersonalBest";
+import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
+import { useReducedGameEffects } from "./useReducedGameEffects";
 import "./game-effects.css";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -43,7 +45,7 @@ interface GameShellProps {
   gameKey: string;
   title: string;
   briefing?: MissionBriefing;
-  children: (props: { onFinish: (result: GameResult) => void }) => React.ReactNode;
+  children: (props: { onFinish: (result: GameResult) => void; reducedEffects: boolean }) => React.ReactNode;
   onComplete: (result: GameResult) => void;
   starThresholds?: [number, number, number];
 }
@@ -269,6 +271,7 @@ export default function GameShell({
     briefing ? "briefing" : "playing",
   );
   const [result, setResult] = useState<GameResult | null>(null);
+  const { reducedEffects, source, setReducedEffects } = useReducedGameEffects();
 
   const handleFinish = useCallback(
     (gameResult: GameResult) => {
@@ -285,8 +288,16 @@ export default function GameShell({
   if (phase === "briefing" && briefing) {
     const tc = briefing.themeColor ?? "indigo";
     return (
-      <div className="max-w-2xl mx-auto space-y-4">
+      <div
+        className="max-w-2xl mx-auto space-y-4"
+        data-reduced-effects={reducedEffects ? "true" : "false"}
+      >
         <ActivityHeader title={title} visualKey="game" />
+        <ReducedEffectsToggle
+          reducedEffects={reducedEffects}
+          source={source}
+          onToggle={setReducedEffects}
+        />
         <div className="slide-up-fade relative overflow-hidden rounded-2xl shadow-xl border border-white/20">
           {/* Gradient background */}
           <div className={`absolute inset-0 bg-gradient-to-br from-${tc}-500/10 via-${tc}-400/5 to-purple-500/10`} />
@@ -344,22 +355,40 @@ export default function GameShell({
 
   if (phase === "results" && result) {
     return (
-      <GameResultsView
-        result={result}
-        title={title}
-        personalBest={personalBest}
-        onPlayAgain={() => { setResult(null); setPhase(briefing ? "briefing" : "playing"); }}
-        onComplete={() => onComplete(result)}
-      />
+      <div
+        className="max-w-2xl mx-auto space-y-4"
+        data-reduced-effects={reducedEffects ? "true" : "false"}
+      >
+        <ReducedEffectsToggle
+          reducedEffects={reducedEffects}
+          source={source}
+          onToggle={setReducedEffects}
+        />
+        <GameResultsView
+          result={result}
+          title={title}
+          personalBest={personalBest}
+          onPlayAgain={() => { setResult(null); setPhase(briefing ? "briefing" : "playing"); }}
+          onComplete={() => onComplete(result)}
+        />
+      </div>
     );
   }
 
   // ── Game Phase ───────────────────────────────────────────────────────
 
   return (
-    <div className="max-w-4xl mx-auto space-y-4">
+    <div
+      className="max-w-4xl mx-auto space-y-4"
+      data-reduced-effects={reducedEffects ? "true" : "false"}
+    >
       <ActivityHeader title={title} visualKey="game" />
-      {children({ onFinish: handleFinish })}
+      <ReducedEffectsToggle
+        reducedEffects={reducedEffects}
+        source={source}
+        onToggle={setReducedEffects}
+      />
+      {children({ onFinish: handleFinish, reducedEffects })}
     </div>
   );
 }

--- a/src/components/games/shared/LearningGameFrame.tsx
+++ b/src/components/games/shared/LearningGameFrame.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
+import { useReducedGameEffects } from "./useReducedGameEffects";
 
 type LearningGameFrameProps = {
   title: string;
@@ -20,12 +22,21 @@ export function LearningGameFrame({
 }: LearningGameFrameProps) {
   const { t } = useTranslation();
   const titleId = `${title.replace(/[^\w\s-]/g, "").replace(/\s+/g, "-").toLowerCase()}-title`;
+  const { reducedEffects, source, setReducedEffects } = useReducedGameEffects();
 
   return (
     <section
       className="mx-auto max-w-5xl rounded-2xl border bg-white p-4 shadow-sm"
       aria-labelledby={titleId}
+      data-reduced-effects={reducedEffects ? "true" : "false"}
     >
+      <div className="mb-2">
+        <ReducedEffectsToggle
+          reducedEffects={reducedEffects}
+          source={source}
+          onToggle={setReducedEffects}
+        />
+      </div>
       <div className="mb-4 rounded-xl border bg-slate-50 p-4">
         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
           <div>

--- a/src/components/games/shared/ReducedEffectsToggle.tsx
+++ b/src/components/games/shared/ReducedEffectsToggle.tsx
@@ -1,0 +1,39 @@
+import { useId } from "react";
+import { Button } from "@/components/ui/button";
+import { ReducedEffectsSource } from "./useReducedGameEffects";
+
+type ReducedEffectsToggleProps = {
+  reducedEffects: boolean;
+  source: ReducedEffectsSource;
+  onToggle: (nextValue: boolean) => void;
+};
+
+export function ReducedEffectsToggle({
+  reducedEffects,
+  source,
+  onToggle,
+}: ReducedEffectsToggleProps) {
+  const descriptionId = useId();
+  const sourceLabel = source === "manual" ? "Manual" : source === "system" ? "System" : "Default";
+
+  return (
+    <div className="flex justify-end">
+      <div className="inline-flex flex-col items-end gap-1 rounded-xl border border-slate-200 bg-white/80 px-2 py-1 shadow-sm">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 px-3 text-xs font-semibold"
+          aria-pressed={reducedEffects}
+          aria-describedby={descriptionId}
+          onClick={() => onToggle(!reducedEffects)}
+        >
+          Reduced effects: {reducedEffects ? "On" : "Off"}
+        </Button>
+        <p id={descriptionId} className="text-[11px] text-slate-500">
+          Reduces motion, particles, and visual intensity for smoother play. Source: {sourceLabel}.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/shared/game-effects.css
+++ b/src/components/games/shared/game-effects.css
@@ -86,6 +86,24 @@
 }
 .cmd-active { animation: cmd-active 0.35s ease-out; }
 
+/* ── Shared reduced-effects wrapper override ───────────────────────────── */
+[data-reduced-effects="true"] .star-pop,
+[data-reduced-effects="true"] .pulse-glow,
+[data-reduced-effects="true"] .hit-burst,
+[data-reduced-effects="true"] .shake,
+[data-reduced-effects="true"] .bounce-in,
+[data-reduced-effects="true"] .slide-up-fade,
+[data-reduced-effects="true"] .float-idle,
+[data-reduced-effects="true"] .count-flash,
+[data-reduced-effects="true"] .streak-fire,
+[data-reduced-effects="true"] .cmd-active {
+  animation: none !important;
+}
+
+[data-reduced-effects="true"] * {
+  transition-duration: 0.01ms !important;
+}
+
 /* ── Reduced motion ───────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .star-pop, .pulse-glow, .hit-burst, .shake, .bounce-in,

--- a/src/components/games/shared/useReducedGameEffects.ts
+++ b/src/components/games/shared/useReducedGameEffects.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export type ReducedEffectsSource = "system" | "manual" | "default";
+
+const STORAGE_KEY = "brightboost.reducedGameEffects";
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function readStoredPreference(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+  } catch {
+    // Ignore localStorage unavailability and use runtime fallback.
+  }
+  return null;
+}
+
+function readSystemPreference(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(QUERY).matches;
+}
+
+export function useReducedGameEffects() {
+  const initialStored = useMemo(readStoredPreference, []);
+  const [manualPreference, setManualPreference] = useState<boolean | null>(initialStored);
+  const [systemPreference, setSystemPreference] = useState<boolean>(readSystemPreference);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia(QUERY);
+    const onChange = (event: MediaQueryListEvent) => {
+      setSystemPreference(event.matches);
+    };
+    setSystemPreference(media.matches);
+    if (typeof media.addEventListener === "function") {
+      media.addEventListener("change", onChange);
+      return () => media.removeEventListener("change", onChange);
+    }
+    media.addListener(onChange);
+    return () => media.removeListener(onChange);
+  }, []);
+
+  const setReducedEffects = useCallback((value: boolean) => {
+    setManualPreference(value);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(value));
+    } catch {
+      // Ignore persistence failure but still update current session state.
+    }
+  }, []);
+
+  const clearReducedEffectsPreference = useCallback(() => {
+    setManualPreference(null);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore persistence failure.
+    }
+  }, []);
+
+  const reducedEffects = manualPreference ?? systemPreference;
+  const source: ReducedEffectsSource = manualPreference !== null
+    ? "manual"
+    : systemPreference
+      ? "system"
+      : "default";
+
+  return {
+    reducedEffects,
+    source,
+    setReducedEffects,
+    clearReducedEffectsPreference,
+  };
+}
+
+export { STORAGE_KEY as REDUCED_EFFECTS_STORAGE_KEY };


### PR DESCRIPTION
### Motivation
- Provide a shared low-performance / reduced-effects mode so arcade-heavy games run more reliably on Chromebooks, older tablets, and low-power phones while respecting accessibility `prefers-reduced-motion`.
- Expose a manual in-game toggle with local persistence so learners and teachers can override system defaults without changing gameplay, scoring, or curriculum artifacts.
- Apply the mode to priority RAF-heavy games first while keeping changes minimal and non-invasive to game logic.

### Description
- Added a reusable hook `useReducedGameEffects` that reads `window.matchMedia("(prefers-reduced-motion: reduce)")`, exposes `reducedEffects` and `source: "system" | "manual" | "default"`, supports `setReducedEffects()` and `clearReducedEffectsPreference()`, and safely falls back in SSR/test environments; persisted key is `brightboost.reducedGameEffects`. (`src/components/games/shared/useReducedGameEffects.ts`)
- Added an accessible UI component `ReducedEffectsToggle` and wired it into shared wrappers so users can toggle the mode in-game; the toggle has a clear label and helper description. (`src/components/games/shared/ReducedEffectsToggle.tsx`)
- Integrated the mode into shared wrappers: `GameShell` and `LearningGameFrame` now render the toggle, pass `reducedEffects` into game children, and expose `data-reduced-effects="true|false"` on the wrapper so games can inherit reductions via CSS. (`src/components/games/shared/GameShell.tsx`, `src/components/games/shared/LearningGameFrame.tsx`)
- Extended shared CSS in `game-effects.css` to suppress/de-intensify decorative animations and shorten transitions when `data-reduced-effects="true"` is present while retaining `@media (prefers-reduced-motion: reduce)` support.
- Applied minimal, safe per-game reductions for priority games only: Bounce & Buds (disable sparkles/streak), Quantum Quest (reduce starfield and hit-burst), Qualify/Tune/Race (suppress wobble/shake), and Rhyme & Ride (consume shared state instead of a local media-query). Other games were updated lightly to accept the render-prop shape so they inherit wrapper-level behavior without behavior/scoring changes. (See modified files under `src/components/games/*`.)

### Testing
- Unit tests added/updated and run via Vitest: `src/components/games/__tests__/useReducedGameEffects.test.tsx`, `src/components/games/__tests__/GameShellReducedEffects.test.tsx`, `src/components/games/__tests__/LearningGameFrame.test.tsx`, plus small deterministic checks in `BounceBuds.test.ts` and `QuantumQuest.test.ts` were executed and passed. (All targeted test runs reported green.)
- Ran the whole game test suite under `src/components/games/__tests__` and observed all tests pass (17 files, 55 tests in the run reported passing).
- Type-check: `npm run typecheck` (`tsc --noEmit`) completed successfully.
- Notes: tests mock `matchMedia` and localStorage where needed; the hook and toggle safely handle environments without `window` or storage access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef8362f56483259e673ef9bc485932)