### PR TITLE
feat: ETO partner readiness — Cyber Launch audit, facilitator polish, citations, demo data

### DIFF
--- a/src/components/pathways/FacilitatorDashboard.tsx
+++ b/src/components/pathways/FacilitatorDashboard.tsx
@@ -3,7 +3,29 @@
  * Answers three questions: Who needs attention? How is the cohort doing? What do I do next?
  */
 import { useEffect, useState } from "react";
-import { Users, CheckCircle2, AlertTriangle, XCircle, Download, ChevronRight, ArrowLeft, StickyNote, RefreshCw } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Users, CheckCircle2, AlertTriangle, XCircle, Download, ChevronRight, ArrowLeft, StickyNote, RefreshCw, BookOpen } from "lucide-react";
+
+const NOTES_STORAGE_KEY = "brightboost.pathways.facilitator.notes";
+
+function loadStoredNotes(): Record<string, string> {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return {};
+    const raw = window.localStorage.getItem(NOTES_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persistNotes(notes: Record<string, string>): void {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return;
+    window.localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes));
+  } catch {
+    // localStorage unavailable — notes will not persist across sessions
+  }
+}
 
 const BAND_LABELS: Record<string, string> = {
   explorer: "Explorer (14–15)",
@@ -42,7 +64,15 @@ export default function FacilitatorDashboard() {
   const [progress, setProgress] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [selectedLearner, setSelectedLearner] = useState<Learner | null>(null);
-  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [notes, setNotes] = useState<Record<string, string>>(() => loadStoredNotes());
+
+  const updateNote = (learnerId: string, value: string) => {
+    setNotes((prev) => {
+      const next = { ...prev, [learnerId]: value };
+      persistNotes(next);
+      return next;
+    });
+  };
 
   const headers = { Authorization: `Bearer ${localStorage.getItem("token")}` };
 
@@ -183,11 +213,11 @@ export default function FacilitatorDashboard() {
           </div>
           <textarea
             value={notes[selectedLearner.id] ?? ""}
-            onChange={(e) => setNotes((prev) => ({ ...prev, [selectedLearner.id]: e.target.value }))}
+            onChange={(e) => updateNote(selectedLearner.id, e.target.value)}
             placeholder="Add a private note about this learner..."
             className="w-full bg-slate-900/50 border border-slate-700 rounded-lg p-3 text-sm text-slate-200 placeholder-slate-500 resize-none h-24 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
           />
-          <p className="text-[10px] text-slate-600 mt-1">Notes are saved locally on this device.</p>
+          <p className="text-[10px] text-slate-600 mt-1">Notes are saved locally in this browser. Server-side persistence is on the roadmap.</p>
         </div>
       </div>
     );
@@ -219,6 +249,13 @@ export default function FacilitatorDashboard() {
               ))}
             </select>
           )}
+          <Link
+            to="/pathways/facilitator/resources"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-slate-300 text-sm hover:bg-slate-700 transition-colors"
+            title="Program overview, session guide, printables"
+          >
+            <BookOpen className="w-4 h-4" /> Resources
+          </Link>
           <button onClick={() => loadCohort(selectedCohort?.id)} className="p-2 rounded-lg bg-slate-800 border border-slate-700 text-slate-400 hover:text-slate-200" title="Refresh">
             <RefreshCw className="w-4 h-4" />
           </button>

--- a/src/components/pathways/PathwaysAbout.tsx
+++ b/src/components/pathways/PathwaysAbout.tsx
@@ -3,7 +3,7 @@
  */
 import { Link } from "react-router-dom";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
-import { Shield, Rocket, DollarSign, Cpu, Film, Users, BarChart3, Award, ArrowRight } from "lucide-react";
+import { Shield, Rocket, DollarSign, Cpu, Film, Users, BarChart3, Award, ArrowRight, Briefcase, FileText, Target } from "lucide-react";
 import LanguageToggle from "@/components/LanguageToggle";
 
 const ICONS: Record<string, React.ReactNode> = {
@@ -30,8 +30,11 @@ export default function PathwaysAbout() {
             <span className="bg-gradient-to-r from-indigo-400 to-cyan-400 bg-clip-text text-transparent">Pathways</span>
           </h1>
           <p className="text-xl text-slate-300 max-w-2xl mx-auto mb-2">Real pathways for real futures.</p>
+          <p className="text-slate-400 max-w-xl mx-auto mb-2">
+            Career-connected learning for opportunity and justice-impacted youth ages 14-17.
+          </p>
           <p className="text-slate-400 max-w-xl mx-auto mb-6">
-            Career-connected learning for 14-17 year olds. Cybersecurity, entrepreneurship, financial literacy, tech, and creative media — delivered through cohort-based programs with facilitator support.
+            Cybersecurity, entrepreneurship, financial literacy, tech, and creative media — delivered through cohort-based programs with facilitator support.
           </p>
           <Link
             to="/student-login"
@@ -79,20 +82,59 @@ export default function PathwaysAbout() {
         </div>
       </div>
 
+      {/* What Outcomes Look Like */}
+      <div className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-2xl font-bold text-center mb-2">What Outcomes Look Like</h2>
+        <p className="text-sm text-slate-400 text-center mb-10">Each learner leaves the program with concrete artifacts and a next-step plan, not just attendance.</p>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          <Feature icon={<FileText className="w-5 h-5" />} title="Portfolio Artifacts" desc="Capstone security plan, career interest profile, and module completion records — concrete proof of skill." />
+          <Feature icon={<Award className="w-5 h-5" />} title="Certification Prep" desc="Direct on-ramps to Cisco NetAcad, ISC2 Certified in Cybersecurity (CC), and CompTIA Security+." />
+          <Feature icon={<Target className="w-5 h-5" />} title="Next-Step Plan" desc="Every learner ends with a concrete next action: a cert to pursue, an internship to apply for, or a credential pathway." />
+        </div>
+      </div>
+
+      {/* Delivery Models */}
+      <div className="bg-slate-900/50 border-y border-slate-800">
+        <div className="max-w-5xl mx-auto px-6 py-16">
+          <h2 className="text-2xl font-bold text-center mb-2">Delivery Models</h2>
+          <p className="text-sm text-slate-400 text-center mb-10">Built to fit how your program actually runs.</p>
+
+          <div className="grid md:grid-cols-3 gap-6">
+            <Feature icon={<Briefcase className="w-5 h-5" />} title="Site-Led" desc="Your staff facilitate using our curriculum, dashboard, and resources. We provide training and support." />
+            <Feature icon={<Users className="w-5 h-5" />} title="Hybrid" desc="Shared delivery — your staff lead in-person sessions, we run virtual deep-dives and credential coaching." />
+            <Feature icon={<Award className="w-5 h-5" />} title="Full-Service" desc="We staff the cohort end-to-end. You provide the space, recruitment, and on-site relationships." />
+          </div>
+        </div>
+      </div>
+
       {/* For Partners */}
       <div className="max-w-5xl mx-auto px-6 py-16">
         <h2 className="text-2xl font-bold text-center mb-2">For Program Partners</h2>
-        <p className="text-sm text-slate-400 text-center mb-10">Deliver Pathways in your community, school, or workforce program.</p>
+        <p className="text-sm text-slate-400 text-center mb-10">Built for correctional education, workforce development, community-based organizations, and alternative schools.</p>
 
         <div className="grid md:grid-cols-3 gap-6">
           <Feature icon={<Users className="w-5 h-5" />} title="Cohort Delivery" desc="Create cohorts, assign tracks, and manage enrollment with join codes." />
-          <Feature icon={<BarChart3 className="w-5 h-5" />} title="Facilitator Dashboard" desc="Track learner progress, completion rates, and engagement in real time." />
+          <Feature icon={<BarChart3 className="w-5 h-5" />} title="Facilitator Dashboard" desc="Track learner progress, completion rates, and engagement in real time. Export CSVs for reporting." />
           <Feature icon={<Award className="w-5 h-5" />} title="Credential Prep" desc="Cisco NetAcad integration, ISC2 CC pathway, and portfolio artifacts." />
+        </div>
+
+        <div className="mt-12 rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
+          <h3 className="font-semibold text-slate-200 mb-2">Funding Fit</h3>
+          <p className="text-sm text-slate-400 mb-3">Pathways content and delivery is designed to align with common youth-serving funding streams:</p>
+          <ul className="grid sm:grid-cols-2 gap-2 text-sm text-slate-300">
+            <li>· WIOA Youth (Title I)</li>
+            <li>· Reentry Employment Opportunities (REO)</li>
+            <li>· Illinois Youth Investment Program</li>
+            <li>· Reaching Youth, Delivering Success (RYDS)</li>
+            <li>· Perkins V / CTE Programs of Study</li>
+            <li>· Local workforce board contracts</li>
+          </ul>
         </div>
 
         <div className="text-center mt-12">
           <a
-            href="mailto:partnerships@brightboost.org?subject=Pathways%20Pilot%20Interest"
+            href="mailto:nwalker@brightbotsint.com?subject=Pathways%20Pilot%20Interest"
             className="inline-flex items-center gap-2 px-8 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors"
           >
             Request a Pilot <ArrowRight className="w-4 h-4" />

--- a/src/components/pathways/modules/CyberLaunchModules.tsx
+++ b/src/components/pathways/modules/CyberLaunchModules.tsx
@@ -119,11 +119,11 @@ const CYBER_SLIDES = [
   },
   {
     title: "Why It Matters",
-    body: "Data breaches cost businesses an average of $4.45 million per incident. Personal data — passwords, financial info, medical records — is constantly at risk. Critical infrastructure like power grids and hospitals depends on strong cyber defense.",
+    body: "Data breaches cost businesses an average of $4.45 million per incident (IBM Cost of a Data Breach Report, 2023). Personal data — passwords, financial info, medical records — is constantly at risk. Critical infrastructure like power grids and hospitals depends on strong cyber defense.",
   },
   {
     title: "Real Breaches",
-    body: "In 2017, a single breach exposed the personal data of 147 million people — names, Social Security numbers, birth dates. In 2020, a ransomware attack shut down a major hospital network, diverting emergency patients and delaying care for days.",
+    body: "In 2017, a single breach exposed the personal data of 147 million people — names, Social Security numbers, birth dates. In 2020, a ransomware attack shut down a major hospital network, diverting emergency patients and delaying care for days. Real incidents like these are why every organization now treats cybersecurity as a business risk, not just an IT problem.",
   },
   {
     title: "Who Works in Cyber?",
@@ -133,13 +133,27 @@ const CYBER_SLIDES = [
       { name: "Incident Responder", desc: "Investigates breaches and leads the recovery effort", pay: "$70K–$105K" },
       { name: "Security Engineer", desc: "Designs and builds security architecture and tools", pay: "$95K–$145K" },
       { name: "GRC Analyst", desc: "Manages governance, risk, and compliance frameworks", pay: "$65K–$100K" },
+      { name: "Digital Forensics", desc: "Recovers evidence from devices after breaches and crimes", pay: "$75K–$120K" },
+      { name: "Security Architect", desc: "Designs the overall security strategy for an organization", pay: "$120K–$180K" },
       { name: "CISO", desc: "Chief Information Security Officer — leads the entire security program", pay: "$150K–$250K" },
     ],
   },
   {
-    title: "The Opportunity",
-    body: "There are nearly 470,000 unfilled cybersecurity jobs in the U.S. alone. The field is growing 33% faster than average — and it rewards curiosity, problem-solving, and persistence over any single degree or background.",
+    title: "Many Ways In",
+    body: "You don't need a four-year degree to start a cyber career. People enter the field through bootcamps, free industry certifications (CompTIA Security+, ISC2 Certified in Cybersecurity), military service, IT help desk roles, and self-study with home labs. Employers care about what you can do, not just what's on your diploma.",
   },
+  {
+    title: "The Opportunity",
+    body: "The U.S. had roughly 470,000 unfilled cybersecurity job openings as of mid-2024 (NIST CyberSeek). The U.S. Bureau of Labor Statistics projects Information Security Analyst employment to grow about 33% from 2023 to 2033 — much faster than the average for all occupations. The field rewards curiosity, problem-solving, and persistence over any single background.",
+  },
+];
+
+const CYBER_SOURCES = [
+  { label: "NIST CyberSeek (job market data)", url: "https://www.cyberseek.org/" },
+  { label: "BLS Information Security Analysts", url: "https://www.bls.gov/ooh/computer-and-information-technology/information-security-analysts.htm" },
+  { label: "ISC2 Certified in Cybersecurity (CC)", url: "https://www.isc2.org/Certifications/CC" },
+  { label: "CompTIA Security+", url: "https://www.comptia.org/certifications/security" },
+  { label: "NIST Cybersecurity Framework", url: "https://www.nist.gov/cyberframework" },
 ];
 
 const CYBER_QUIZ = [
@@ -272,6 +286,30 @@ export function CyberFoundations({ onComplete, onBack }: ModuleProps) {
           </PrimaryButton>
         )}
       </div>
+
+      {/* Sources — visible on every slide so claims are verifiable */}
+      <details className="mt-8 group">
+        <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-300 select-none">
+          Sources &amp; further reading
+        </summary>
+        <ul className="mt-2 space-y-1 pl-3 border-l border-slate-700">
+          {CYBER_SOURCES.map((s) => (
+            <li key={s.url} className="text-xs text-slate-400">
+              <a
+                href={s.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-indigo-300 hover:underline"
+              >
+                {s.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p className="text-[10px] text-slate-600 mt-2 pl-3">
+          Job-market and salary figures cited above are point-in-time references; verify against current BLS/CyberSeek data before quoting in partner materials.
+        </p>
+      </details>
     </ModuleShell>
   );
 }
@@ -527,9 +565,10 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handlePwSubmit}>Submit</PrimaryButton>
           )}
           {pwSubmitted && (
-            <p className="text-xs text-teal-400">
-              Strong passwords use length, mixed case, numbers, and symbols.
-            </p>
+            <div className="text-xs text-teal-400 space-y-1">
+              <p>Modern NIST guidance (SP 800-63B): length beats complexity. A long passphrase like four random words is stronger than a short scramble — and you don't have to rotate passwords on a schedule if they aren't compromised.</p>
+              <p className="text-slate-500">A password manager lets you use a unique, long password for every account without memorizing them.</p>
+            </div>
           )}
         </div>
       )}
@@ -1186,6 +1225,20 @@ const CAREERS: CareerCard[] = [
     tags: ["Organized", "Policy-minded", "Strong communicator"],
   },
   {
+    role: "Digital Forensics",
+    what: "Recovers and analyzes evidence from devices after breaches, crimes, or insider incidents. Often works with law enforcement or legal teams.",
+    salary: "$75K–$120K",
+    education: "GIAC GCFE/GCFA cert, criminal justice or CS background, EnCase or FTK training",
+    tags: ["Patient", "Detail-obsessed", "Evidence-driven"],
+  },
+  {
+    role: "Security Architect",
+    what: "Designs the overall security strategy and reference architecture for an organization. Translates business risk into technical controls.",
+    salary: "$120K–$180K",
+    education: "10+ years experience, CISSP-ISSAP, deep network and cloud knowledge",
+    tags: ["Big-picture", "Designer", "Risk-aware"],
+  },
+  {
     role: "CISO",
     what: "Chief Information Security Officer. Leads the entire security program, sets strategy, and reports to the board.",
     salary: "$150K–$250K",
@@ -1209,12 +1262,14 @@ export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
   };
 
   const nextSteps: Record<string, string[]> = {
-    "Security Analyst": ["CompTIA Security+ certification", "SOC analyst internship", "Home lab practice"],
-    "Penetration Tester": ["TryHackMe / HackTheBox practice", "CEH or OSCP certification", "Bug bounty programs"],
-    "Incident Responder": ["SANS GCIH certification", "Volunteer for IT help desk", "Incident response simulations"],
-    "Security Engineer": ["AWS/Azure cloud certifications", "Learn Python scripting", "Open source security projects"],
-    "GRC Analyst": ["ISACA CISA certification", "Study compliance frameworks (NIST, ISO)", "Business writing courses"],
-    "CISO": ["Build broad security experience first", "MBA or security management degree", "Leadership and communication training"],
+    "Security Analyst": ["ISC2 Certified in Cybersecurity (CC) — free for first year", "CompTIA Security+ certification", "Home lab + SOC analyst internship"],
+    "Penetration Tester": ["TryHackMe / HackTheBox practice", "CEH or OSCP certification", "Bug bounty programs (HackerOne, Bugcrowd)"],
+    "Incident Responder": ["SANS GCIH certification", "IT help desk role to learn the environment", "Tabletop incident-response simulations"],
+    "Security Engineer": ["AWS/Azure cloud certifications", "Learn Python scripting", "Contribute to open-source security tooling"],
+    "GRC Analyst": ["ISACA CISA certification", "Study NIST CSF and ISO 27001 frameworks", "Build clear technical-writing samples"],
+    "Digital Forensics": ["SANS GCFE certification", "Practice with Autopsy / FTK Imager on test drives", "Learn chain-of-custody basics"],
+    "Security Architect": ["Earn CISSP first, then CISSP-ISSAP", "Get deep on cloud (AWS/Azure security)", "Study NIST 800-53 controls"],
+    "CISO": ["Build broad security experience first", "MBA or security management coursework", "Leadership and board-communication training"],
   };
 
   if (showSummary) {
@@ -1304,11 +1359,29 @@ export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
 // MODULE 6 — CiscoNetacadLink (External)
 // ═══════════════════════════════════════════════════════════════════════════
 
+const NETACAD_URL =
+  "https://www.cisco.com/site/us/en/learn/training-certifications/training/netacad/index.html";
+
+const RECOMMENDED_NETACAD_COURSES = [
+  {
+    name: "Introduction to Cybersecurity",
+    detail: "~15 hr, no prerequisites. Best starting point after this module.",
+  },
+  {
+    name: "Cybersecurity Essentials",
+    detail: "~30 hr, builds on the intro. Maps to CompTIA Security+ and Cisco CyberOps Associate.",
+  },
+  {
+    name: "CCNA (Introduction to Networks)",
+    detail: "Deeper networking foundation — useful for SOC, security engineering, and incident response roles.",
+  },
+];
+
 export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
   const [clicked, setClicked] = useState(false);
 
   const handleOpen = () => {
-    window.open("https://www.netacad.com/", "_blank", "noopener,noreferrer");
+    window.open(NETACAD_URL, "_blank", "noopener,noreferrer");
     setClicked(true);
     onComplete(100);
   };
@@ -1316,15 +1389,28 @@ export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
   return (
     <ModuleShell title="Cisco NetAcad" step={1} totalSteps={1} onBack={onBack}>
       <div className="flex items-center justify-center min-h-[50vh]">
-        <Card className="max-w-md w-full text-center space-y-4 p-6">
-          {/* Cisco logo placeholder */}
-          <div className="w-16 h-16 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
-            <span className="text-2xl font-bold text-teal-400">C</span>
+        <Card className="max-w-md w-full space-y-4 p-6">
+          <div className="text-center space-y-3">
+            {/* Cisco logo placeholder */}
+            <div className="w-16 h-16 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
+              <span className="text-2xl font-bold text-teal-400">C</span>
+            </div>
+            <h2 className="text-lg font-semibold text-white">Cisco Networking Academy</h2>
+            <p className="text-sm text-slate-400 leading-relaxed">
+              Cisco NetAcad offers free, industry-recognized courses in networking, cybersecurity, and IT fundamentals. Build skills that employers actively look for.
+            </p>
           </div>
-          <h2 className="text-lg font-semibold text-white">Cisco Networking Academy</h2>
-          <p className="text-sm text-slate-400 leading-relaxed">
-            Cisco NetAcad offers free, industry-recognized courses in networking, cybersecurity, and IT fundamentals. Build skills that employers actively look for.
-          </p>
+
+          <div className="space-y-2 pt-2 border-t border-slate-700">
+            <p className="text-xs text-slate-500 uppercase tracking-wider">Recommended after this module</p>
+            {RECOMMENDED_NETACAD_COURSES.map((c) => (
+              <div key={c.name} className="text-left">
+                <p className="text-sm font-medium text-slate-200">{c.name}</p>
+                <p className="text-xs text-slate-400">{c.detail}</p>
+              </div>
+            ))}
+          </div>
+
           <div className="space-y-2">
             <button
               onClick={handleOpen}
@@ -1333,7 +1419,7 @@ export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
               Open Cisco NetAcad
             </button>
             {clicked && (
-              <p className="text-xs text-teal-400">
+              <p className="text-xs text-teal-400 text-center">
                 Link opened. Module complete.
               </p>
             )}


### PR DESCRIPTION
## Summary

Pre-meeting polish ahead of the Aaron Smith (Escape The Odds) + cybersecurity-expert demo. Goal: make the Cyber Launch curriculum verifiable, the facilitator experience honest, and the partner pitch on-message.

## Cyber Launch curriculum (\`CyberLaunchModules.tsx\`)

- **Dated qualifiers + sources** on every external claim so the cyber expert can verify against current data instead of trusting a snapshot:
  - \"470,000 unfilled cyber jobs\" → \"as of mid-2024 (NIST CyberSeek)\"
  - \"33% faster than average\" → \"33% from 2023-2033 (BLS Information Security Analyst)\"
  - \"$4.45M average breach cost\" → attributed to IBM Cost of a Data Breach Report, 2023
- **New slide: \"Many Ways In\"** — names bootcamps, ISC2 CC (free first year), Security+, military service, IT help desk, and home-lab self-study as legitimate on-ramps. Counters the implicit \"need a CS degree\" framing for justice-impacted youth.
- **Sources & further reading** footer on the Foundations module linking NIST CyberSeek, BLS OOH, ISC2 CC, CompTIA Security+, NIST CSF.
- **Module 5 careers expanded**: added **Digital Forensics** and **Security Architect** with realistic salary ranges and education paths. Added matching next-step entries (GCFE, CISSP-ISSAP, NIST 800-53 study).
- **Module 2 password feedback** now cites **NIST SP 800-63B**: length over complexity, passphrases, no forced rotation. Names password managers.
- **Module 6 NetAcad**: replaced bare \`netacad.com\` link with the full canonical \`cisco.com/.../netacad/index.html\` URL. Added a \"Recommended after this module\" panel: Introduction to Cybersecurity, Cybersecurity Essentials, CCNA (Introduction to Networks) with hours and cert mapping.

## Facilitator dashboard

- **Notes actually persist now.** Wired to \`localStorage\` (\`brightboost.pathways.facilitator.notes\`). Copy already said \"saved locally\" — it was a lie until this PR. Server-side persistence is a follow-up.
- **Resources button** in the cohort header → \`/pathways/facilitator/resources\` (Program Overview / Session Guide / Printables). Coach Davis can now find facilitator materials without typing the URL.

## PathwaysAbout (partner pitch)

- Hero now explicitly states **\"for opportunity and justice-impacted youth ages 14-17\"**.
- New section: **What Outcomes Look Like** (portfolio artifacts, certification prep, next-step plan).
- New section: **Delivery Models** (Site-Led / Hybrid / Full-Service).
- New panel: **Funding Fit** (WIOA Youth, Reentry Employment Opportunities, Illinois Youth Investment, RYDS, Perkins V / CTE, local workforce board contracts).
- Reframed \"For Program Partners\" to name correctional education, workforce development, CBOs, and alternative schools directly.
- \"Request a Pilot\" CTA now mails **nwalker@brightbotsint.com** (was \`partnerships@brightboost.org\`).

## Demo data — already correct

Verified \`prisma/seed.cjs\` L1500-1614. Marcus, Aisha, Coach Davis, and ETO Spring 2026 cohort already match the prompt's expected story bit-for-bit:
- Marcus: Foundations=85, Safety Sim=90, Network Basics=78, Threat Detective=in progress
- Aisha: enrolled, zero milestones
- Coach Davis: facilitator on cohort with both students

No seed changes needed.

## What I did NOT do (transparency)

- **Could not independently verify \"current\" BLS/CyberSeek figures** from this environment — no live web access. Kept existing numbers, added dated qualifiers, and linked the canonical sources so the cybersecurity expert can spot-check in 30 seconds. **Final numbers should be re-verified at cyberseek.org and bls.gov/ooh in a browser before the meeting** in case 2025/2026 BLS revisions have shifted things.
- **Browser smoke test** for the Pathways flows must be done by a human — I can't drive a browser from here. Use \`docs/pre-launch-smoke-test.md\` (from #573) plus the audit list in the prompt.

## Test plan

- [ ] Log in as \`facilitator@test.com\` / \`pathway123\` → see ETO Spring 2026 cohort, Marcus + Aisha in the roster
- [ ] Click Marcus → confirm module strip shows 3 completed + 1 in-progress
- [ ] Add a note on Marcus → refresh page → note persists
- [ ] Click Resources button in header → lands on Program Overview / Session Guide / Printables
- [ ] Log in as Marcus (\`marcus@test.com\` / \`marcus123\`) → /pathways shows track progress; complete Threat Detective → milestone updates
- [ ] Log in as Aisha → fresh state, can start Cyber Foundations
- [ ] Hit \`/pathways/about\` anonymously → hero text + Outcomes + Delivery Models + Funding Fit + Request-a-Pilot CTA all render
- [ ] Open Cyber Foundations → expand \"Sources & further reading\" → all 5 external links open in new tabs
- [ ] Open Cisco NetAcad module → \"Open Cisco NetAcad\" goes to the full canonical URL
- [ ] Open Module 5 Career Map → Digital Forensics + Security Architect appear with next-steps

## Out of scope / follow-up

- Server-side facilitator notes (DB column + endpoint + migration) — currently \`localStorage\`-only.
- Live verification of BLS/CyberSeek numbers — needs a browser.
- The same Windows-only \`ControlInstructions\` casing collision is still on main; Linux CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)