### PR TITLE
fix: resolve 500 on facilitator login post-ETO deploy (CORS allowlist)

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -124,6 +124,8 @@ app.use("/api", nocache);
 // 🛡️ Sentinel: Configure CORS securely
 // Only allow trusted origins in production to prevent unauthorized access
 const defaultAllowedOrigins = [
+  "https://brightboost.org",
+  "https://www.brightboost.org",
   "https://fe-production-3552.up.railway.app",
   "http://localhost:5173",
   "http://localhost:3000",


### PR DESCRIPTION
## Summary
- Production frontend at `https://brightboost.org` was being rejected by backend CORS middleware after the ETO deploy, surfacing as a 500 on `/api/login` (facilitator@test.com, marcus@test.com, aisha@test.com — all accounts).
- Root cause: `backend/src/server.ts` `defaultAllowedOrigins` only listed the `fe-production-3552` Railway URL and localhost. `brightboost.org` was never in the allowlist, and the `FRONTEND_ORIGINS` env var on Railway is not set to include it.
- Fix: add `https://brightboost.org` and `https://www.brightboost.org` to the default allowlist so it works regardless of Railway env state.

## Evidence from Railway logs
- `SEED COMPLETED SUCCESSFULLY` — DB is fine, facilitator seeded.
- `Server running on port 8080` — boot is fine.
- `[CORS BLOCKED] origin: https://brightboost.org` — actual error.
- `Unhandled error: CORS blocked origin: https://brightboost.org` — what surfaces as the 500.

## Why minimal
- Touches only the CORS allowlist. No schema, no auth, no seed changes.
- Additive — does not remove or weaken any existing origin.

## Test plan
- [ ] After Railway redeploy from main, `facilitator@test.com / pathway123` logs in and lands on `/pathways/facilitator` with no 500.
- [ ] `marcus@test.com / marcus123` logs in and lands on `/pathways` with Cyber Launch progress visible.
- [ ] `aisha@test.com / aisha123` logs in and lands on `/pathways` (fresh).
- [ ] `/pathways/about` loads (public, no auth).
- [ ] `/pathways/facilitator/resources` loads with all 3 tabs.
- [ ] No `[CORS BLOCKED]` lines for `brightboost.org` in Railway logs after deploy.

## Follow-up (not in this PR)
- Set `FRONTEND_ORIGINS=https://brightboost.org,https://www.brightboost.org` in Railway env so the allowlist is also declarative outside the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)