### PR TITLE
fix(i18n): always initialize i18n, drop VITE_ENABLE_I18N feature flag

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,8 +11,4 @@ const renderApp = () => {
   );
 };
 
-if (import.meta.env.VITE_ENABLE_I18N === "true") {
-  import("./i18n").then(() => renderApp());
-} else {
-  renderApp();
-}
+import("./i18n").then(() => renderApp());


### PR DESCRIPTION
## Summary

One-line fix that turns translation back on across the entire app.

Without \`VITE_ENABLE_I18N=true\` at build time, \`src/main.tsx\` never imported \`src/i18n.ts\`. The \`LanguageToggle\` dropdown still showed all four languages (those labels come from the \`SUPPORTED_LANGUAGES\` constant in \`src/i18n.ts\`, which the toggle imports directly even when the i18n bundle hasn't been initialized), but:

- every \`t()\` call fell through to its key or \`defaultValue\`
- \`i18n.changeLanguage()\` was a no-op on an uninitialized instance

So picking Español / Tiếng Việt / 简体中文 changed nothing visible — the symptom that prompted this fix.

## What changed

\`src/main.tsx\`: removed the \`if (import.meta.env.VITE_ENABLE_I18N === "true")\` gate. \`./i18n\` is now always imported before the React tree mounts.

## Why drop the flag instead of just setting it in prod

The flag was added in #375 (Dec 2025) to stage the i18n rollout. It has graduated:

- The toggle is mounted on every public, auth, and Pathways page (#568, merged April 2026).
- \`en/es/vi/zh-CN\` locale files cover ~93% of UI strings; \`fallbackLng: "en"\` handles the rest.
- Translation keys are used throughout the app — every page uses \`useTranslation()\` somewhere.

There's no longer a scenario where you'd want the app *not* to load i18n. Removing the flag closes the footgun and makes future deploys reliable without depending on env config.

## Test plan

- [ ] Home (\`/\`): toggle to Español, Tiếng Việt, 简体中文 → hero copy, badge, buttons, secondary links update visibly
- [ ] Any \`/student/*\` page: toggle works
- [ ] Any \`/teacher/*\` page: toggle works
- [ ] \`/login\`, \`/student-login\`, \`/teacher-login\`: toggle works
- [ ] \`/pathways/about\` and \`/pathways/*\` (dark variant): toggle works
- [ ] Selection persists after navigation and reload (\`localStorage.preferredLanguage\`)
- [ ] No regression in initial paint timing — i18n is small (~1500-line JSON × 4 locales, two of which lazy-load on first use)

## Relationship to other PRs

- #568 (already merged): mounted the toggle everywhere. Originally included this same one-line fix on the source branch but it didn't make it into the merge.
- #571 (open): unrelated CI hygiene + mascot asset move. This PR is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)