### PR TITLE
fix(home): mascot hero uses real asset; flip wrapper protects fallback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,6 +91,10 @@ body {
   animation: mascot-bob 4.5s ease-in-out infinite;
 }
 
+.mascot-flip {
+  transform: scaleX(-1);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mascot-bob {
     animation: none !important;

--- a/src/components/home/MascotHeroVisual.tsx
+++ b/src/components/home/MascotHeroVisual.tsx
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import FloatingBadge from "./FloatingBadge";
 
+const MASCOT_SRC = "/robots/robot_default.png";
+
 const MascotHeroVisual: React.FC = () => {
+  const [mascotLoaded, setMascotLoaded] = useState(true);
+
   return (
     <div className="relative flex items-center justify-center h-[250px] md:h-[320px] w-full">
       <div
@@ -11,12 +15,24 @@ const MascotHeroVisual: React.FC = () => {
       />
 
       <div className="relative z-10 mascot-bob">
-        <img
-          src="/robots/robot_explorer.png"
-          alt="Bright Boost mascot"
-          className="w-[180px] md:w-[250px]"
-          style={{ transform: "scaleX(-1)" }}
-        />
+        {mascotLoaded ? (
+          <div className="mascot-flip">
+            <img
+              src={MASCOT_SRC}
+              alt="Bright Boost mascot"
+              className="w-[180px] md:w-[250px] block"
+              onError={() => setMascotLoaded(false)}
+            />
+          </div>
+        ) : (
+          <div
+            role="img"
+            aria-label="Bright Boost mascot placeholder"
+            className="w-[180px] h-[180px] md:w-[250px] md:h-[250px] rounded-full bg-white/85 border-2 border-[#46B1E6]/30 flex items-center justify-center text-6xl md:text-7xl shadow-md"
+          >
+            🤖
+          </div>
+        )}
       </div>
 
       <FloatingBadge


### PR DESCRIPTION
## Summary

Fixes the broken-image mascot symptom captured in last week's screenshot. The mascot-led hero shipped (PR #569) with two issues that combined to produce the gray broken-box-with-mirrored-text:

1. The hero referenced `/robots/robot_explorer.png` — a 2 KB placeholder — instead of `/robots/robot_default.png` (357 KB), the actual mascot illustration that's already used as the default avatar elsewhere.
2. `transform: scaleX(-1)` was applied directly to the `<img>` element, so when the asset failed to load the broken-image placeholder rendered inside the same flipped box, mirroring the alt text.

## What changed

- `src/components/home/MascotHeroVisual.tsx`
  - Switched source to `/robots/robot_default.png`.
  - Moved `scaleX(-1)` off the `<img>` and onto a new `.mascot-flip` wrapper. The `.mascot-bob` animation still lives on a separate outer wrapper, so the two transforms don't collide per keyframe.
  - Added an `onError` fallback: a `role="img"` styled disc with a 🤖 emoji, sized to match the mascot. The fallback sits outside the flip wrapper so it's never mirrored, even if the PNG ever 404s in production.
- `src/App.css` — added the `.mascot-flip { transform: scaleX(-1); }` rule. Existing `@keyframes mascot-bob` and the `prefers-reduced-motion` block (lines 80-98) are unchanged.

No routes, auth, or page-shell files were touched.

## Test plan

- [ ] `/` renders the mascot at hero scale (right column), facing left toward the headline
- [ ] Sun glow renders behind the mascot, mascot is above the glow
- [ ] Desktop shows four floating badges: Always Free, Interactive Games, Track Progress, Bilingual
- [ ] Mobile shows two badges: Always Free, Bilingual
- [ ] Both primary CTAs ("I'm a Teacher", "I'm a Student!") still navigate to `/teacher-login` and `/student-login`
- [ ] Bob animation visible on desktop; disabled when OS-level reduced motion is requested
- [ ] (Edge case) blocking `/robots/robot_default.png` in devtools shows the emoji fallback **without** mirrored text
- [ ] Lighthouse / a11y: hero has exactly one `<h1>`, mascot has alt text, fallback uses `role="img"` + `aria-label`

## Pre-existing issues surfaced (not in scope)

- `npm run build` and `npm run typecheck` fail on Windows because `src/components/games/shared/ControlInstructions.tsx` (capital, `.tsx`) and `controlInstructions.ts` (lowercase, `.ts`) collide on case-insensitive filesystems. Confirmed identical failure on `origin/main` with this PR's changes stashed. Worth a separate rename PR.
- `/feedback` and `/donate` routes referenced by the hero secondary links don't exist in `App.tsx`. The Index page has matching `#feedback` and `#donation` anchor sections — could either change the links to `/#feedback`/`/#donation` or add real routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)