### PR TITLE
Homepage v2: implement sectioned Bright Boost landing, SEO, analytics, and safe routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import LoginSelection from "./pages/LoginSelection";
 import SignupSelection from "./pages/SignupSelection";
 import Index from "./pages/Index";
+import HomeSectionRedirect from "./pages/HomeSectionRedirect";
+import AudiencePlaceholder from "./pages/AudiencePlaceholder";
 import Modules from "./pages/Modules";
 import ModuleDetail from "./pages/ModuleDetail";
 import Avatar from "./pages/Avatar";
@@ -100,6 +102,12 @@ function App() {
               <Route path="/for-reviewers" element={<ForReviewers />} />
               <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="/terms" element={<TermsOfService />} />
+              <Route path="/feedback" element={<HomeSectionRedirect sectionId="feedback" />} />
+              <Route path="/donate" element={<HomeSectionRedirect sectionId="donation" />} />
+              <Route path="/students" element={<AudiencePlaceholder audience="Students" />} />
+              <Route path="/teachers" element={<AudiencePlaceholder audience="Teachers" />} />
+              <Route path="/parents" element={<AudiencePlaceholder audience="Parents" />} />
+              <Route path="/organizations" element={<AudiencePlaceholder audience="Organizations" />} />
 
               {/* Protected Teacher routes (nested) */}
               <Route

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,16 @@
 export type AnalyticsEvent =
   | { kind: "quest_start"; questId: string }
   | { kind: "quest_complete"; questId: string; attempts: number }
-  | { kind: "quiz_answer"; questionId: string; isCorrect: boolean };
+  | { kind: "quiz_answer"; questionId: string; isCorrect: boolean }
+  | { kind: "homepage_viewed" }
+  | { kind: "signup_clicked"; audience: "teacher" | "student" }
+  | { kind: "feedback_clicked" }
+  | { kind: "donation_clicked"; cadence?: "monthly" }
+  | { kind: "student_page_clicked" }
+  | { kind: "teacher_page_clicked" }
+  | { kind: "parent_page_clicked" }
+  | { kind: "organization_page_clicked" }
+  | { kind: "free_plan_clicked"; plan: string }
+  | { kind: "feedback_submitted"; audience: "teacher" | "student" | "parent" | "org" };
 
 export function track(_event: AnalyticsEvent): void {}

--- a/src/pages/AudiencePlaceholder.tsx
+++ b/src/pages/AudiencePlaceholder.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+import GameBackground from "@/components/GameBackground";
+
+interface AudiencePlaceholderProps {
+  audience: string;
+}
+
+const AudiencePlaceholder = ({ audience }: AudiencePlaceholderProps) => {
+  return (
+    <GameBackground>
+      <main className="min-h-screen flex items-center justify-center px-4 py-16">
+        <section className="max-w-xl rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+          <h1 className="text-3xl font-extrabold text-brightboost-navy">{audience} at Bright Boost</h1>
+          <p className="mt-3 text-brightboost-navy/85 font-semibold">
+            This page is a safe placeholder route so homepage audience links stay live. Content can be expanded in a follow-up pass.
+          </p>
+          <Link to="/" className="inline-block mt-5 text-brightboost-blue font-bold underline">
+            Return to homepage
+          </Link>
+        </section>
+      </main>
+    </GameBackground>
+  );
+};
+
+export default AudiencePlaceholder;

--- a/src/pages/HomeSectionRedirect.tsx
+++ b/src/pages/HomeSectionRedirect.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { Navigate } from "react-router-dom";
+
+interface HomeSectionRedirectProps {
+  sectionId: string;
+}
+
+const HomeSectionRedirect = ({ sectionId }: HomeSectionRedirectProps) => {
+  useEffect(() => {
+    sessionStorage.setItem("bb-home-scroll", sectionId);
+  }, [sectionId]);
+
+  return <Navigate to="/" replace />;
+};
+
+export default HomeSectionRedirect;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,135 +1,405 @@
-// src/pages/Index.tsx
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import GameBackground from "../components/GameBackground";
 import LanguageToggle from "../components/LanguageToggle";
-import { Gamepad2, BarChart3, Users, Globe, ChevronDown, ChevronUp, Presentation, ClipboardCheck } from "lucide-react";
+import { track } from "@/lib/analytics";
+
+const HOMEPAGE_TITLE = "Bright Boost — Free K-8 STEM Learning for Students, Teachers & Families";
+const HOMEPAGE_DESCRIPTION =
+  "Bright Boost is a free STEM K-8 bilingual, classroom-friendly platform where students, teachers, and families explore playful learning challenges together.";
+
+type Audience = "teacher" | "student" | "parent" | "org";
+
+const secondaryLinks = [
+  { label: "Give Feedback", to: "/feedback", analytics: "feedback_clicked" as const },
+  { label: "Support Bright Boost", to: "/donate", analytics: "donation_clicked" as const },
+  { label: "Explore Pathways", to: "/pathways", analytics: undefined },
+];
+
+const audienceCards = [
+  { title: "Students", description: "Play through STEM missions and track your progress.", to: "/students", event: "student_page_clicked" as const },
+  { title: "Teachers", description: "Bring standards-friendly STEM exploration into your classroom.", to: "/teachers", event: "teacher_page_clicked" as const },
+  { title: "Parents", description: "Support fun STEM practice and confidence at home.", to: "/parents", event: "parent_page_clicked" as const },
+  { title: "Organizations", description: "Partner on pilots and bring access to more learners.", to: "/organizations", event: "organization_page_clicked" as const },
+];
 
 const Index: React.FC = () => {
-  const { t } = useTranslation();
-  const [showDemo, setShowDemo] = useState(false);
+  const [feedbackAudience, setFeedbackAudience] = useState<Audience>("teacher");
+  const [feedbackMessage, setFeedbackMessage] = useState("");
+  const [feedbackEmail, setFeedbackEmail] = useState("");
+  const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+  const [donationAmount, setDonationAmount] = useState<string>("15");
+  const donationUrl = import.meta.env.VITE_DONATION_URL;
+
+  useEffect(() => {
+    track({ kind: "homepage_viewed" });
+  }, []);
+
+  useEffect(() => {
+    document.title = HOMEPAGE_TITLE;
+
+    const upsertMeta = (name: string, content: string, property = false) => {
+      const selector = property ? `meta[property="${name}"]` : `meta[name="${name}"]`;
+      let el = document.head.querySelector(selector) as HTMLMetaElement | null;
+      if (!el) {
+        el = document.createElement("meta");
+        if (property) {
+          el.setAttribute("property", name);
+        } else {
+          el.setAttribute("name", name);
+        }
+        document.head.appendChild(el);
+      }
+      el.setAttribute("content", content);
+    };
+
+    upsertMeta("description", HOMEPAGE_DESCRIPTION);
+    upsertMeta("og:title", HOMEPAGE_TITLE, true);
+    upsertMeta("og:description", HOMEPAGE_DESCRIPTION, true);
+    upsertMeta("twitter:title", HOMEPAGE_TITLE);
+    upsertMeta("twitter:description", HOMEPAGE_DESCRIPTION);
+
+    const schemaId = "bb-home-schema";
+    const existing = document.getElementById(schemaId);
+    if (existing) existing.remove();
+
+    const schema = document.createElement("script");
+    schema.id = schemaId;
+    schema.type = "application/ld+json";
+    schema.text = JSON.stringify([
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "Bright Bots Initiative",
+        url: window.location.origin,
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "EducationalOrganization",
+        name: "Bright Boost",
+        educationalLevel: "K-8",
+      },
+    ]);
+    document.head.appendChild(schema);
+
+    return () => {
+      const current = document.getElementById(schemaId);
+      if (current) current.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    const section = sessionStorage.getItem("bb-home-scroll");
+    if (section) {
+      sessionStorage.removeItem("bb-home-scroll");
+      requestAnimationFrame(() => {
+        document.getElementById(section)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    }
+  }, []);
+
+  const feedbackTabs = useMemo(
+    () => [
+      { key: "teacher" as const, label: "Teacher" },
+      { key: "student" as const, label: "Student" },
+      { key: "parent" as const, label: "Parent" },
+      { key: "org" as const, label: "Org" },
+    ],
+    [],
+  );
+
+  const submitFeedback = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFeedbackSubmitted(true);
+    track({ kind: "feedback_submitted", audience: feedbackAudience });
+  };
+
+  const chunkyPrimary =
+    "button-shadow rounded-[12px] font-extrabold text-base md:text-lg px-6 py-3 text-white transition-all active:translate-y-[3px] hover:brightness-110 focus-visible:ring-2 focus-visible:ring-offset-2";
 
   return (
     <GameBackground>
-      <div className="flex flex-col min-h-screen p-4 relative z-10">
-        {/* Language toggle — top-right, always visible */}
-        <div className="flex justify-end pt-2 pr-1">
-          <LanguageToggle />
-        </div>
-
-        <div className="flex-grow flex flex-col items-center justify-center">
-          {/* Hero */}
-          <div className="text-center mb-8">
-            <h1 className="text-5xl md:text-7xl font-extrabold text-brightboost-navy mb-3 drop-shadow-sm tracking-tight">
-              {t("landing.title")}
-            </h1>
-            <p className="text-xl md:text-2xl text-brightboost-navy font-semibold">
-              {t("landing.subtitle")}
-            </p>
-            <p className="text-base md:text-lg text-brightboost-navy/70 mt-1 max-w-lg mx-auto">
-              {t("landing.tagline")}
-            </p>
-          </div>
-
-          {/* Feature highlights */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-8 max-w-2xl w-full px-2">
-            {[
-              { icon: Gamepad2, key: "landing.feat1" },
-              { icon: BarChart3, key: "landing.feat2" },
-              { icon: Users, key: "landing.feat3" },
-              { icon: Globe, key: "landing.feat4" },
-            ].map(({ icon: Icon, key }) => (
-              <div
-                key={key}
-                className="bg-white/80 backdrop-blur rounded-xl p-3 text-center shadow-sm"
+      <div className="relative z-10">
+        <nav className="sticky top-0 z-20 bg-white/80 backdrop-blur border-b border-white/70" aria-label="Homepage">
+          <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-3">
+            <Link to="/" className="font-extrabold text-brightboost-navy tracking-tight text-lg">
+              Bright Boost
+            </Link>
+            <div className="flex items-center gap-3">
+              <LanguageToggle />
+              <Link
+                to="/student-login"
+                className="button-shadow rounded-[12px] px-4 py-2 font-extrabold bg-brightboost-navy text-white text-sm hover:brightness-110 active:translate-y-[3px]"
               >
-                <Icon className="w-6 h-6 mx-auto mb-1 text-brightboost-blue" />
-                <p className="text-xs md:text-sm font-medium text-brightboost-navy">
-                  {t(key)}
+                Sign in
+              </Link>
+            </div>
+          </div>
+        </nav>
+
+        <main>
+          <section
+            id="hero"
+            aria-labelledby="hero-heading"
+            className="mx-auto max-w-6xl px-4 py-10 md:py-12 md:min-h-[520px] min-h-[560px] max-h-[600px] md:max-h-[540px]"
+            style={{ background: "linear-gradient(180deg,#BFE5F7 0%,#DCEEFB 55%,#EAF6FD 100%)" }}
+          >
+            <div className="grid md:grid-cols-2 gap-6 items-center h-full">
+              <div>
+                <p className="inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs uppercase tracking-[0.15em] bg-white text-brightboost-navy font-bold">
+                  <span className="w-2 h-2 rounded-full bg-brightboost-green" aria-hidden="true" />
+                  Free STEM Learning Platform
+                </p>
+                <h1 id="hero-heading" className="mt-4 text-[30px] md:text-[40px] leading-tight font-extrabold text-brightboost-navy">
+                  Build STEM confidence through playful learning
+                </h1>
+                <p className="mt-4 text-brightboost-navy/85 text-base md:text-lg font-semibold max-w-xl">
+                  Bright Boost helps students explore STEM through games, guided challenges, progress
+                  tracking, and classroom-friendly tools.
+                </p>
+
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <Link
+                    to="/teacher-login"
+                    className={`${chunkyPrimary} bg-gradient-to-r from-[#46B1E6] to-[#2f92ca]`}
+                    onClick={() => track({ kind: "signup_clicked", audience: "teacher" })}
+                  >
+                    I’m a Teacher
+                  </Link>
+                  <Link
+                    to="/student-login"
+                    className={`${chunkyPrimary} bg-gradient-to-r from-purple-500 to-pink-500`}
+                    onClick={() => track({ kind: "signup_clicked", audience: "student" })}
+                  >
+                    I’m a Student!
+                  </Link>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+                  {secondaryLinks.map((item) => (
+                    <Link
+                      key={item.label}
+                      to={item.to}
+                      className="text-brightboost-navy font-semibold underline-offset-2 hover:underline"
+                      onClick={() => item.analytics && track({ kind: item.analytics })}
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
+
+                <p className="mt-4 inline-flex rounded-full bg-white/85 px-4 py-2 text-sm text-brightboost-navy font-semibold">
+                  🌱 Early access · join our first 1,000 users
                 </p>
               </div>
-            ))}
-          </div>
 
-          {/* Primary CTAs */}
-          <div className="space-y-3 flex flex-col items-center">
-            <Link
-              to="/teacher-login"
-              className="button-shadow rounded-xl px-8 py-4 bg-brightboost-blue text-white font-bold text-center text-lg hover:bg-opacity-90 hover:scale-105 transition-all w-64 ui-lift"
-            >
-              {t("landing.imATeacher")}
-            </Link>
-            <Link
-              to="/student-login"
-              className="button-shadow rounded-xl px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 text-white font-bold text-center text-lg hover:scale-105 transition-all w-64 ui-lift"
-            >
-              {t("landing.imAStudent")} 🎒
-            </Link>
-          </div>
+              <Card className="rounded-[22px] border-2 border-white/90 shadow-xl bg-white/95 p-0 md:rotate-[-2deg] motion-reduce:rotate-0">
+                <CardHeader className="border-b border-slate-100 pb-3">
+                  <div className="flex items-center gap-2 mb-2" aria-hidden="true">
+                    <span className="w-2.5 h-2.5 rounded-full bg-red-300" />
+                    <span className="w-2.5 h-2.5 rounded-full bg-yellow-300" />
+                    <span className="w-2.5 h-2.5 rounded-full bg-green-300" />
+                  </div>
+                  <CardTitle className="text-brightboost-navy text-lg">Student Dashboard Preview</CardTitle>
+                  <span className="inline-flex self-start rounded-full bg-[#FACC15] px-3 py-1 text-xs font-extrabold text-brightboost-navy">
+                    🎮 Always Free
+                  </span>
+                </CardHeader>
+                <CardContent className="grid grid-cols-2 gap-3 pt-4">
+                  {["Build circuits", "Math mission", "Track streak", "Classroom mode"].map((tile) => (
+                    <div key={tile} className="rounded-[18px] bg-sky-50 border border-sky-100 p-3 text-sm text-brightboost-navy font-semibold">
+                      {tile}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </div>
+          </section>
 
-          {/* Pathways link */}
-          <div className="mt-4">
-            <Link
-              to="/pathways/about"
-              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium hover:underline transition-colors"
-            >
-              {t("landing.pathwaysLink", { defaultValue: "Ages 14-17? Check out Bright Boost Pathways →" })}
-            </Link>
-          </div>
+          <section id="early-access" aria-labelledby="early-access-heading" className="mx-auto max-w-6xl px-4 py-14">
+            <h2 id="early-access-heading" className="text-2xl font-extrabold text-brightboost-navy">Early Access Goal</h2>
+            <Card className="mt-4 rounded-[18px] border-2 border-white/80 bg-white/85">
+              <CardContent className="pt-1 text-brightboost-navy font-semibold">
+                Join our first 1,000 users
+              </CardContent>
+            </Card>
+          </section>
 
-          {/* Reviewer / Partner entry points */}
-          <div className="flex flex-col sm:flex-row items-center gap-3 mt-6">
-            <Link
-              to="/for-reviewers"
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-white/80 backdrop-blur text-sm font-medium text-brightboost-navy hover:bg-white transition-colors shadow-sm"
-            >
-              <ClipboardCheck className="w-4 h-4 text-brightboost-blue" />
-              {t("landing.forReviewers")}
-            </Link>
-            <Link
-              to="/showcase"
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-white/80 backdrop-blur text-sm font-medium text-brightboost-navy hover:bg-white transition-colors shadow-sm"
-            >
-              <Presentation className="w-4 h-4 text-brightboost-blue" />
-              {t("landing.viewShowcase")}
-            </Link>
-          </div>
+          <section id="plans" aria-labelledby="plans-heading" className="mx-auto max-w-6xl px-4 py-14">
+            <h2 id="plans-heading" className="text-2xl font-extrabold text-brightboost-navy">Free Access Plans</h2>
+            <div className="grid md:grid-cols-3 gap-4 mt-4">
+              {[
+                { name: "Learner", details: "Hands-on STEM games, challenges, and personal progress tracking." },
+                { name: "Classroom", details: "Teacher-friendly tools, shared activities, and student progress visibility." },
+                { name: "Organization", details: "Support multiple classrooms and collaboration for outreach programs." },
+              ].map((plan) => (
+                <Card key={plan.name} className="rounded-[18px] border-2 border-[#46B1E6]/20">
+                  <CardHeader>
+                    <CardTitle className="text-brightboost-navy">{plan.name}</CardTitle>
+                    <span className="inline-flex rounded-full bg-[#69D681]/25 text-brightboost-navy px-3 py-1 text-xs font-bold w-fit">
+                      Always Free
+                    </span>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-brightboost-navy/85 font-medium">{plan.details}</p>
+                    <Button
+                      className="mt-4 rounded-[12px] font-extrabold bg-brightboost-navy text-white hover:bg-brightboost-navy/90"
+                      onClick={() => track({ kind: "free_plan_clicked", plan: plan.name.toLowerCase() })}
+                    >
+                      Learn more
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
 
-          {/* Demo / Partner section */}
-          <div className="mt-6 max-w-md w-full">
-            <button
-              onClick={() => setShowDemo(!showDemo)}
-              className="flex items-center justify-center gap-2 mx-auto text-sm text-brightboost-navy/70 hover:text-brightboost-navy transition-colors"
-            >
-              {t("landing.demoToggle")}
-              {showDemo ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-            </button>
-            {showDemo && (
-              <div className="mt-3 bg-white/90 backdrop-blur rounded-xl p-5 shadow-md text-sm text-brightboost-navy space-y-3">
-                <p className="font-semibold">{t("landing.demoTitle")}</p>
-                <div className="space-y-1 text-xs font-mono bg-gray-50 rounded-lg p-3">
-                  <p>{t("landing.demoTeacher")}: <strong>teacher@school.com</strong> / <strong>password123</strong></p>
-                  <p>{t("landing.demoStudent")}: <strong>student@test.com</strong> / <strong>password</strong></p>
+          <section id="audience" aria-labelledby="audience-heading" className="mx-auto max-w-6xl px-4 py-14">
+            <h2 id="audience-heading" className="text-2xl font-extrabold text-brightboost-navy">Who Bright Boost Supports</h2>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
+              {audienceCards.map((audience) => (
+                <Card key={audience.title} className="rounded-[18px] border border-sky-100">
+                  <CardHeader>
+                    <CardTitle className="text-lg text-brightboost-navy">{audience.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm font-medium text-brightboost-navy/80">{audience.description}</p>
+                    <Link
+                      to={audience.to}
+                      className="inline-block mt-3 text-sm text-brightboost-blue font-bold underline"
+                      onClick={() => track({ kind: audience.event })}
+                    >
+                      Explore
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section id="feedback" aria-labelledby="feedback-heading" className="mx-auto max-w-6xl px-4 py-14">
+            <h2 id="feedback-heading" className="text-2xl font-extrabold text-brightboost-navy">Feedback</h2>
+            <Card className="mt-4 rounded-[18px]">
+              <CardContent className="pt-1">
+                <form className="space-y-4" onSubmit={submitFeedback}>
+                  <div className="flex flex-wrap gap-2" role="tablist" aria-label="Feedback audience type">
+                    {feedbackTabs.map((tab) => (
+                      <button
+                        key={tab.key}
+                        type="button"
+                        role="tab"
+                        aria-selected={feedbackAudience === tab.key}
+                        onClick={() => setFeedbackAudience(tab.key)}
+                        className={`rounded-full px-4 py-1.5 text-sm font-bold ${
+                          feedbackAudience === tab.key
+                            ? "bg-brightboost-navy text-white"
+                            : "bg-slate-100 text-brightboost-navy"
+                        }`}
+                      >
+                        {tab.label}
+                      </button>
+                    ))}
+                  </div>
+
+                  <label className="block">
+                    <span className="text-sm font-semibold text-brightboost-navy">Share your ideas</span>
+                    <textarea
+                      className="mt-1 w-full rounded-xl border border-slate-200 p-3 focus:ring-2 focus:ring-brightboost-blue focus:outline-none"
+                      rows={4}
+                      value={feedbackMessage}
+                      onChange={(e) => setFeedbackMessage(e.target.value)}
+                    />
+                  </label>
+
+                  <label className="block">
+                    <span className="text-sm font-semibold text-brightboost-navy">Email (optional)</span>
+                    <input
+                      type="email"
+                      className="mt-1 w-full rounded-xl border border-slate-200 p-3 focus:ring-2 focus:ring-brightboost-blue focus:outline-none"
+                      value={feedbackEmail}
+                      onChange={(e) => setFeedbackEmail(e.target.value)}
+                    />
+                  </label>
+
+                  <Button type="submit" className="rounded-[12px] bg-brightboost-blue hover:bg-brightboost-blue/90 font-extrabold text-white">
+                    Send Feedback
+                  </Button>
+
+                  {feedbackSubmitted && (
+                    <p className="text-sm text-brightboost-navy font-semibold">
+                      Thank you! Your feedback was captured in this browser session. Backend persistence still needs to be connected.
+                    </p>
+                  )}
+                </form>
+              </CardContent>
+            </Card>
+          </section>
+
+          <section id="donation" aria-labelledby="donation-heading" className="mx-auto max-w-6xl px-4 py-14">
+            <h2 id="donation-heading" className="text-2xl font-extrabold text-brightboost-navy">Donation</h2>
+            <Card className="mt-4 rounded-[18px]">
+              <CardContent className="pt-1">
+                <div className="flex flex-wrap gap-2">
+                  {["5", "15", "50", "100", "Other"].map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setDonationAmount(amount)}
+                      className={`rounded-full px-4 py-2 text-sm font-bold ${
+                        donationAmount === amount
+                          ? "bg-brightboost-navy text-white"
+                          : "bg-slate-100 text-brightboost-navy"
+                      }`}
+                    >
+                      {amount === "Other" ? "Other" : `$${amount}`}
+                    </button>
+                  ))}
                 </div>
-                <p className="text-xs text-gray-600">{t("landing.demoPath")}</p>
-              </div>
-            )}
-          </div>
-        </div>
 
-        <footer className="text-center py-4 text-sm text-brightboost-navy/70 space-x-2">
-          <Link to="/for-reviewers" className="hover:underline">
-            {t("landing.forReviewers")}
-          </Link>
-          <span>|</span>
-          <Link to="/privacy" className="hover:underline">
-            {t("landing.privacy")}
-          </Link>
-          <span>|</span>
-          <Link to="/terms" className="hover:underline">
-            {t("landing.terms")}
-          </Link>
+                <div className="mt-4 flex flex-col sm:flex-row sm:items-center gap-3">
+                  {donationUrl ? (
+                    <a
+                      href={donationUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center justify-center rounded-[12px] px-5 py-2.5 font-extrabold bg-[#FF9C81] text-brightboost-navy button-shadow"
+                      onClick={() => track({ kind: "donation_clicked" })}
+                    >
+                      Donate Once
+                    </a>
+                  ) : (
+                    <p className="text-sm text-brightboost-navy font-semibold">Donation link coming soon.</p>
+                  )}
+                  <a
+                    href={donationUrl || "#"}
+                    className="text-sm font-bold text-brightboost-navy underline"
+                    onClick={() => donationUrl && track({ kind: "donation_clicked", cadence: "monthly" })}
+                  >
+                    Give monthly
+                  </a>
+                </div>
+
+                <p className="mt-4 text-sm text-brightboost-navy font-semibold">
+                  Donating is optional and never required to use Bright Boost.
+                </p>
+              </CardContent>
+            </Card>
+          </section>
+        </main>
+
+        <footer className="bg-[#1C3D6C] text-white mt-8" aria-label="Footer">
+          <div className="mx-auto max-w-6xl px-4 py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <p className="font-semibold">Bright Boost by Bright Bots Initiative — playful STEM growth for every learner.</p>
+            <div className="flex flex-wrap gap-4 text-sm">
+              <Link to="/for-reviewers" className="hover:underline">Evaluator Guide</Link>
+              <Link to="/pathways/about" className="hover:underline">Pathways</Link>
+              <Link to="/privacy" className="hover:underline">Privacy</Link>
+              <Link to="/terms" className="hover:underline">Terms</Link>
+              <a href="mailto:hello@brightbots.org" className="hover:underline">Contact</a>
+            </div>
+          </div>
         </footer>
       </div>
     </GameBackground>


### PR DESCRIPTION
### Motivation
- Implement the Bright Boost Homepage v2 spec to polish the landing experience while preserving the existing playful brand, hero constraints, and teacher/student entry clarity. 
- Provide accessible structure, SPA-safe SEO metadata + JSON-LD, lightweight analytics wiring, feedback UI, and a donation area that never blocks free access.

### Description
- Rebuilt the homepage at `src/pages/Index.tsx` to add the required sections in order (Hero, Early Access Goal, Free Access Plans, Audience, Feedback, Donation, Footer) while keeping the specified copy, two primary CTAs, and the app-preview card with a slight tilt. 
- Added SPA-safe SEO updates (title, description, OG/Twitter meta tags) and JSON-LD schema on mount, and wired no-op analytics events via an extended `src/lib/analytics.ts` event union (homepage_viewed, signup_clicked, feedback_submitted, donation_clicked, audience/page clicks, free_plan_clicked). 
- Preserved and validated existing auth/pathways routes and added safe routing helpers: `src/pages/HomeSectionRedirect.tsx` for `/feedback` and `/donate` section-jumps and `src/pages/AudiencePlaceholder.tsx` placeholders for `/students`, `/teachers`, `/parents`, and `/organizations` so homepage links do not crash the app. 
- Reused existing UI primitives (`GameBackground`, `LanguageToggle`, `Card`, `Button`) and respected accessibility rules (single `h1`, per-section `h2` + `aria-labelledby`, nav/main/section/footer, prefers-reduced-motion-safe tilt). 

### Testing
- Ran `npm run build` which completed successfully in this environment (Vite build produced `dist`).
- Ran `npm run lint` which failed due to pre-existing repository lint errors outside the modified files (these are unrelated to the homepage changes). 
- Ran `npm test` which failed in this environment because Playwright browser binaries are not installed (install `npx playwright install` in CI to run browser tests). 
- Ran focused linting `npx eslint src/pages/Index.tsx src/pages/AudiencePlaceholder.tsx src/pages/HomeSectionRedirect.tsx src/App.tsx src/lib/analytics.ts` which passed for the modified files, and performed a route grep check to confirm required routes remain present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efff03ffc08325953b612436e4ae81)