### PR TITLE
feat(i18n): mount LanguageToggle on all public, auth, and Pathways pages

### DIFF
--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { changeLanguage, SUPPORTED_LANGUAGES } from "@/i18n";
 
-const LanguageToggle = () => {
+type LanguageToggleProps = {
+  variant?: "light" | "dark";
+};
+
+const LanguageToggle = ({ variant = "light" }: LanguageToggleProps) => {
   const { i18n, t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [, setTick] = useState(0);
@@ -16,18 +20,37 @@ const LanguageToggle = () => {
   const currentLang = i18n.resolvedLanguage || i18n.language;
   const currentLabel = SUPPORTED_LANGUAGES.find((l) => l.code === currentLang)?.label ?? "English";
 
+  const triggerClass =
+    variant === "dark"
+      ? "bg-slate-800 text-slate-100 hover:bg-slate-700 border border-slate-700 text-sm px-3 py-1 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-400 focus:ring-offset-slate-900 font-medium"
+      : "bg-brightboost-yellow hover:bg-yellow-300 text-sm px-3 py-1 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-400 font-medium";
+
+  const menuClass =
+    variant === "dark"
+      ? "absolute right-0 mt-1 bg-slate-900 border border-slate-700 rounded-lg shadow-lg z-50 min-w-[140px] py-1"
+      : "absolute right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-50 min-w-[140px] py-1";
+
+  const itemActive =
+    variant === "dark"
+      ? "font-bold text-indigo-300 bg-slate-800"
+      : "font-bold text-brightboost-navy bg-slate-50";
+  const itemIdle =
+    variant === "dark" ? "text-slate-300" : "text-slate-700";
+  const itemHover =
+    variant === "dark" ? "hover:bg-slate-800" : "hover:bg-slate-50";
+
   return (
     <div className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="bg-brightboost-yellow hover:bg-yellow-300 text-sm px-3 py-1 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-400 font-medium"
+        className={triggerClass}
         aria-label={t("common.changeLanguage", { defaultValue: "Change language" })}
         aria-expanded={open}
       >
         {currentLabel}
       </button>
       {open && (
-        <div className="absolute right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-50 min-w-[140px] py-1">
+        <div className={menuClass}>
           {SUPPORTED_LANGUAGES.map((lang) => (
             <button
               key={lang.code}
@@ -35,8 +58,8 @@ const LanguageToggle = () => {
                 changeLanguage(lang.code);
                 setOpen(false);
               }}
-              className={`w-full text-left px-3 py-2 text-sm hover:bg-slate-50 ${
-                currentLang === lang.code ? "font-bold text-brightboost-navy bg-slate-50" : "text-slate-700"
+              className={`w-full text-left px-3 py-2 text-sm ${itemHover} ${
+                currentLang === lang.code ? itemActive : itemIdle
               }`}
             >
               {lang.label}

--- a/src/components/auth/LoginCard.tsx
+++ b/src/components/auth/LoginCard.tsx
@@ -3,6 +3,7 @@
  */
 import React from "react";
 import { Link } from "react-router-dom";
+import LanguageToggle from "@/components/LanguageToggle";
 
 export default function LoginCard({
   icon,
@@ -16,7 +17,10 @@ export default function LoginCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-sky-100 via-sky-50 to-white p-4">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-sky-100 via-sky-50 to-white p-4 relative">
+      <div className="absolute top-4 right-4 z-20">
+        <LanguageToggle />
+      </div>
       <div className="w-full max-w-md space-y-6">
         <div className="text-center">
           {icon && <div className="text-4xl mb-2">{icon}</div>}

--- a/src/components/pathways/PathwaysAbout.tsx
+++ b/src/components/pathways/PathwaysAbout.tsx
@@ -4,6 +4,7 @@
 import { Link } from "react-router-dom";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
 import { Shield, Rocket, DollarSign, Cpu, Film, Users, BarChart3, Award, ArrowRight } from "lucide-react";
+import LanguageToggle from "@/components/LanguageToggle";
 
 const ICONS: Record<string, React.ReactNode> = {
   Shield: <Shield className="w-6 h-6" />,
@@ -16,6 +17,10 @@ const ICONS: Record<string, React.ReactNode> = {
 export default function PathwaysAbout() {
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
+      {/* Language toggle — top-right, always visible */}
+      <div className="absolute top-4 right-4 z-20">
+        <LanguageToggle variant="dark" />
+      </div>
       {/* Hero */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-indigo-900/50 to-cyan-900/30" />

--- a/src/components/pathways/PathwaysLayout.tsx
+++ b/src/components/pathways/PathwaysLayout.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Outlet, NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { Home, Compass, User, Users, LogOut, Moon, Sun, BookOpen } from "lucide-react";
+import LanguageToggle from "@/components/LanguageToggle";
 
 export default function PathwaysLayout() {
   const { user, logout } = useAuth();
@@ -48,6 +49,9 @@ export default function PathwaysLayout() {
         </div>
 
         <div className="p-3 border-t border-slate-800 space-y-2">
+          <div className="px-1">
+            <LanguageToggle variant={dark ? "dark" : "light"} />
+          </div>
           <button onClick={() => setDark((d) => !d)} className={`flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs ${navIdle}`}>
             {dark ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
             {dark ? "Light Mode" : "Dark Mode"}
@@ -66,6 +70,7 @@ export default function PathwaysLayout() {
             Pathways
           </p>
           <div className="flex items-center gap-3">
+            <LanguageToggle variant={dark ? "dark" : "light"} />
             <button onClick={() => setDark((d) => !d)} className="p-1.5">
               {dark ? <Sun className="w-4 h-4 text-slate-400" /> : <Moon className="w-4 h-4 text-slate-600" />}
             </button>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 import { Input } from "../components/ui/input";
 import { Button } from "../components/ui/button";
 
@@ -46,6 +47,9 @@ const ForgotPassword: React.FC = () => {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-6 w-full max-w-md ui-sheen ui-highlight">
           <div className="flex items-center gap-2 mb-4">
             <Link

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,13 +2,17 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 import { useTranslation } from "react-i18next";
 
 const NotFound: React.FC = () => {
   const { t } = useTranslation();
   return (
     <GameBackground>
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 relative">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-8 w-full max-w-md text-center">
           <h1 className="text-6xl font-bold text-brightboost-navy mb-4">404</h1>
           <h2 className="text-2xl font-semibold text-brightboost-navy mb-6">

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -2,11 +2,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 
 const PrivacyPolicy: React.FC = () => {
   return (
     <GameBackground>
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 relative">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-8 w-full max-w-2xl text-left">
           <h1 className="text-3xl font-bold text-brightboost-navy mb-2">
             Privacy Policy

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
 
@@ -58,6 +59,9 @@ const ResetPassword: React.FC = () => {
     return (
       <GameBackground>
         <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+          <div className="absolute top-4 right-4 z-20">
+            <LanguageToggle />
+          </div>
           <div className="game-card p-6 w-full max-w-md text-center">
             <p className="text-red-600 font-medium mb-4">
               {t("auth.resetInvalid")}
@@ -77,6 +81,9 @@ const ResetPassword: React.FC = () => {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-6 w-full max-w-md ui-sheen ui-highlight">
           <div className="flex items-center gap-2 mb-4">
             <Link

--- a/src/pages/SignupSelection.tsx
+++ b/src/pages/SignupSelection.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 
 const SignupSelection: React.FC = () => {
   return (
     <GameBackground>
-      <div className="flex flex-col items-center justify-center min-h-screen p-4">
+      <div className="flex flex-col items-center justify-center min-h-screen p-4 relative">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="text-center mb-8">
           <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-2">
             Create an Account

--- a/src/pages/StudentClassLogin.tsx
+++ b/src/pages/StudentClassLogin.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "../contexts/AuthContext";
 import { API_BASE, join } from "../services/api";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 import {
   InputOTP,
   InputOTPGroup,
@@ -149,6 +150,9 @@ export default function StudentClassLogin() {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-8 w-full max-w-lg ui-sheen">
           {/* Step 1: Enter Class Code */}
           {step === "code" && (

--- a/src/pages/StudentLogin.tsx
+++ b/src/pages/StudentLogin.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { loginUser } from "../services/api";
 import GameBackground from "../components/GameBackground";
 import BrightBoostRobot from "../components/BrightBoostRobot";
+import LanguageToggle from "../components/LanguageToggle";
 import { Input } from "../components/ui/input";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
@@ -60,6 +61,9 @@ const StudentLogin: React.FC = () => {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="flex flex-col md:flex-row items-center justify-center gap-6 w-full max-w-4xl">
           <div className="text-center md:text-left flex-1">
             <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-4">

--- a/src/pages/StudentSignup.tsx
+++ b/src/pages/StudentSignup.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { signupStudent } from "../services/api";
 import GameBackground from "../components/GameBackground";
 import BrightBoostRobot from "../components/BrightBoostRobot";
+import LanguageToggle from "../components/LanguageToggle";
 import { Input } from "../components/ui/input";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
@@ -71,6 +72,9 @@ const StudentSignup: React.FC = () => {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="flex flex-col md:flex-row items-center justify-center gap-6 w-full max-w-4xl">
           <div className="text-center md:text-left flex-1">
             <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-4">

--- a/src/pages/TeacherSignup.tsx
+++ b/src/pages/TeacherSignup.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { signupTeacher } from "../services/api";
 import GameBackground from "../components/GameBackground";
 import BrightBoostRobot from "../components/BrightBoostRobot";
+import LanguageToggle from "../components/LanguageToggle";
 import { Input } from "../components/ui/input";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
@@ -60,6 +61,9 @@ const TeacherSignup: React.FC = () => {
   return (
     <GameBackground>
       <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="flex flex-col md:flex-row items-center justify-center gap-6 w-full max-w-4xl">
           <div className="text-center md:text-left flex-1">
             <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-4">

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -2,11 +2,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
 
 const TermsOfService: React.FC = () => {
   return (
     <GameBackground>
-      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 relative">
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageToggle />
+        </div>
         <div className="game-card p-8 w-full max-w-2xl text-left">
           <h1 className="text-3xl font-bold text-brightboost-navy mb-2">
             Terms of Service


### PR DESCRIPTION
## Summary

Makes the en/es/vi/zh-CN language toggle reachable from anywhere a user lands first — login, signup, public legal pages, 404, and the entire Pathways shell. The toggle component already supported all four languages via `SUPPORTED_LANGUAGES` in `src/i18n.ts`, but was previously only mounted in `StudentLayout`, `TeacherNavbar`, `Index`, and a handful of pages.

- Adds a `variant: "light" | "dark"` prop to `LanguageToggle` so it fits the Pathways slate/indigo theme without overriding the K-8 yellow. Default is `light`, so all existing call sites are unchanged.
- Mounts in `PathwaysLayout` sidebar footer + mobile top bar (dark variant) — covers all `/pathways/*` auth routes.
- Mounts on `PathwaysAbout` public landing (dark variant).
- Mounts in shared `LoginCard` wrapper — covers `LoginSelection`, `TeacherLogin`.
- Direct mounts on `StudentLogin`, `StudentClassLogin`, `SignupSelection`, `StudentSignup`, `TeacherSignup`, `ForgotPassword`, `ResetPassword`, `PrivacyPolicy`, `TermsOfService`, `NotFound`.
- `JoinClass` already inherits the toggle via `StudentLayout`, so no change there.

## Test plan

- [ ] Home page (`/`) — toggle visible top-right, all 4 languages selectable
- [ ] Login flows — toggle visible on `/login`, `/student-login`, `/teacher-login`, `/student-class-login`
- [ ] Signup flows — toggle visible on `/signup`, `/student/signup`, `/teacher/signup`
- [ ] Password recovery — toggle visible on `/forgot-password` and `/reset-password`
- [ ] Pathways — toggle visible in `/pathways/about` (public) and `/pathways/*` (sidebar + mobile top bar) using dark variant
- [ ] Public pages — toggle visible on `/privacy`, `/terms`, and 404
- [ ] Switching to vi or zh-CN persists across navigation (existing `localStorage` persistence)
- [ ] No visual regressions on previously-mounted call sites (`Index`, `Showcase`, `Stem1`, `TeacherSettings`, `ForReviewers`, student/teacher dashboards)

## Notes

- vi (`Tiếng Việt`) and zh-CN (`简体中文`) locale files already exist with ~93% of EN coverage; missing keys fall back to EN.
- 9 pre-existing test failures in `LanguageToggle.test.tsx` are unrelated to this PR — they fail identically on `origin/main`. The mock for `useTranslation` doesn't provide `.on`/`.off`, which the existing component already calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)