### PR TITLE
Revert homepage hero and CTA redesign

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,20 +22,13 @@ const Index: React.FC = () => {
           {/* Hero */}
           <div className="text-center mb-8">
             <h1 className="text-5xl md:text-7xl font-extrabold text-brightboost-navy mb-3 drop-shadow-sm tracking-tight">
-              {t("landing.mainHeadline", {
-                defaultValue: "Free STEM Learning for Students, Teachers, Families, and Organizations",
-              })}
+              {t("landing.title")}
             </h1>
             <p className="text-xl md:text-2xl text-brightboost-navy font-semibold">
-              {t("landing.mainSubheadline", {
-                defaultValue:
-                  "Bright Boost helps learners build confidence through gamified STEM lessons, adaptive challenges, and future-ready skills.",
-              })}
+              {t("landing.subtitle")}
             </p>
             <p className="text-base md:text-lg text-brightboost-navy/70 mt-1 max-w-lg mx-auto">
-              {t("landing.mainSupportLine", {
-                defaultValue: "Join our first 1,000 users and help shape the future of Bright Boost.",
-              })}
+              {t("landing.tagline")}
             </p>
           </div>
 
@@ -59,32 +52,8 @@ const Index: React.FC = () => {
             ))}
           </div>
 
-          {/* Main launch CTAs */}
+          {/* Primary CTAs */}
           <div className="space-y-3 flex flex-col items-center">
-            <Link
-              to="/signup"
-              className="button-shadow rounded-xl px-8 py-4 bg-brightboost-blue text-white font-bold text-center text-lg hover:bg-opacity-90 hover:scale-105 transition-all w-72 ui-lift"
-            >
-              {t("landing.joinFreeCta", { defaultValue: "Join Bright Boost Free" })}
-            </Link>
-            <div className="flex flex-col sm:flex-row gap-3 w-72 sm:w-auto">
-              <Link
-                to="/for-reviewers"
-                className="button-shadow rounded-xl px-5 py-3 bg-white/90 text-brightboost-navy font-bold text-center text-base hover:bg-white hover:scale-105 transition-all ui-lift border border-brightboost-lightblue"
-              >
-                {t("landing.giveFeedbackCta", { defaultValue: "Give Feedback" })}
-              </Link>
-              <a
-                href="mailto:partnerships@brightboost.org?subject=Donate%20to%20Keep%20Bright%20Boost%20Free"
-                className="button-shadow rounded-xl px-5 py-3 bg-brightboost-yellow text-brightboost-navy font-bold text-center text-base hover:opacity-90 hover:scale-105 transition-all ui-lift"
-              >
-                {t("landing.donateCta", { defaultValue: "Donate to Keep Bright Boost Free" })}
-              </a>
-            </div>
-          </div>
-
-          {/* Teacher / student entry points */}
-          <div className="space-y-3 flex flex-col items-center mt-5">
             <Link
               to="/teacher-login"
               className="button-shadow rounded-xl px-8 py-4 bg-brightboost-blue text-white font-bold text-center text-lg hover:bg-opacity-90 hover:scale-105 transition-all w-64 ui-lift"


### PR DESCRIPTION
### Motivation
- Undo an unapproved visual redesign of the Bright Boost landing that introduced an oversized hero and new CTA layout, restoring the previously approved visual feel. 
- Preserve existing routes, domain/deployment settings, and backend/auth/database logic while only changing the homepage visuals. 

### Description
- Restored `src/pages/Index.tsx` to the pre-`61a98e2` version, returning hero copy to `landing.title`, `landing.subtitle`, and `landing.tagline`. 
- Removed the newly added launch CTA block (signup / feedback / donate buttons) and reinstated the original teacher/student primary CTA layout. 
- Left all non-homepage files, route wiring (including `/teacher-login`, `/student-login`, `/class-login`, `/teacher/signup`, `/student/signup`, `/forgot-password`, `/reset-password`, `/student/*`, `/teacher/*`, `/pathways`, and `/pathways/about`), and deployment/domain settings unchanged. 
- Committed the revert with the message `Revert homepage hero and CTA redesign`.

### Testing
- Ran `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the Vite dev server started successfully. 
- Ran `npm run build` and the production build completed successfully. 
- Ran `npm run lint` and it failed due to pre-existing unrelated lint errors in backend and other components. 
- Ran `npm test` and it failed in this environment because Playwright browser binaries are not installed (error instructs to run `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9dc36b108325a16c2218c986df7f)