### PR TITLE
Add shared keyboard instruction banners and focus management for games

### DIFF
--- a/docs/game-audit.md
+++ b/docs/game-audit.md
@@ -152,3 +152,27 @@ A shared reduced-effects system is now implemented for React game wrappers.
 ### Light-touch inheritance checks
 
 Games already using shared wrappers (including Fast Lane, Sky Shield, Maze Maps, and Data Dash) inherit wrapper-level reduced-effects behavior via shared CSS without learning/scoring changes.
+
+## 7) Keyboard instructions + focus management rollout (April 27, 2026)
+
+Shared game wrappers now include a reusable keyboard/control banner and safer, predictable focus flow.
+
+- Added a shared `ControlInstructions` component and control-instruction model used across wrappers and priority games.
+- `GameShell` now supports control instructions in mission briefings and game view, with default fallback instructions when a game does not provide custom guidance.
+- `LearningGameFrame` now supports control instructions and links the game area to the instruction region for assistive technology context.
+- Focus behavior now follows a stable intro → game → results path:
+  - Intro/briefing focuses the primary Start action.
+  - Game start focuses the labeled game area region.
+  - Results focus the results heading without stealing focus during normal in-round feedback.
+- Initial priority game guidance covered in this rollout:
+  - Boost Path Planner
+  - Tank Trek
+  - Maze Maps
+  - Qualify, Tune, Race
+  - Rhyme & Ride
+  - Data Dash
+
+### Remaining future work
+
+- Add deeper game-by-game keyboard-path tests for complex in-round control surfaces.
+- Add axe-based integration checks for live game views and command-heavy mobile layouts.

--- a/src/components/games/BoostPathPlannerGame.tsx
+++ b/src/components/games/BoostPathPlannerGame.tsx
@@ -186,6 +186,12 @@ export default function BoostPathPlannerGame({
       ]}
       progressLabel={`${t("games.boostPath.levelLabel")} ${levelIndex + 1}/${activeLevels.length}`}
       feedback={t(feedbackKey)}
+      controlInstructions={{
+        keyboard: [
+          "Use Tab to move through cards and buttons. Use Enter or Space to choose.",
+        ],
+        buttons: ["Put steps in the correct order."],
+      }}
     >
       <div className="grid gap-6 md:grid-cols-[1fr_280px]">
         <div

--- a/src/components/games/DataDashSortDiscoverGame.tsx
+++ b/src/components/games/DataDashSortDiscoverGame.tsx
@@ -80,6 +80,10 @@ const BRIEFING: MissionBriefing = {
   tips: ["Use one attribute per sort rule", "Look for what all cards in a group share", "Use chart counts as evidence"],
   chapterLabel: "Life Science Data",
   themeColor: "emerald",
+  controlInstructions: {
+    keyboard: ["Use Tab to select a card, then choose a bin or answer with Enter or Space."],
+    buttons: ["Select a card, then choose a bin or answer.", "Use attributes as evidence."],
+  },
 };
 
 function DataDashPlayfield({ onFinish }: { onFinish: (result: GameResult) => void }) {

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -119,6 +119,10 @@ const BRIEFING: MissionBriefing = {
   ],
   chapterLabel: "AI Lab",
   themeColor: "cyan",
+  controlInstructions: {
+    keyboard: ["Use Tab to move to action buttons and Enter or Space to choose."],
+    buttons: ["Choose a move or wait action.", "Watch the pattern before moving."],
+  },
 };
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -69,6 +69,10 @@ const BRIEFING: MissionBriefing = {
   tips: ["Drive carefully on the first run", "Pick ONE upgrade to test", "Compare your two runs!"],
   chapterLabel: "Race Lab",
   themeColor: "amber",
+  controlInstructions: {
+    keyboard: ["Use Tab to reach lane controls, then use Enter or Space to steer."],
+    buttons: ["Use lane controls or available buttons to steer.", "Test one change at a time."],
+  },
 };
 
 // ── Metric card (reused in results1) ──────────────────────────────────────

--- a/src/components/games/RhymeRideGame.tsx
+++ b/src/components/games/RhymeRideGame.tsx
@@ -920,6 +920,10 @@ export default function RhymeRideGame({
       t("games.rhymeRide.tipCombos"),
       t("games.rhymeRide.tipShowdown"),
     ],
+    controlInstructions: {
+      keyboard: ["Use Tab to reach lane controls and Enter or Space to choose."],
+      buttons: ["Choose the word that rhymes with the target.", "Say the ending sounds out loud."],
+    },
   };
 
   return (

--- a/src/components/games/TankTrekGame.tsx
+++ b/src/components/games/TankTrekGame.tsx
@@ -641,6 +641,11 @@ export default function TankTrekGame({ config, onComplete }: TankTrekGameProps) 
       vi: ["Lên kế hoạch trước khi chạy", "Ít bước hơn = nhiều sao hơn", "Thu thập chip dữ liệu!"],
       "zh-CN": ["跑之前先计划", "步数越少 = 星星越多", "收集数据芯片！"],
     }, ["Plan before you run", "Fewer moves = more stars", "Collect the data chips!"]),
+ 
+    controlInstructions: {
+      keyboard: ["Use Tab to move through controls. Use Enter or Space to add commands."],
+      buttons: ["Choose Forward, Turn Left, or Turn Right to build a path.", "Use fewer moves when possible."],
+    },
   };
 
   return (

--- a/src/components/games/__tests__/ControlInstructions.test.tsx
+++ b/src/components/games/__tests__/ControlInstructions.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ControlInstructions } from "../shared/ControlInstructions";
+
+describe("ControlInstructions", () => {
+  it("renders heading and keyboard/touch/button lists", () => {
+    render(
+      <ControlInstructions
+        id="controls"
+        instructions={{
+          keyboard: ["Use Tab to move."],
+          touch: ["Tap cards to choose."],
+          buttons: ["Press Start to begin."],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "How to play" })).toBeInTheDocument();
+    expect(screen.getByText("Use Tab to move.")).toBeInTheDocument();
+    expect(screen.getByText("Tap cards to choose.")).toBeInTheDocument();
+    expect(screen.getByText("Press Start to begin.")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "How to play" })).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/src/components/games/__tests__/GameInstructionCoverage.test.tsx
+++ b/src/components/games/__tests__/GameInstructionCoverage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import MazeMapsGame from "../MazeMapsGame";
+import DataDashSortDiscoverGame from "../DataDashSortDiscoverGame";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key }),
+}));
+
+vi.mock("@/components/activities/ActivityHeader", () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/hooks/usePersonalBest", () => ({
+  usePersonalBest: () => null,
+}));
+
+describe("Priority game control instructions", () => {
+  it("shows Maze Maps keyboard/button guidance in briefing", () => {
+    render(<MazeMapsGame onComplete={() => {}} />);
+
+    expect(screen.getByText(/choose a move or wait action/i)).toBeInTheDocument();
+    expect(screen.getByText(/watch the pattern before moving/i)).toBeInTheDocument();
+  });
+
+  it("shows Data Dash keyboard/button guidance in briefing", () => {
+    render(<DataDashSortDiscoverGame onComplete={() => {}} />);
+
+    expect(screen.getByText("Select a card, then choose a bin or answer.")).toBeInTheDocument();
+    expect(screen.getByText(/use attributes as evidence/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/games/__tests__/GameShellAccessibility.test.tsx
+++ b/src/components/games/__tests__/GameShellAccessibility.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GameShell from "../shared/GameShell";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/activities/ActivityHeader", () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/hooks/usePersonalBest", () => ({
+  usePersonalBest: () => null,
+}));
+
+describe("GameShell accessibility", () => {
+  beforeEach(() => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+  });
+
+  it("renders control instructions on briefing and focuses start/results headings", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <GameShell
+        gameKey="access-test"
+        title="Access Test"
+        onComplete={() => {}}
+        briefing={{
+          title: "Mission",
+          story: "Story",
+          icon: "🎮",
+          controlInstructions: {
+            keyboard: ["Use Tab and Enter."],
+            buttons: ["Choose an action."],
+          },
+        }}
+      >
+        {({ onFinish }) => (
+          <button
+            type="button"
+            onClick={() => onFinish({ gameKey: "access-test", score: 1, total: 1, streakMax: 1, roundsCompleted: 1 })}
+          >
+            finish
+          </button>
+        )}
+      </GameShell>,
+    );
+
+    const startButton = screen.getByRole("button", { name: /games\.shared\.startMission/i });
+    expect(startButton).toHaveFocus();
+    expect(screen.getByText("Use Tab and Enter.")).toBeInTheDocument();
+
+    await user.click(startButton);
+    expect(screen.getByRole("region", { name: /access test game area/i })).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: "finish" }));
+    expect(screen.getByRole("heading", { name: /games\.shared\.amazing/i })).toHaveFocus();
+  });
+});

--- a/src/components/games/__tests__/LearningGameFrame.test.tsx
+++ b/src/components/games/__tests__/LearningGameFrame.test.tsx
@@ -45,7 +45,7 @@ describe("LearningGameFrame", () => {
     expect(statuses).toHaveLength(2);
     expect(statuses[0]).toHaveAttribute("aria-live", "polite");
     expect(statuses[1]).toHaveAttribute("aria-live", "polite");
-    expect(screen.getByRole("region", { name: /rhymo's rhyme rocket/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /rhymo's rhyme rocket game area/i })).toBeInTheDocument();
   });
 
   it("renders words to know when vocabulary is provided", () => {
@@ -57,5 +57,24 @@ describe("LearningGameFrame", () => {
 
     expect(screen.getByText(/games\.learning\.wordsToKnow/i)).toBeInTheDocument();
     expect(screen.getByText(/rhyme, pattern/i)).toBeInTheDocument();
+  });
+
+  it("renders control instructions and links game area to instructions", () => {
+    render(
+      <LearningGameFrame
+        title="Game"
+        objective="Obj"
+        controlInstructions={{
+          keyboard: ["Use Tab to move through controls."],
+          buttons: ["Choose an answer button."],
+        }}
+      >
+        <div>Body</div>
+      </LearningGameFrame>,
+    );
+
+    expect(screen.getByRole("heading", { name: /how to play/i })).toBeInTheDocument();
+    expect(screen.getByText(/use tab to move through controls/i)).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /game game area/i })).toHaveAttribute("aria-describedby", "game-title-instructions");
   });
 });

--- a/src/components/games/shared/ControlInstructions.tsx
+++ b/src/components/games/shared/ControlInstructions.tsx
@@ -1,0 +1,59 @@
+import { type ControlInstructionsModel } from "./controlInstructions";
+
+type ControlInstructionsProps = {
+  id?: string;
+  headingId?: string;
+  instructions: ControlInstructionsModel;
+  className?: string;
+};
+
+function InstructionGroup({
+  label,
+  items,
+}: {
+  label: string;
+  items?: string[];
+}) {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h4 className="text-sm font-semibold text-slate-800">{label}</h4>
+      <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-700">
+        {items.map((item, index) => (
+          <li key={`${label}-${index}`}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function ControlInstructions({
+  id,
+  headingId,
+  instructions,
+  className,
+}: ControlInstructionsProps) {
+  const resolvedHeadingId = headingId ?? `${id ?? "game"}-instructions-heading`;
+
+  return (
+    <section
+      id={id}
+      aria-labelledby={resolvedHeadingId}
+      tabIndex={0}
+      className={`rounded-xl border bg-blue-50/60 p-4 ${className ?? ""}`.trim()}
+    >
+      <h3 id={resolvedHeadingId} className="text-base font-bold text-slate-900">
+        How to play
+      </h3>
+      <div className="mt-3 space-y-3">
+        <InstructionGroup label="Keyboard" items={instructions.keyboard} />
+        <InstructionGroup label="Touch" items={instructions.touch} />
+        <InstructionGroup label="Buttons" items={instructions.buttons} />
+        <InstructionGroup label="Screen reader" items={instructions.screenReader} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -5,7 +5,7 @@
  * results screen with staggered star reveal, achievement toasts, and
  * score count-up.
  */
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy } from "lucide-react";
@@ -13,6 +13,8 @@ import ActivityHeader from "@/components/activities/ActivityHeader";
 import { usePersonalBest } from "@/hooks/usePersonalBest";
 import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
 import { useReducedGameEffects } from "./useReducedGameEffects";
+import { ControlInstructions } from "./ControlInstructions";
+import { mergeControlInstructions, type ControlInstructionsModel } from "./controlInstructions";
 import "./game-effects.css";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -37,6 +39,7 @@ export interface MissionBriefing {
   story: string;
   icon: string;
   tips?: string[];
+  controlInstructions?: ControlInstructionsModel;
   chapterLabel?: string;
   themeColor?: string; // tailwind color stem e.g. "indigo", "violet", "cyan"
 }
@@ -122,12 +125,14 @@ function GameResultsView({
   personalBest,
   onPlayAgain,
   onComplete,
+  headingRef,
 }: {
   result: GameResult;
   title: string;
   personalBest: ReturnType<typeof usePersonalBest>;
   onPlayAgain: () => void;
   onComplete: () => void;
+  headingRef: RefObject<HTMLHeadingElement>;
 }) {
   const { t } = useTranslation();
   const pct = result.accuracy ?? 0;
@@ -174,7 +179,12 @@ function GameResultsView({
               {stars >= 3 ? "🏆" : stars >= 2 ? "🌟" : stars >= 1 ? "⭐" : "💪"}
             </div>
           </div>
-          <h2 className="text-2xl font-extrabold text-amber-900 bounce-in" style={{ animationDelay: "200ms" }}>
+          <h2
+            ref={headingRef}
+            tabIndex={-1}
+            className="text-2xl font-extrabold text-amber-900 bounce-in focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            style={{ animationDelay: "200ms" }}
+          >
             {stars >= 3 ? t("games.shared.amazing") : stars >= 2 ? t("games.shared.greatJob") : stars >= 1 ? t("games.shared.goodWork") : t("games.shared.keepTrying")}
           </h2>
 
@@ -272,6 +282,11 @@ export default function GameShell({
   );
   const [result, setResult] = useState<GameResult | null>(null);
   const { reducedEffects, source, setReducedEffects } = useReducedGameEffects();
+  const startButtonRef = useRef<HTMLButtonElement | null>(null);
+  const gameRegionRef = useRef<HTMLDivElement | null>(null);
+  const resultsHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const instructionsId = `${gameKey}-control-instructions`;
+  const activeInstructions = mergeControlInstructions(briefing?.controlInstructions);
 
   const handleFinish = useCallback(
     (gameResult: GameResult) => {
@@ -282,6 +297,22 @@ export default function GameShell({
     },
     [starThresholds],
   );
+
+  useEffect(() => {
+    if (phase === "briefing") {
+      startButtonRef.current?.focus();
+      return;
+    }
+
+    if (phase === "playing") {
+      gameRegionRef.current?.focus();
+      return;
+    }
+
+    if (phase === "results") {
+      resultsHeadingRef.current?.focus();
+    }
+  }, [phase]);
 
   // ── Briefing ─────────────────────────────────────────────────────────
 
@@ -332,6 +363,7 @@ export default function GameShell({
                 </ul>
               </div>
             )}
+            <ControlInstructions id={instructionsId} instructions={activeInstructions} className="max-w-xl mx-auto text-left" />
             {personalBest && personalBest.bestScore > 0 && (
               <div className="inline-flex items-center gap-2 px-4 py-2 bg-white/60 backdrop-blur-sm rounded-full border border-white/50 shadow-sm text-sm">
                 <Trophy className="w-4 h-4 text-yellow-500" />
@@ -339,6 +371,7 @@ export default function GameShell({
               </div>
             )}
             <Button
+              ref={startButtonRef}
               size="lg"
               className={`bg-gradient-to-r from-${tc}-500 to-${tc}-600 hover:from-${tc}-600 hover:to-${tc}-700 text-lg px-10 py-6 rounded-2xl shadow-lg shadow-${tc}-500/25 transition-all hover:scale-105 active:scale-95`}
               onClick={() => setPhase("playing")}
@@ -368,6 +401,7 @@ export default function GameShell({
           result={result}
           title={title}
           personalBest={personalBest}
+          headingRef={resultsHeadingRef}
           onPlayAgain={() => { setResult(null); setPhase(briefing ? "briefing" : "playing"); }}
           onComplete={() => onComplete(result)}
         />
@@ -388,7 +422,18 @@ export default function GameShell({
         source={source}
         onToggle={setReducedEffects}
       />
-      {children({ onFinish: handleFinish, reducedEffects })}
+      <div
+        ref={gameRegionRef}
+        role="region"
+        aria-label={`${title} game area`}
+        aria-describedby={instructionsId}
+        tabIndex={-1}
+      >
+        <div className="mb-4">
+          <ControlInstructions id={instructionsId} instructions={activeInstructions} />
+        </div>
+        {children({ onFinish: handleFinish, reducedEffects })}
+      </div>
     </div>
   );
 }

--- a/src/components/games/shared/LearningGameFrame.tsx
+++ b/src/components/games/shared/LearningGameFrame.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
 import { useReducedGameEffects } from "./useReducedGameEffects";
+import { ControlInstructions } from "./ControlInstructions";
+import { mergeControlInstructions, type ControlInstructionsModel } from "./controlInstructions";
 
 type LearningGameFrameProps = {
   title: string;
@@ -9,6 +11,7 @@ type LearningGameFrameProps = {
   vocabulary?: string[];
   progressLabel?: string;
   feedback?: string;
+  controlInstructions?: ControlInstructionsModel;
   children: React.ReactNode;
 };
 
@@ -18,10 +21,13 @@ export function LearningGameFrame({
   vocabulary = [],
   progressLabel,
   feedback,
+  controlInstructions,
   children,
 }: LearningGameFrameProps) {
   const { t } = useTranslation();
   const titleId = `${title.replace(/[^\w\s-]/g, "").replace(/\s+/g, "-").toLowerCase()}-title`;
+  const instructionRegionId = `${titleId}-instructions`;
+  const resolvedInstructions = mergeControlInstructions(controlInstructions);
   const { reducedEffects, source, setReducedEffects } = useReducedGameEffects();
 
   return (
@@ -61,7 +67,17 @@ export function LearningGameFrame({
         </div>
       </div>
 
-      <div>{children}</div>
+      <div className="space-y-4">
+        <ControlInstructions id={instructionRegionId} instructions={resolvedInstructions} />
+        <div
+          role="region"
+          aria-label={`${title} game area`}
+          aria-describedby={instructionRegionId}
+          tabIndex={-1}
+        >
+          {children}
+        </div>
+      </div>
 
       {feedback ? (
         <div

--- a/src/components/games/shared/controlInstructions.ts
+++ b/src/components/games/shared/controlInstructions.ts
@@ -1,0 +1,38 @@
+export type ControlInstructionsModel = {
+  keyboard?: string[];
+  touch?: string[];
+  buttons?: string[];
+  screenReader?: string[];
+};
+
+export const DEFAULT_CONTROL_INSTRUCTIONS: ControlInstructionsModel = {
+  keyboard: [
+    "Use Tab to move between controls and Enter or Space to choose.",
+  ],
+  touch: ["Tap buttons or cards to make your choice."],
+  buttons: ["Follow the on-screen prompts to play each step."],
+};
+
+export function mergeControlInstructions(
+  instructions?: ControlInstructionsModel,
+): ControlInstructionsModel {
+  if (!instructions) {
+    return DEFAULT_CONTROL_INSTRUCTIONS;
+  }
+
+  return {
+    keyboard:
+      instructions.keyboard && instructions.keyboard.length > 0
+        ? instructions.keyboard
+        : DEFAULT_CONTROL_INSTRUCTIONS.keyboard,
+    touch:
+      instructions.touch && instructions.touch.length > 0
+        ? instructions.touch
+        : DEFAULT_CONTROL_INSTRUCTIONS.touch,
+    buttons:
+      instructions.buttons && instructions.buttons.length > 0
+        ? instructions.buttons
+        : DEFAULT_CONTROL_INSTRUCTIONS.buttons,
+    screenReader: instructions.screenReader,
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide consistent, reusable keyboard/touch/button guidance across registry-backed games to improve keyboard and screen-reader accessibility.
- Make intro → playing → results focus behavior predictable so assistive tech users and classrooms have a stable experience without changing gameplay logic.
- Prefer a shared wrapper approach to avoid per-game duplication while covering a priority set of games with concise instructions.

### Description

- Introduced a control-instructions model and defaults in `src/components/games/shared/controlInstructions.ts` (`ControlInstructionsModel`, `mergeControlInstructions`).
- Added a reusable `ControlInstructions` component in `src/components/games/shared/ControlInstructions.tsx` that renders an accessible “How to play” region with semantic lists and is keyboard reachable (`tabIndex=0`).
- Integrated instructions and minimal focus management into `GameShell` (`src/components/games/shared/GameShell.tsx`) to render instructions in briefings and game view, label/describe the game region (`aria-label`/`aria-describedby`), and move focus to the Start button → game region → results heading at the appropriate phase without trapping focus.
- Extended `LearningGameFrame` (`src/components/games/shared/LearningGameFrame.tsx`) to accept optional `controlInstructions`, render the shared instructions, and link the game area via `aria-describedby` for screen-reader context.
- Added concise control-instruction payloads for priority games (Boost Path Planner, Tank Trek, Maze Maps, Qualify/Tune/Race, Rhyme & Ride, Data Dash) with keyboard/buttons guidance while leaving gameplay/scoring untouched.
- Added unit tests covering the `ControlInstructions` component, `LearningGameFrame` and `GameShell` instruction rendering and focus behavior, and a small coverage test for priority game briefings; and documented the rollout in `docs/game-audit.md`.

### Testing

- Ran targeted tests: `npm test -- --run src/components/games/__tests__/ControlInstructions.test.tsx src/components/games/__tests__/LearningGameFrame.test.tsx src/components/games/__tests__/GameShellAccessibility.test.tsx src/components/games/__tests__/GameInstructionCoverage.test.tsx` and all passed.
- Ran full game test subset: `npm test -- --run src/components/games/__tests__` and observed all tests in that suite passing (20 files / 60 tests passed).
- Type-check completed successfully with `npm run typecheck` and no TS errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef995c557c8325a4368a5d1f0c0423)