### PR TITLE
fix: wire Pathways i18n + accessible light mode

### DIFF
--- a/docs/pathways-translation-status.md
+++ b/docs/pathways-translation-status.md
@@ -1,0 +1,111 @@
+# Pathways Translation Status
+
+Last updated: 2026-05-13
+
+This doc tracks the state of multilingual coverage for the Pathways product
+layer. The K-2 / K-8 side has its own translation status; this doc is
+Pathways-specific.
+
+i18n infrastructure:
+- Locale files: `src/locales/{en,es,vi,zh-CN}/pathways.json`
+- Merged into the existing `translation` namespace in `src/i18n.ts`
+- `fallbackLng: "en"` means missing keys in any locale gracefully fall back
+  to English — the UI **never** shows raw key strings like
+  `pathways.foo.bar`.
+
+## Per-Locale Coverage
+
+| Locale | UI Chrome | Modules (slides/quizzes) | Module Guides | FAQs | Worksheets | Facilitation Tips |
+|---|---|---|---|---|---|---|
+| en | ✅ complete | ✅ complete | ✅ complete (data file in TS) | ✅ complete (data file in TS) | ✅ complete (data file in TS) | ✅ complete (data file in TS) |
+| es | ✅ complete | ⚠️ Module 1 (Cyber Foundations) only | ❌ falls back to en | ❌ falls back to en | ⚠️ section titles only | ⚠️ section titles only |
+| vi | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en |
+| zh-CN | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en | ❌ falls back to en |
+
+Legend:
+- ✅ complete: all visible keys exist in the locale file
+- ⚠️ partial: tab titles and high-level chrome translated; deeper content
+  in English fallback
+- ❌ falls back to en: no keys in this locale; i18next returns the English
+  value via `fallbackLng`
+
+## What "UI Chrome" Covers
+
+- `PathwaysLayout` — sidebar nav, mobile bottom nav, theme toggle labels
+- `PathwaysHome` — hero, stats, sections
+- `PathwaysAbout` — entire public landing page
+- `TracksOverview` — track grid + names/taglines/descriptions
+- `TrackDetail` — module timeline, status labels
+- `ModulePlayer` — completion screen, back nav
+- `PathwaysProfile` — stats, completed modules list
+- `FacilitatorDashboard` — full dashboard + learner detail view
+- `Resources` tabs — tab labels + UI chrome inside each tab
+
+## What's NOT Yet Translated (and Where the English Lives)
+
+The following content remains in English-only TypeScript data files. These
+files are facilitator-facing and English is the partner-meeting language
+for the current pilots, so they were deprioritized for translation. The
+hook to fix them later is in place — see "Migration Path" below.
+
+1. **`src/components/pathways/modules/CyberLaunchModules.tsx`** — Modules
+   2-7 interior content (phishing scenarios, password ratings, log entries,
+   career cards, capstone businesses). Module 1 (Cyber Foundations) IS
+   wired to i18n and translated to Spanish as a proof-of-concept.
+
+2. **`src/components/pathways/facilitator/data/moduleGuides.ts`** — all 7
+   detailed module guides (11 sections each: what it teaches, why it
+   matters, facilitator role, discussion questions, sticking points,
+   extensions, real-world connection, vocabulary, red flags).
+
+3. **`src/components/pathways/facilitator/data/faqs.ts`** — 38 FAQ entries
+   across 3 categories (youth, parents, partners).
+
+4. **`src/components/pathways/facilitator/data/worksheets.ts`** — 8
+   printable worksheets. The print output itself is English; the tab UI
+   chrome is i18n'd.
+
+5. **`src/components/pathways/facilitator/data/facilitationTips.ts`** — 6
+   sections of facilitation guidance.
+
+## Migration Path for Deep Translation
+
+When deep translation of the data files becomes a priority, the cleanest
+path is:
+
+1. **Per-data-file:** Add a sibling locale key in `pathways.json` that
+   mirrors the data structure. For example, `pathways.moduleGuides.foundations.whatItTeaches`.
+2. **At render time:** Components rendering this data already use
+   `useTranslation()`. Wrap each rendered string with
+   `t(\`pathways.moduleGuides.${guide.slug}.whatItTeaches\`, guide.whatItTeaches)`.
+3. The second argument is the English fallback. Since the TS data still
+   holds English, the fallback chain is correct even with partial coverage.
+
+This approach was already applied to Module 1 (`CyberFoundations`) — see
+that component for the pattern. The other modules and data files can be
+incrementally migrated using the same shape.
+
+## Sensitive Content Translation Notes
+
+Some content has nuance that machine translation will mishandle. Items
+flagged for native-speaker review when translation begins:
+
+- **Trauma-informed and justice-impacted youth framing** (in
+  `facilitationTips.ts`) — needs review by a clinician or program staff
+  familiar with the population in each target language community.
+- **"I have a record" FAQ responses** — legal nuance and tone matter.
+  Inappropriate translation could give false hope or be unintentionally
+  patronizing.
+- **Partner outcome claims** — translated numbers should be checked
+  against the source data still valid in each target market.
+
+## Adding a New Locale (e.g., Haitian Creole)
+
+1. Create `src/locales/ht/pathways.json` mirroring `en/pathways.json`.
+2. Import in `src/i18n.ts` and add to `resources`. If lazy-loadable, add
+   to the `ensureLocaleLoaded` switch instead.
+3. Add to `SUPPORTED_LANGUAGES` in `src/i18n.ts`.
+4. Update this doc.
+
+Missing keys gracefully fall back to English; you can ship a partial file
+and fill it in over time.

--- a/src/components/pathways/FacilitatorDashboard.tsx
+++ b/src/components/pathways/FacilitatorDashboard.tsx
@@ -1,10 +1,23 @@
 /**
  * Facilitator Dashboard — simplified for non-technical program staff.
  * Answers three questions: Who needs attention? How is the cohort doing? What do I do next?
+ * i18n + light/dark.
  */
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Users, CheckCircle2, AlertTriangle, XCircle, Download, ChevronRight, ArrowLeft, StickyNote, RefreshCw, BookOpen } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  Users,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Download,
+  ChevronRight,
+  ArrowLeft,
+  StickyNote,
+  RefreshCw,
+  BookOpen,
+} from "lucide-react";
 
 const NOTES_STORAGE_KEY = "brightboost.pathways.facilitator.notes";
 
@@ -23,16 +36,11 @@ function persistNotes(notes: Record<string, string>): void {
     if (typeof window === "undefined" || !window.localStorage) return;
     window.localStorage.setItem(NOTES_STORAGE_KEY, JSON.stringify(notes));
   } catch {
-    // localStorage unavailable — notes will not persist across sessions
+    /* localStorage unavailable — notes will not persist across sessions */
   }
 }
 
-const BAND_LABELS: Record<string, string> = {
-  explorer: "Explorer (14–15)",
-  launch: "Launch (16–17)",
-};
-
-const TOTAL_MODULES = 7; // Cyber Launch has 7 modules
+const TOTAL_MODULES = 7;
 
 type Learner = {
   id: string;
@@ -44,21 +52,34 @@ type Learner = {
   milestones: any[];
 };
 
-function getStatus(learner: Learner): { label: string; icon: React.ReactNode; color: string } {
-  if (learner.completedCount === 0 && !learner.lastActive) {
-    return { label: "Not Started", icon: <XCircle className="w-4 h-4" />, color: "text-red-400" };
-  }
-  // "Needs check-in" if no activity in 5+ days
+type StatusKey = "onTrack" | "needsCheckIn" | "notStarted";
+
+function getStatusKey(learner: Learner): StatusKey {
+  if (learner.completedCount === 0 && !learner.lastActive) return "notStarted";
   if (learner.lastActive) {
     const daysSince = Math.floor((Date.now() - new Date(learner.lastActive).getTime()) / 86400000);
-    if (daysSince >= 5) {
-      return { label: "Needs Check-In", icon: <AlertTriangle className="w-4 h-4" />, color: "text-amber-400" };
-    }
+    if (daysSince >= 5) return "needsCheckIn";
   }
-  return { label: "On Track", icon: <CheckCircle2 className="w-4 h-4" />, color: "text-emerald-400" };
+  return "onTrack";
 }
 
+const STATUS_PRESENT = {
+  onTrack: {
+    icon: <CheckCircle2 className="w-4 h-4" />,
+    color: "text-emerald-700 dark:text-emerald-400",
+  },
+  needsCheckIn: {
+    icon: <AlertTriangle className="w-4 h-4" />,
+    color: "text-amber-700 dark:text-amber-400",
+  },
+  notStarted: {
+    icon: <XCircle className="w-4 h-4" />,
+    color: "text-red-700 dark:text-red-400",
+  },
+} as const;
+
 export default function FacilitatorDashboard() {
+  const { t } = useTranslation();
   const [cohorts, setCohorts] = useState<any[]>([]);
   const [selectedCohort, setSelectedCohort] = useState<any>(null);
   const [progress, setProgress] = useState<any>(null);
@@ -98,8 +119,17 @@ export default function FacilitatorDashboard() {
       setSelectedCohort(cohortRes);
       setProgress(progressRes);
       setSelectedLearner(null);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   };
+
+  const bandLabel = (band: string | null) =>
+    band === "explorer"
+      ? t("pathways.facilitator.band.explorer")
+      : band === "launch"
+        ? t("pathways.facilitator.band.launch")
+        : "—";
 
   const exportProgress = () => {
     if (!selectedCohort || !learners.length) return;
@@ -107,11 +137,11 @@ export default function FacilitatorDashboard() {
       ["Name", "Band", "Modules Completed", "Out of", "Status", "Last Active"],
       ...learners.map((l) => [
         l.name,
-        BAND_LABELS[l.ageBand ?? ""] ?? l.ageBand ?? "—",
+        bandLabel(l.ageBand),
         String(l.completedCount),
         String(TOTAL_MODULES),
-        getStatus(l).label,
-        l.lastActive ? new Date(l.lastActive).toLocaleDateString() : "Not yet",
+        t(`pathways.facilitator.status.${getStatusKey(l)}`),
+        l.lastActive ? new Date(l.lastActive).toLocaleDateString() : "—",
       ]),
     ];
     const csv = rows.map((r) => r.map((c) => `"${c}"`).join(",")).join("\n");
@@ -125,80 +155,123 @@ export default function FacilitatorDashboard() {
   };
 
   if (loading) {
-    return <div className="text-center py-20 text-slate-400">Loading your dashboard...</div>;
+    return (
+      <div className="text-center py-20 text-slate-600 dark:text-slate-400">
+        {t("pathways.facilitator.loading")}
+      </div>
+    );
   }
 
   if (cohorts.length === 0) {
     return (
       <div className="text-center py-20 space-y-4">
-        <Users className="w-12 h-12 text-slate-600 mx-auto" />
-        <h2 className="text-xl font-bold text-slate-200">No Groups Yet</h2>
-        <p className="text-slate-400 text-sm">Create a cohort to start tracking learner progress.</p>
+        <Users className="w-12 h-12 text-slate-400 dark:text-slate-600 mx-auto" />
+        <h2 className="text-xl font-bold text-slate-900 dark:text-slate-200">
+          {t("pathways.facilitator.noGroups")}
+        </h2>
+        <p className="text-slate-600 dark:text-slate-400 text-sm">
+          {t("pathways.facilitator.noGroupsDesc")}
+        </p>
       </div>
     );
   }
 
   const learners: Learner[] = progress?.learners ?? [];
-  const onTrack = learners.filter((l) => getStatus(l).label === "On Track").length;
-  const needsCheckIn = learners.filter((l) => getStatus(l).label === "Needs Check-In").length;
-  const notStarted = learners.filter((l) => getStatus(l).label === "Not Started").length;
+  const onTrack = learners.filter((l) => getStatusKey(l) === "onTrack").length;
+  const needsCheckIn = learners.filter((l) => getStatusKey(l) === "needsCheckIn").length;
+  const notStarted = learners.filter((l) => getStatusKey(l) === "notStarted").length;
 
   // ── Learner Detail View ──
   if (selectedLearner) {
-    const status = getStatus(selectedLearner);
-    const moduleNames = ["Cyber Foundations", "Digital Safety Sim", "Network Basics", "Threat Detective", "Cyber Career Map", "Cisco NetAcad", "Capstone: Security Plan"];
-    const moduleStatuses = moduleNames.map((name, i) => {
-      const slugs = ["cyber-foundations", "digital-safety-sim", "network-basics", "threat-detective", "career-map", "cisco-netacad-link", "capstone-security-plan"];
-      const m = selectedLearner.milestones?.find((ms: any) => ms.moduleSlug === slugs[i]);
-      return { name, status: m?.status ?? "not_started", score: m?.score };
+    const statusKey = getStatusKey(selectedLearner);
+    const statusPresent = STATUS_PRESENT[statusKey];
+    const slugs = [
+      "cyber-foundations",
+      "digital-safety-sim",
+      "network-basics",
+      "threat-detective",
+      "career-map",
+      "cisco-netacad-link",
+      "capstone-security-plan",
+    ];
+    const moduleStatuses = slugs.map((slug, i) => {
+      const m = selectedLearner.milestones?.find((ms: any) => ms.moduleSlug === slug);
+      return {
+        name: t(`pathways.tracks.modules.${slug}.name`),
+        status: m?.status ?? "not_started",
+        score: m?.score,
+        idx: i,
+      };
     });
 
     return (
       <div className="space-y-6">
-        <button onClick={() => setSelectedLearner(null)} className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200">
-          <ArrowLeft className="w-4 h-4" /> Back to roster
+        <button
+          onClick={() => setSelectedLearner(null)}
+          className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          <ArrowLeft className="w-4 h-4" /> {t("pathways.facilitator.backToRoster")}
         </button>
 
-        <div className="rounded-2xl border border-slate-700 bg-slate-800/80 p-6">
+        <div className="rounded-2xl border bg-white border-slate-200 dark:bg-slate-800/80 dark:border-slate-700 p-6 shadow-sm">
           <div className="flex items-center justify-between">
             <div>
-              <h2 className="text-xl font-bold text-slate-100">{selectedLearner.name}</h2>
-              <p className="text-sm text-slate-400">
-                {BAND_LABELS[selectedLearner.ageBand ?? ""] ?? "—"}
+              <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{selectedLearner.name}</h2>
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                {bandLabel(selectedLearner.ageBand)}
                 {" • "}
-                {selectedLearner.completedCount} of {TOTAL_MODULES} modules completed
+                {t("pathways.facilitator.modulesCompletedFmt", {
+                  done: selectedLearner.completedCount,
+                  total: TOTAL_MODULES,
+                })}
               </p>
             </div>
-            <span className={`flex items-center gap-1.5 text-sm font-medium ${status.color}`}>
-              {status.icon} {status.label}
+            <span className={`flex items-center gap-1.5 text-sm font-medium ${statusPresent.color}`}>
+              {statusPresent.icon} {t(`pathways.facilitator.status.${statusKey}`)}
             </span>
           </div>
         </div>
 
         {/* Module Progress */}
-        <div className="rounded-2xl border border-slate-700 bg-slate-800/50 overflow-hidden">
-          <div className="p-4 border-b border-slate-700">
-            <h3 className="font-semibold text-slate-200">Module Progress</h3>
+        <div className="rounded-2xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 overflow-hidden shadow-sm">
+          <div className="p-4 border-b border-slate-200 dark:border-slate-700">
+            <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+              {t("pathways.facilitator.moduleProgress")}
+            </h3>
           </div>
-          <div className="divide-y divide-slate-700/50">
-            {moduleStatuses.map((m, i) => (
-              <div key={i} className="flex items-center gap-3 px-4 py-3">
-                <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
-                  m.status === "completed" ? "bg-emerald-600 text-white" :
-                  m.status === "in_progress" ? "bg-indigo-600 text-white" :
-                  "bg-slate-700 text-slate-400"
-                }`}>
-                  {m.status === "completed" ? "✓" : i + 1}
+          <div className="divide-y divide-slate-200 dark:divide-slate-700/50">
+            {moduleStatuses.map((m) => (
+              <div key={m.idx} className="flex items-center gap-3 px-4 py-3">
+                <div
+                  className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
+                    m.status === "completed"
+                      ? "bg-emerald-600 text-white"
+                      : m.status === "in_progress"
+                        ? "bg-indigo-600 text-white"
+                        : "bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-400"
+                  }`}
+                >
+                  {m.status === "completed" ? "✓" : m.idx + 1}
                 </div>
                 <div className="flex-1">
-                  <p className="text-sm text-slate-200">{m.name}</p>
+                  <p className="text-sm text-slate-800 dark:text-slate-200">{m.name}</p>
                 </div>
-                <span className={`text-xs capitalize ${
-                  m.status === "completed" ? "text-emerald-400" :
-                  m.status === "in_progress" ? "text-indigo-400" :
-                  "text-slate-500"
-                }`}>
-                  {m.status === "not_started" ? "Not started" : m.status === "in_progress" ? "In progress" : `Done${m.score ? ` (${m.score}%)` : ""}`}
+                <span
+                  className={`text-xs ${
+                    m.status === "completed"
+                      ? "text-emerald-700 dark:text-emerald-400"
+                      : m.status === "in_progress"
+                        ? "text-indigo-700 dark:text-indigo-400"
+                        : "text-slate-500"
+                  }`}
+                >
+                  {m.status === "not_started"
+                    ? t("pathways.facilitator.module.notStarted")
+                    : m.status === "in_progress"
+                      ? t("pathways.facilitator.module.inProgress")
+                      : m.score
+                        ? t("pathways.facilitator.module.doneScoreFmt", { score: m.score })
+                        : t("pathways.facilitator.module.done")}
                 </span>
               </div>
             ))}
@@ -206,18 +279,22 @@ export default function FacilitatorDashboard() {
         </div>
 
         {/* Facilitator Notes */}
-        <div className="rounded-2xl border border-slate-700 bg-slate-800/50 p-4">
+        <div className="rounded-2xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 p-4 shadow-sm">
           <div className="flex items-center gap-2 mb-3">
-            <StickyNote className="w-4 h-4 text-slate-400" />
-            <h3 className="font-semibold text-slate-200 text-sm">Your Notes</h3>
+            <StickyNote className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+            <h3 className="font-semibold text-slate-900 dark:text-slate-200 text-sm">
+              {t("pathways.facilitator.notes.title")}
+            </h3>
           </div>
           <textarea
             value={notes[selectedLearner.id] ?? ""}
             onChange={(e) => updateNote(selectedLearner.id, e.target.value)}
-            placeholder="Add a private note about this learner..."
-            className="w-full bg-slate-900/50 border border-slate-700 rounded-lg p-3 text-sm text-slate-200 placeholder-slate-500 resize-none h-24 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            placeholder={t("pathways.facilitator.notes.placeholder")}
+            className="w-full bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-700 rounded-lg p-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 resize-none h-24 focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
           />
-          <p className="text-[10px] text-slate-600 mt-1">Notes are saved locally in this browser. Server-side persistence is on the roadmap.</p>
+          <p className="text-[10px] text-slate-500 dark:text-slate-600 mt-1">
+            {t("pathways.facilitator.notes.disclaimer")}
+          </p>
         </div>
       </div>
     );
@@ -227,36 +304,43 @@ export default function FacilitatorDashboard() {
   return (
     <div className="space-y-6">
       {/* Cohort Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
-          <h1 className="text-xl font-bold text-slate-100">
-            {selectedCohort?.name ?? "Your Cohort"}
+          <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+            {selectedCohort?.name ?? t("pathways.facilitator.yourCohort")}
           </h1>
-          <p className="text-sm text-slate-400 mt-0.5">
-            {learners.length} learners enrolled
+          <p className="text-sm text-slate-600 dark:text-slate-400 mt-0.5">
+            {t("pathways.facilitator.learnersEnrolled", { count: learners.length })}
             {selectedCohort?.sitePartner && ` • ${selectedCohort.sitePartner}`}
           </p>
         </div>
         <div className="flex items-center gap-2">
           {cohorts.length > 1 && (
             <select
-              className="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2"
+              className="bg-white border border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 text-sm rounded-lg px-3 py-2"
               value={selectedCohort?.id}
               onChange={(e) => loadCohort(e.target.value)}
             >
               {cohorts.map((c: any) => (
-                <option key={c.id} value={c.id}>{c.name}</option>
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
               ))}
             </select>
           )}
           <Link
             to="/pathways/facilitator/resources"
-            className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-slate-300 text-sm hover:bg-slate-700 transition-colors"
-            title="Program overview, session guide, printables"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-700 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700 text-sm transition-colors"
+            title={t("pathways.facilitator.resourcesTitle")}
           >
-            <BookOpen className="w-4 h-4" /> Resources
+            <BookOpen className="w-4 h-4" /> {t("pathways.layout.nav.resources")}
           </Link>
-          <button onClick={() => loadCohort(selectedCohort?.id)} className="p-2 rounded-lg bg-slate-800 border border-slate-700 text-slate-400 hover:text-slate-200" title="Refresh">
+          <button
+            onClick={() => loadCohort(selectedCohort?.id)}
+            className="p-2 rounded-lg border bg-white border-slate-200 text-slate-600 hover:text-slate-900 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+            title={t("pathways.common.refresh")}
+            aria-label={t("pathways.common.refresh")}
+          >
             <RefreshCw className="w-4 h-4" />
           </button>
         </div>
@@ -264,52 +348,81 @@ export default function FacilitatorDashboard() {
 
       {/* Join Code */}
       {selectedCohort?.joinCode && (
-        <div className="flex items-center gap-3 p-3 rounded-xl bg-indigo-900/20 border border-indigo-800/30">
-          <span className="text-xs text-indigo-300">Join code for new learners:</span>
-          <span className="font-mono font-bold text-indigo-400 text-lg tracking-wider">{selectedCohort.joinCode}</span>
+        <div className="flex items-center gap-3 p-3 rounded-xl border bg-indigo-50 border-indigo-200 dark:bg-indigo-900/20 dark:border-indigo-800/30">
+          <span className="text-xs text-indigo-800 dark:text-indigo-300">
+            {t("pathways.facilitator.joinCodeLabel")}
+          </span>
+          <span className="font-mono font-bold text-indigo-700 dark:text-indigo-400 text-lg tracking-wider">
+            {selectedCohort.joinCode}
+          </span>
         </div>
       )}
 
       {/* Status Summary */}
       <div className="grid grid-cols-3 gap-3">
-        <StatusCard icon={<CheckCircle2 className="w-5 h-5" />} label="On Track" count={onTrack} color="text-emerald-400 bg-emerald-900/20 border-emerald-800/30" />
-        <StatusCard icon={<AlertTriangle className="w-5 h-5" />} label="Needs Check-In" count={needsCheckIn} color="text-amber-400 bg-amber-900/20 border-amber-800/30" />
-        <StatusCard icon={<XCircle className="w-5 h-5" />} label="Not Started" count={notStarted} color="text-red-400 bg-red-900/20 border-red-800/30" />
+        <StatusCard
+          icon={<CheckCircle2 className="w-5 h-5" />}
+          label={t("pathways.facilitator.status.onTrack")}
+          count={onTrack}
+          color="text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-400 dark:bg-emerald-900/20 dark:border-emerald-800/30"
+        />
+        <StatusCard
+          icon={<AlertTriangle className="w-5 h-5" />}
+          label={t("pathways.facilitator.status.needsCheckIn")}
+          count={needsCheckIn}
+          color="text-amber-700 bg-amber-50 border-amber-200 dark:text-amber-400 dark:bg-amber-900/20 dark:border-amber-800/30"
+        />
+        <StatusCard
+          icon={<XCircle className="w-5 h-5" />}
+          label={t("pathways.facilitator.status.notStarted")}
+          count={notStarted}
+          color="text-red-700 bg-red-50 border-red-200 dark:text-red-400 dark:bg-red-900/20 dark:border-red-800/30"
+        />
       </div>
 
       {/* Learner List */}
-      <div className="rounded-2xl border border-slate-700 bg-slate-800/50 overflow-hidden">
-        <div className="flex items-center justify-between p-4 border-b border-slate-700">
-          <h3 className="font-semibold text-slate-200">Learners</h3>
-          <button onClick={exportProgress} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-700 text-slate-300 text-xs hover:bg-slate-600 transition-colors">
-            <Download className="w-3 h-3" /> Export CSV
+      <div className="rounded-2xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 overflow-hidden shadow-sm">
+        <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.learnersHeading")}
+          </h3>
+          <button
+            onClick={exportProgress}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-300 dark:hover:bg-slate-600 text-xs transition-colors"
+          >
+            <Download className="w-3 h-3" /> {t("pathways.common.exportCsv")}
           </button>
         </div>
 
-        <div className="divide-y divide-slate-700/50">
+        <div className="divide-y divide-slate-200 dark:divide-slate-700/50">
           {learners.map((l: Learner) => {
-            const status = getStatus(l);
+            const sk = getStatusKey(l);
+            const sp = STATUS_PRESENT[sk];
             return (
               <button
                 key={l.id}
                 onClick={() => setSelectedLearner(l)}
-                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-slate-800/50 transition-colors text-left"
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors text-left"
               >
-                <span className={`${status.color}`}>{status.icon}</span>
+                <span className={sp.color}>{sp.icon}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-slate-200">{l.name}</p>
-                  <p className="text-xs text-slate-500">
-                    {BAND_LABELS[l.ageBand ?? ""] ?? "—"} • {l.completedCount}/{TOTAL_MODULES} modules
-                    {l.lastActive && ` • Active ${new Date(l.lastActive).toLocaleDateString()}`}
+                  <p className="text-sm font-medium text-slate-800 dark:text-slate-200">{l.name}</p>
+                  <p className="text-xs text-slate-600 dark:text-slate-500">
+                    {bandLabel(l.ageBand)} •{" "}
+                    {t("pathways.facilitator.modulesCompletedFmt", {
+                      done: l.completedCount,
+                      total: TOTAL_MODULES,
+                    })}
+                    {l.lastActive && ` • ${new Date(l.lastActive).toLocaleDateString()}`}
                   </p>
                 </div>
-                <ChevronRight className="w-4 h-4 text-slate-600" />
+                <ChevronRight className="w-4 h-4 text-slate-400 dark:text-slate-600" />
               </button>
             );
           })}
           {learners.length === 0 && (
             <div className="px-4 py-8 text-center text-slate-500 text-sm">
-              No learners enrolled yet. Share the join code above.
+              {t("pathways.facilitator.noLearners")}
             </div>
           )}
         </div>
@@ -318,12 +431,22 @@ export default function FacilitatorDashboard() {
   );
 }
 
-function StatusCard({ icon, label, count, color }: { icon: React.ReactNode; label: string; count: number; color: string }) {
+function StatusCard({
+  icon,
+  label,
+  count,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+  color: string;
+}) {
   return (
     <div className={`flex items-center gap-3 p-4 rounded-xl border ${color}`}>
       {icon}
       <div>
-        <p className="text-2xl font-bold text-white">{count}</p>
+        <p className="text-2xl font-bold">{count}</p>
         <p className="text-xs">{label}</p>
       </div>
     </div>

--- a/src/components/pathways/ModulePlayer.tsx
+++ b/src/components/pathways/ModulePlayer.tsx
@@ -1,43 +1,54 @@
 /**
  * Module Player — wrapper that loads and renders a Cyber Launch module.
- * Handles progress saving and completion callbacks.
+ * Handles progress saving and completion callbacks. i18n + light/dark.
  */
 import { useState, useCallback, useEffect, lazy, Suspense } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { getTrackBySlug } from "@/constants/pathwayTracks";
 import { ArrowLeft } from "lucide-react";
 
-// Lazy-load the module components
 const CyberLaunchModules = lazy(() => import("./modules/CyberLaunchModules"));
 
 export default function ModulePlayer() {
   const { trackSlug, moduleSlug } = useParams();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const track = getTrackBySlug(trackSlug ?? "");
   const mod = track?.modules.find((m) => m.slug === moduleSlug);
   const [completed, setCompleted] = useState(false);
 
-  // Mark as in_progress on mount
   useEffect(() => {
     if (trackSlug && moduleSlug) {
       fetch("/api/pathways/student/milestones", {
         method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${localStorage.getItem("token")}` },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
         body: JSON.stringify({ trackSlug, moduleSlug, status: "in_progress" }),
       }).catch(() => {});
     }
   }, [trackSlug, moduleSlug]);
 
-  const handleComplete = useCallback(async (score: number) => {
-    try {
-      await fetch("/api/pathways/student/milestones", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${localStorage.getItem("token")}` },
-        body: JSON.stringify({ trackSlug, moduleSlug, status: "completed", score }),
-      });
-    } catch { /* ignore */ }
-    setCompleted(true);
-  }, [trackSlug, moduleSlug]);
+  const handleComplete = useCallback(
+    async (score: number) => {
+      try {
+        await fetch("/api/pathways/student/milestones", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+          body: JSON.stringify({ trackSlug, moduleSlug, status: "completed", score }),
+        });
+      } catch {
+        /* ignore */
+      }
+      setCompleted(true);
+    },
+    [trackSlug, moduleSlug],
+  );
 
   const handleBack = useCallback(() => {
     navigate(`/pathways/tracks/${trackSlug}`);
@@ -46,20 +57,35 @@ export default function ModulePlayer() {
   if (!track || !mod) {
     return (
       <div className="text-center py-20">
-        <p className="text-slate-400">Module not found.</p>
-        <button onClick={() => navigate("/pathways/tracks")} className="mt-4 text-indigo-400 text-sm">Back to Tracks</button>
+        <p className="text-slate-600 dark:text-slate-400">{t("pathways.modulePlayer.notFound")}</p>
+        <button
+          onClick={() => navigate("/pathways/tracks")}
+          className="mt-4 text-indigo-700 dark:text-indigo-400 text-sm"
+        >
+          {t("pathways.modulePlayer.backToTracks")}
+        </button>
       </div>
     );
   }
+
+  const trackName = t(`pathways.tracks.items.${track.slug}.name`, track.name);
+  const modName = t(`pathways.tracks.modules.${mod.slug}.name`, mod.name);
 
   if (completed) {
     return (
       <div className="text-center py-20 space-y-4">
         <div className="text-5xl">✅</div>
-        <h2 className="text-2xl font-bold text-slate-100">Module Complete</h2>
-        <p className="text-slate-400">{mod.name} — finished!</p>
-        <button onClick={handleBack} className="px-6 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors">
-          Back to Track
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.modulePlayer.moduleComplete")}
+        </h2>
+        <p className="text-slate-600 dark:text-slate-400">
+          {t("pathways.modulePlayer.finishedFmt", { moduleName: modName })}
+        </p>
+        <button
+          onClick={handleBack}
+          className="px-6 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors"
+        >
+          {t("pathways.modulePlayer.backToTrackCta")}
         </button>
       </div>
     );
@@ -67,11 +93,20 @@ export default function ModulePlayer() {
 
   return (
     <div className="space-y-4">
-      <button onClick={handleBack} className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200">
-        <ArrowLeft className="w-4 h-4" /> Back to {track.name}
+      <button
+        onClick={handleBack}
+        className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        <ArrowLeft className="w-4 h-4" /> {t("pathways.modulePlayer.backToTrack", { trackName })}
       </button>
 
-      <Suspense fallback={<div className="text-center py-20 text-slate-400">Loading module...</div>}>
+      <Suspense
+        fallback={
+          <div className="text-center py-20 text-slate-600 dark:text-slate-400">
+            {t("pathways.modulePlayer.loading")}
+          </div>
+        }
+      >
         <CyberLaunchModules moduleSlug={moduleSlug ?? ""} onComplete={handleComplete} onBack={handleBack} />
       </Suspense>
     </div>

--- a/src/components/pathways/PathwaysAbout.tsx
+++ b/src/components/pathways/PathwaysAbout.tsx
@@ -1,9 +1,32 @@
 /**
  * Pathways About — public landing page for the Pathways program.
+ *
+ * Theme: standalone page (no PathwaysLayout wrapper). Reads the same
+ * `bb_pathways_theme` localStorage key the layout writes, so partners
+ * coming from the authenticated app see consistent theming.
+ *
+ * i18n: every visible string keyed under `pathways.about.*`.
  */
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
-import { Shield, Rocket, DollarSign, Cpu, Film, Users, BarChart3, Award, ArrowRight, Briefcase, FileText, Target } from "lucide-react";
+import {
+  Shield,
+  Rocket,
+  DollarSign,
+  Cpu,
+  Film,
+  Users,
+  BarChart3,
+  Award,
+  ArrowRight,
+  Briefcase,
+  FileText,
+  Target,
+  Moon,
+  Sun,
+} from "lucide-react";
 import LanguageToggle from "@/components/LanguageToggle";
 
 const ICONS: Record<string, React.ReactNode> = {
@@ -14,137 +37,250 @@ const ICONS: Record<string, React.ReactNode> = {
   Film: <Film className="w-6 h-6" />,
 };
 
+const THEME_KEY = "bb_pathways_theme";
+
+function readStoredTheme(): "dark" | "light" {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
 export default function PathwaysAbout() {
+  const { t } = useTranslation();
+  const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
+  const isDark = theme === "dark";
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, [theme]);
+
+  const fundingItems = t("pathways.about.partners.funding", { returnObjects: true }) as string[];
+
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      {/* Language toggle — top-right, always visible */}
-      <div className="absolute top-4 right-4 z-20">
-        <LanguageToggle variant="dark" />
+    <div className={`${isDark ? "dark" : ""} min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100`}>
+      {/* Top controls — language + theme */}
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-3">
+        <LanguageToggle variant={isDark ? "dark" : "light"} />
+        <button
+          onClick={() => setTheme(isDark ? "light" : "dark")}
+          aria-label={isDark ? t("pathways.common.lightMode") : t("pathways.common.darkMode")}
+          className="p-2 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:hover:bg-slate-700 dark:text-slate-300"
+        >
+          {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+        </button>
       </div>
+
       {/* Hero */}
       <div className="relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-indigo-900/50 to-cyan-900/30" />
+        <div className="absolute inset-0 bg-gradient-to-br from-indigo-50 to-cyan-50 dark:from-indigo-900/50 dark:to-cyan-900/30" />
         <div className="relative max-w-5xl mx-auto px-6 py-20 text-center">
-          <p className="text-xs uppercase tracking-[0.3em] text-indigo-300 font-medium mb-4">Bright Boost</p>
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-indigo-400 to-cyan-400 bg-clip-text text-transparent">Pathways</span>
-          </h1>
-          <p className="text-xl text-slate-300 max-w-2xl mx-auto mb-2">Real pathways for real futures.</p>
-          <p className="text-slate-400 max-w-xl mx-auto mb-2">
-            Career-connected learning for opportunity and justice-impacted youth ages 14-17.
+          <p className="text-xs uppercase tracking-[0.3em] text-indigo-700 dark:text-indigo-300 font-medium mb-4">
+            {t("pathways.about.hero.eyebrow")}
           </p>
-          <p className="text-slate-400 max-w-xl mx-auto mb-6">
-            Cybersecurity, entrepreneurship, financial literacy, tech, and creative media — delivered through cohort-based programs with facilitator support.
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">
+            <span className="bg-gradient-to-r from-indigo-600 to-cyan-600 dark:from-indigo-400 dark:to-cyan-400 bg-clip-text text-transparent">
+              {t("pathways.layout.brand")}
+            </span>
+          </h1>
+          <p className="text-xl text-slate-800 dark:text-slate-300 max-w-2xl mx-auto mb-2">
+            {t("pathways.about.hero.tagline")}
+          </p>
+          <p className="text-slate-700 dark:text-slate-400 max-w-xl mx-auto mb-2">
+            {t("pathways.about.hero.sub1")}
+          </p>
+          <p className="text-slate-700 dark:text-slate-400 max-w-xl mx-auto mb-6">
+            {t("pathways.about.hero.sub2")}
           </p>
           <Link
             to="/student-login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg transition-colors"
           >
-            Log In or Join <ArrowRight className="w-4 h-4" />
+            {t("pathways.common.logInOrJoin")} <ArrowRight className="w-4 h-4" />
           </Link>
         </div>
       </div>
 
       {/* Tracks */}
       <div className="max-w-5xl mx-auto px-6 py-16">
-        <h2 className="text-2xl font-bold text-center mb-2">Five Tracks. Your Choice.</h2>
-        <p className="text-sm text-slate-400 text-center mb-10">Each track builds real skills and connects to real careers.</p>
+        <h2 className="text-2xl font-bold text-center mb-2 text-slate-900 dark:text-slate-100">
+          {t("pathways.about.tracksSection.title")}
+        </h2>
+        <p className="text-sm text-slate-700 dark:text-slate-400 text-center mb-10">
+          {t("pathways.about.tracksSection.sub")}
+        </p>
 
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {PATHWAY_TRACKS.map((track) => (
-            <div key={track.slug} className="rounded-xl border border-slate-800 bg-slate-900/50 p-5">
-              <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-3" style={{ backgroundColor: track.color + "15", color: track.color }}>
-                {ICONS[track.icon]}
+          {PATHWAY_TRACKS.map((track) => {
+            const name = t(`pathways.tracks.items.${track.slug}.name`, track.name);
+            const tagline = t(`pathways.tracks.items.${track.slug}.tagline`, track.tagline);
+            return (
+              <div
+                key={track.slug}
+                className="rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/50 p-5 shadow-sm"
+              >
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-3"
+                  style={{ backgroundColor: track.color + "15", color: track.color }}
+                >
+                  {ICONS[track.icon]}
+                </div>
+                <h3 className="font-semibold text-slate-900 dark:text-slate-100 mb-1">{name}</h3>
+                <p className="text-xs text-slate-700 dark:text-slate-400 mb-2">{tagline}</p>
+                <div className="flex gap-1">
+                  {track.bands.map((b) => (
+                    <span
+                      key={b}
+                      className="text-[9px] px-1.5 py-0.5 rounded bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-400 capitalize"
+                    >
+                      {b}
+                    </span>
+                  ))}
+                </div>
               </div>
-              <h3 className="font-semibold text-slate-100 mb-1">{track.name}</h3>
-              <p className="text-xs text-slate-400 mb-2">{track.tagline}</p>
-              <div className="flex gap-1">
-                {track.bands.map((b) => (
-                  <span key={b} className="text-[9px] px-1.5 py-0.5 rounded bg-slate-800 text-slate-400 capitalize">{b}</span>
-                ))}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
 
       {/* Bands */}
-      <div className="bg-slate-900/50 border-y border-slate-800">
+      <div className="bg-slate-50 dark:bg-slate-900/50 border-y border-slate-200 dark:border-slate-800">
         <div className="max-w-5xl mx-auto px-6 py-16 grid md:grid-cols-2 gap-8">
-          <div className="p-6 rounded-xl border border-indigo-800/30 bg-indigo-900/10">
-            <h3 className="font-bold text-lg text-indigo-300 mb-2">Explorer Band (Ages 14-15)</h3>
-            <p className="text-sm text-slate-400">Foundation skills, exposure, and discovery. Build confidence with hands-on activities and find what excites you.</p>
+          <div className="p-6 rounded-xl border border-indigo-200 bg-indigo-50 dark:border-indigo-800/30 dark:bg-indigo-900/10">
+            <h3 className="font-bold text-lg text-indigo-700 dark:text-indigo-300 mb-2">
+              {t("pathways.about.bands.explorerTitle")}
+            </h3>
+            <p className="text-sm text-slate-700 dark:text-slate-400">
+              {t("pathways.about.bands.explorerDesc")}
+            </p>
           </div>
-          <div className="p-6 rounded-xl border border-cyan-800/30 bg-cyan-900/10">
-            <h3 className="font-bold text-lg text-cyan-300 mb-2">Launch Band (Ages 16-17)</h3>
-            <p className="text-sm text-slate-400">Credential prep, portfolio building, and career planning. Get ready for what comes next — college, certification, or career.</p>
+          <div className="p-6 rounded-xl border border-cyan-200 bg-cyan-50 dark:border-cyan-800/30 dark:bg-cyan-900/10">
+            <h3 className="font-bold text-lg text-cyan-700 dark:text-cyan-300 mb-2">
+              {t("pathways.about.bands.launchTitle")}
+            </h3>
+            <p className="text-sm text-slate-700 dark:text-slate-400">
+              {t("pathways.about.bands.launchDesc")}
+            </p>
           </div>
         </div>
       </div>
 
       {/* What Outcomes Look Like */}
       <div className="max-w-5xl mx-auto px-6 py-16">
-        <h2 className="text-2xl font-bold text-center mb-2">What Outcomes Look Like</h2>
-        <p className="text-sm text-slate-400 text-center mb-10">Each learner leaves the program with concrete artifacts and a next-step plan, not just attendance.</p>
+        <h2 className="text-2xl font-bold text-center mb-2 text-slate-900 dark:text-slate-100">
+          {t("pathways.about.outcomes.title")}
+        </h2>
+        <p className="text-sm text-slate-700 dark:text-slate-400 text-center mb-10">
+          {t("pathways.about.outcomes.sub")}
+        </p>
 
         <div className="grid md:grid-cols-3 gap-6">
-          <Feature icon={<FileText className="w-5 h-5" />} title="Portfolio Artifacts" desc="Capstone security plan, career interest profile, and module completion records — concrete proof of skill." />
-          <Feature icon={<Award className="w-5 h-5" />} title="Certification Prep" desc="Direct on-ramps to Cisco NetAcad, ISC2 Certified in Cybersecurity (CC), and CompTIA Security+." />
-          <Feature icon={<Target className="w-5 h-5" />} title="Next-Step Plan" desc="Every learner ends with a concrete next action: a cert to pursue, an internship to apply for, or a credential pathway." />
+          <Feature
+            icon={<FileText className="w-5 h-5" />}
+            title={t("pathways.about.outcomes.portfolioTitle")}
+            desc={t("pathways.about.outcomes.portfolioDesc")}
+          />
+          <Feature
+            icon={<Award className="w-5 h-5" />}
+            title={t("pathways.about.outcomes.certTitle")}
+            desc={t("pathways.about.outcomes.certDesc")}
+          />
+          <Feature
+            icon={<Target className="w-5 h-5" />}
+            title={t("pathways.about.outcomes.nextStepTitle")}
+            desc={t("pathways.about.outcomes.nextStepDesc")}
+          />
         </div>
       </div>
 
       {/* Delivery Models */}
-      <div className="bg-slate-900/50 border-y border-slate-800">
+      <div className="bg-slate-50 dark:bg-slate-900/50 border-y border-slate-200 dark:border-slate-800">
         <div className="max-w-5xl mx-auto px-6 py-16">
-          <h2 className="text-2xl font-bold text-center mb-2">Delivery Models</h2>
-          <p className="text-sm text-slate-400 text-center mb-10">Built to fit how your program actually runs.</p>
+          <h2 className="text-2xl font-bold text-center mb-2 text-slate-900 dark:text-slate-100">
+            {t("pathways.about.delivery.title")}
+          </h2>
+          <p className="text-sm text-slate-700 dark:text-slate-400 text-center mb-10">
+            {t("pathways.about.delivery.sub")}
+          </p>
 
           <div className="grid md:grid-cols-3 gap-6">
-            <Feature icon={<Briefcase className="w-5 h-5" />} title="Site-Led" desc="Your staff facilitate using our curriculum, dashboard, and resources. We provide training and support." />
-            <Feature icon={<Users className="w-5 h-5" />} title="Hybrid" desc="Shared delivery — your staff lead in-person sessions, we run virtual deep-dives and credential coaching." />
-            <Feature icon={<Award className="w-5 h-5" />} title="Full-Service" desc="We staff the cohort end-to-end. You provide the space, recruitment, and on-site relationships." />
+            <Feature
+              icon={<Briefcase className="w-5 h-5" />}
+              title={t("pathways.about.delivery.siteLedTitle")}
+              desc={t("pathways.about.delivery.siteLedDesc")}
+            />
+            <Feature
+              icon={<Users className="w-5 h-5" />}
+              title={t("pathways.about.delivery.hybridTitle")}
+              desc={t("pathways.about.delivery.hybridDesc")}
+            />
+            <Feature
+              icon={<Award className="w-5 h-5" />}
+              title={t("pathways.about.delivery.fullServiceTitle")}
+              desc={t("pathways.about.delivery.fullServiceDesc")}
+            />
           </div>
         </div>
       </div>
 
       {/* For Partners */}
       <div className="max-w-5xl mx-auto px-6 py-16">
-        <h2 className="text-2xl font-bold text-center mb-2">For Program Partners</h2>
-        <p className="text-sm text-slate-400 text-center mb-10">Built for correctional education, workforce development, community-based organizations, and alternative schools.</p>
+        <h2 className="text-2xl font-bold text-center mb-2 text-slate-900 dark:text-slate-100">
+          {t("pathways.about.partners.title")}
+        </h2>
+        <p className="text-sm text-slate-700 dark:text-slate-400 text-center mb-10">
+          {t("pathways.about.partners.sub")}
+        </p>
 
         <div className="grid md:grid-cols-3 gap-6">
-          <Feature icon={<Users className="w-5 h-5" />} title="Cohort Delivery" desc="Create cohorts, assign tracks, and manage enrollment with join codes." />
-          <Feature icon={<BarChart3 className="w-5 h-5" />} title="Facilitator Dashboard" desc="Track learner progress, completion rates, and engagement in real time. Export CSVs for reporting." />
-          <Feature icon={<Award className="w-5 h-5" />} title="Credential Prep" desc="Cisco NetAcad integration, ISC2 CC pathway, and portfolio artifacts." />
+          <Feature
+            icon={<Users className="w-5 h-5" />}
+            title={t("pathways.about.partners.cohortTitle")}
+            desc={t("pathways.about.partners.cohortDesc")}
+          />
+          <Feature
+            icon={<BarChart3 className="w-5 h-5" />}
+            title={t("pathways.about.partners.dashTitle")}
+            desc={t("pathways.about.partners.dashDesc")}
+          />
+          <Feature
+            icon={<Award className="w-5 h-5" />}
+            title={t("pathways.about.partners.credTitle")}
+            desc={t("pathways.about.partners.credDesc")}
+          />
         </div>
 
-        <div className="mt-12 rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
-          <h3 className="font-semibold text-slate-200 mb-2">Funding Fit</h3>
-          <p className="text-sm text-slate-400 mb-3">Pathways content and delivery is designed to align with common youth-serving funding streams:</p>
-          <ul className="grid sm:grid-cols-2 gap-2 text-sm text-slate-300">
-            <li>· WIOA Youth (Title I)</li>
-            <li>· Reentry Employment Opportunities (REO)</li>
-            <li>· Illinois Youth Investment Program</li>
-            <li>· Reaching Youth, Delivering Success (RYDS)</li>
-            <li>· Perkins V / CTE Programs of Study</li>
-            <li>· Local workforce board contracts</li>
+        <div className="mt-12 rounded-2xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40 p-6 shadow-sm">
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200 mb-2">
+            {t("pathways.about.partners.fundingTitle")}
+          </h3>
+          <p className="text-sm text-slate-700 dark:text-slate-400 mb-3">
+            {t("pathways.about.partners.fundingIntro")}
+          </p>
+          <ul className="grid sm:grid-cols-2 gap-2 text-sm text-slate-800 dark:text-slate-300">
+            {fundingItems?.map((item, i) => <li key={i}>· {item}</li>)}
           </ul>
         </div>
 
         <div className="text-center mt-12">
           <a
             href="mailto:nwalker@brightbotsint.com?subject=Pathways%20Pilot%20Interest"
-            className="inline-flex items-center gap-2 px-8 py-3 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors"
+            className="inline-flex items-center gap-2 px-8 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg transition-colors"
           >
-            Request a Pilot <ArrowRight className="w-4 h-4" />
+            {t("pathways.common.requestPilot")} <ArrowRight className="w-4 h-4" />
           </a>
         </div>
       </div>
 
       {/* Footer */}
-      <div className="border-t border-slate-800 py-8 text-center text-xs text-slate-600">
-        Bright Boost Pathways — A program of Bright Bots Initiative
+      <div className="border-t border-slate-200 dark:border-slate-800 py-8 text-center text-xs text-slate-500 dark:text-slate-600">
+        {t("pathways.about.footer")}
       </div>
     </div>
   );
@@ -152,10 +288,10 @@ export default function PathwaysAbout() {
 
 function Feature({ icon, title, desc }: { icon: React.ReactNode; title: string; desc: string }) {
   return (
-    <div className="p-5 rounded-xl border border-slate-800 bg-slate-900/50">
-      <div className="text-indigo-400 mb-2">{icon}</div>
-      <h3 className="font-semibold text-slate-200 mb-1">{title}</h3>
-      <p className="text-xs text-slate-400">{desc}</p>
+    <div className="p-5 rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/50 shadow-sm">
+      <div className="text-indigo-700 dark:text-indigo-400 mb-2">{icon}</div>
+      <h3 className="font-semibold text-slate-900 dark:text-slate-200 mb-1">{title}</h3>
+      <p className="text-xs text-slate-700 dark:text-slate-400">{desc}</p>
     </div>
   );
 }

--- a/src/components/pathways/PathwaysHome.tsx
+++ b/src/components/pathways/PathwaysHome.tsx
@@ -1,13 +1,16 @@
 /**
  * Pathways Home — student landing page.
+ * i18n + light/dark mode aware (Tailwind `dark:` variants).
  */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
 import { Shield, Compass, ArrowRight, CheckCircle2 } from "lucide-react";
 
 export default function PathwaysHome() {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [homeData, setHomeData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
 
@@ -30,8 +33,8 @@ export default function PathwaysHome() {
   if (loading) {
     return (
       <div className="space-y-6 animate-pulse">
-        <div className="h-32 bg-slate-800 rounded-2xl" />
-        <div className="h-48 bg-slate-800 rounded-2xl" />
+        <div className="h-32 bg-slate-200 dark:bg-slate-800 rounded-2xl" />
+        <div className="h-48 bg-slate-200 dark:bg-slate-800 rounded-2xl" />
       </div>
     );
   }
@@ -42,10 +45,14 @@ export default function PathwaysHome() {
       <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-600 to-cyan-600 p-8">
         <div className="relative z-10">
           <p className="text-sm text-indigo-200 font-medium uppercase tracking-wider mb-2">
-            {band === "launch" ? "Launch Band" : "Explorer Band"}
+            {band === "launch"
+              ? t("pathways.home.launchEyebrow")
+              : t("pathways.home.explorerEyebrow")}
           </p>
           <h1 className="text-3xl font-bold text-white mb-2">
-            {band === "launch" ? "Build Your Launch Plan" : "Your Pathway Starts Here"}
+            {band === "launch"
+              ? t("pathways.home.launchTitle")
+              : t("pathways.home.explorerTitle")}
           </h1>
           {cohort && (
             <p className="text-indigo-100 text-sm">
@@ -60,38 +67,56 @@ export default function PathwaysHome() {
 
       {/* Quick Stats */}
       <div className="grid grid-cols-3 gap-4">
-        <StatCard label="Completed" value={completed} />
-        <StatCard label="In Progress" value={inProgress} />
-        <StatCard label="Streak" value={homeData?.user?.streak ?? 0} />
+        <StatCard label={t("pathways.home.stats.completed")} value={completed} />
+        <StatCard label={t("pathways.home.stats.inProgress")} value={inProgress} />
+        <StatCard label={t("pathways.home.stats.streak")} value={homeData?.user?.streak ?? 0} />
       </div>
 
       {/* Active Tracks */}
       <div>
-        <h2 className="text-lg font-semibold mb-4 text-slate-200">Your Tracks</h2>
+        <h2 className="text-lg font-semibold mb-4 text-slate-900 dark:text-slate-200">
+          {t("pathways.home.sections.yourTracks")}
+        </h2>
         <div className="grid gap-4 md:grid-cols-2">
           {PATHWAY_TRACKS.filter((t) => t.status === "active").map((track) => {
             const trackMilestones = milestones.filter((m: any) => m.trackSlug === track.slug);
             const trackCompleted = trackMilestones.filter((m: any) => m.status === "completed").length;
             const pct = track.modules.length > 0 ? Math.round((trackCompleted / track.modules.length) * 100) : 0;
+            const trackName = t(`pathways.tracks.items.${track.slug}.name`, track.name);
+            const trackTagline = t(`pathways.tracks.items.${track.slug}.tagline`, track.tagline);
 
             return (
               <button
                 key={track.slug}
                 onClick={() => navigate(`/pathways/tracks/${track.slug}`)}
-                className="flex items-center gap-4 p-4 rounded-xl border border-slate-700 bg-slate-800/50 hover:bg-slate-800 transition-colors text-left group"
+                className="flex items-center gap-4 p-4 rounded-xl border bg-white border-slate-200 hover:bg-slate-50 hover:border-slate-300 dark:bg-slate-800/50 dark:border-slate-700 dark:hover:bg-slate-800 transition-colors text-left group shadow-sm"
               >
-                <div className="w-12 h-12 rounded-lg flex items-center justify-center" style={{ backgroundColor: track.color + "20" }}>
+                <div
+                  className="w-12 h-12 rounded-lg flex items-center justify-center"
+                  style={{ backgroundColor: track.color + "20" }}
+                >
                   <Shield className="w-6 h-6" style={{ color: track.color }} />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="font-semibold text-slate-200 group-hover:text-white">{track.name}</p>
-                  <p className="text-xs text-slate-400 truncate">{track.tagline}</p>
-                  <div className="mt-2 h-1.5 bg-slate-700 rounded-full overflow-hidden">
-                    <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: track.color }} />
+                  <p className="font-semibold text-slate-900 dark:text-slate-200 group-hover:text-indigo-700 dark:group-hover:text-white">
+                    {trackName}
+                  </p>
+                  <p className="text-xs text-slate-600 dark:text-slate-400 truncate">{trackTagline}</p>
+                  <div className="mt-2 h-1.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{ width: `${pct}%`, backgroundColor: track.color }}
+                    />
                   </div>
-                  <p className="text-[10px] text-slate-500 mt-1">{trackCompleted}/{track.modules.length} modules • {pct}%</p>
+                  <p className="text-[10px] text-slate-500 mt-1">
+                    {t("pathways.home.modulesProgress", {
+                      done: trackCompleted,
+                      total: track.modules.length,
+                      pct,
+                    })}
+                  </p>
                 </div>
-                <ArrowRight className="w-4 h-4 text-slate-600 group-hover:text-slate-400" />
+                <ArrowRight className="w-4 h-4 text-slate-400 dark:text-slate-600 group-hover:text-slate-700 dark:group-hover:text-slate-400" />
               </button>
             );
           })}
@@ -101,21 +126,35 @@ export default function PathwaysHome() {
       {/* Recent Activity */}
       {milestones.length > 0 && (
         <div>
-          <h2 className="text-lg font-semibold mb-4 text-slate-200">Recent Activity</h2>
+          <h2 className="text-lg font-semibold mb-4 text-slate-900 dark:text-slate-200">
+            {t("pathways.home.sections.recentActivity")}
+          </h2>
           <div className="space-y-2">
-            {milestones.slice(0, 5).map((m: any) => (
-              <div key={m.id} className="flex items-center gap-3 p-3 rounded-lg bg-slate-800/50 border border-slate-700/50">
-                {m.status === "completed" ? (
-                  <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
-                ) : (
-                  <Compass className="w-4 h-4 text-indigo-400 shrink-0" />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm text-slate-300">{m.moduleSlug.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase())}</p>
-                  <p className="text-[10px] text-slate-500">{m.trackSlug} • {m.status}{m.score ? ` • ${m.score}%` : ""}</p>
+            {milestones.slice(0, 5).map((m: any) => {
+              const moduleName = t(
+                `pathways.tracks.modules.${m.moduleSlug}.name`,
+                m.moduleSlug.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase()),
+              ) as string;
+              return (
+                <div
+                  key={m.id}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-white border-slate-200 border dark:bg-slate-800/50 dark:border-slate-700/50"
+                >
+                  {m.status === "completed" ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-500 shrink-0" />
+                  ) : (
+                    <Compass className="w-4 h-4 text-indigo-600 dark:text-indigo-400 shrink-0" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-slate-800 dark:text-slate-300">{moduleName}</p>
+                    <p className="text-[10px] text-slate-500">
+                      {m.trackSlug} • {m.status}
+                      {m.score ? ` • ${m.score}%` : ""}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}
@@ -125,9 +164,9 @@ export default function PathwaysHome() {
 
 function StatCard({ label, value }: { label: string; value: number }) {
   return (
-    <div className="p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 text-center">
-      <p className="text-2xl font-bold text-white">{value}</p>
-      <p className="text-xs text-slate-400">{label}</p>
+    <div className="p-4 rounded-xl bg-white border border-slate-200 dark:bg-slate-800/50 dark:border-slate-700/50 text-center shadow-sm">
+      <p className="text-2xl font-bold text-slate-900 dark:text-white">{value}</p>
+      <p className="text-xs text-slate-600 dark:text-slate-400">{label}</p>
     </div>
   );
 }

--- a/src/components/pathways/PathwaysLayout.tsx
+++ b/src/components/pathways/PathwaysLayout.tsx
@@ -1,63 +1,98 @@
 /**
- * Pathways Layout — mature, clean shell for secondary-age (14-17) users.
- * Dark mode default with light toggle. Indigo/teal palette.
+ * Pathways Layout — mature shell for secondary-age (14-17) users.
+ *
+ * Theme: toggles a `.dark` class on the Pathways root <div> so Tailwind
+ * `dark:` variants apply only inside Pathways. The K-8 surfaces stay
+ * unaffected. Preference is persisted under `bb_pathways_theme` so it
+ * survives reload.
+ *
+ * i18n: every label is keyed under `pathways.layout.*` and falls back
+ * to English via i18n.ts fallbackLng.
  */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Outlet, NavLink, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { Home, Compass, User, Users, LogOut, Moon, Sun, BookOpen } from "lucide-react";
 import LanguageToggle from "@/components/LanguageToggle";
 
+const THEME_KEY = "bb_pathways_theme";
+
+function readStoredTheme(): "dark" | "light" {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
 export default function PathwaysLayout() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
-  const [dark, setDark] = useState(true);
+  const { t } = useTranslation();
+  const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
+  const isDark = theme === "dark";
+
+  // Persist theme preference whenever it changes.
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      /* localStorage unavailable — preference will not persist */
+    }
+  }, [theme]);
 
   const handleLogout = () => {
     logout();
     navigate("/");
   };
 
-  const shell = dark ? "bg-slate-950 text-slate-100" : "bg-white text-slate-900";
-  const sidebar = dark ? "bg-slate-900 border-slate-800" : "bg-slate-50 border-slate-200";
-  const navActive = dark ? "bg-indigo-600/20 text-indigo-400 border-l-2 border-indigo-500" : "bg-indigo-50 text-indigo-700 border-l-2 border-indigo-500";
-  const navIdle = dark ? "text-slate-400 hover:text-slate-200 hover:bg-slate-800" : "text-slate-600 hover:text-slate-900 hover:bg-slate-100";
-
   const isFacilitator = user?.role === "teacher";
 
   return (
-    <div className={`min-h-screen flex ${shell} transition-colors`}>
+    <div
+      className={`${isDark ? "dark" : ""} min-h-screen flex bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors`}
+    >
       {/* Sidebar */}
-      <nav className={`hidden md:flex flex-col w-56 border-r ${sidebar} shrink-0`}>
-        <div className="p-4 border-b border-slate-800">
-          <p className="text-[10px] uppercase tracking-widest text-slate-500 font-medium">Bright Boost</p>
-          <p className="text-lg font-bold bg-gradient-to-r from-indigo-400 to-cyan-400 bg-clip-text text-transparent">
-            Pathways
+      <nav className="hidden md:flex flex-col w-56 border-r shrink-0 bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+        <div className="p-4 border-b border-slate-200 dark:border-slate-800">
+          <p className="text-[10px] uppercase tracking-widest text-slate-500 font-medium">
+            {t("pathways.layout.eyebrow")}
+          </p>
+          <p className="text-lg font-bold bg-gradient-to-r from-indigo-600 to-cyan-600 dark:from-indigo-400 dark:to-cyan-400 bg-clip-text text-transparent">
+            {t("pathways.layout.brand")}
           </p>
         </div>
 
         <div className="flex-1 py-4 space-y-1 px-2">
-          <SidebarLink to="/pathways" icon={<Home className="w-4 h-4" />} label="Home" activeClass={navActive} idleClass={navIdle} end />
-          <SidebarLink to="/pathways/tracks" icon={<Compass className="w-4 h-4" />} label="Tracks" activeClass={navActive} idleClass={navIdle} />
-          <SidebarLink to="/pathways/profile" icon={<User className="w-4 h-4" />} label="Profile" activeClass={navActive} idleClass={navIdle} />
+          <SidebarLink to="/pathways" icon={<Home className="w-4 h-4" />} label={t("pathways.layout.nav.home")} end />
+          <SidebarLink to="/pathways/tracks" icon={<Compass className="w-4 h-4" />} label={t("pathways.layout.nav.tracks")} />
+          <SidebarLink to="/pathways/profile" icon={<User className="w-4 h-4" />} label={t("pathways.layout.nav.profile")} />
           {isFacilitator && (
             <>
-              <SidebarLink to="/pathways/facilitator" icon={<Users className="w-4 h-4" />} label="Dashboard" activeClass={navActive} idleClass={navIdle} />
-              <SidebarLink to="/pathways/facilitator/resources" icon={<BookOpen className="w-4 h-4" />} label="Resources" activeClass={navActive} idleClass={navIdle} />
+              <SidebarLink to="/pathways/facilitator" icon={<Users className="w-4 h-4" />} label={t("pathways.layout.nav.dashboard")} />
+              <SidebarLink to="/pathways/facilitator/resources" icon={<BookOpen className="w-4 h-4" />} label={t("pathways.layout.nav.resources")} />
             </>
           )}
         </div>
 
-        <div className="p-3 border-t border-slate-800 space-y-2">
+        <div className="p-3 border-t border-slate-200 dark:border-slate-800 space-y-2">
           <div className="px-1">
-            <LanguageToggle variant={dark ? "dark" : "light"} />
+            <LanguageToggle variant={isDark ? "dark" : "light"} />
           </div>
-          <button onClick={() => setDark((d) => !d)} className={`flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs ${navIdle}`}>
-            {dark ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
-            {dark ? "Light Mode" : "Dark Mode"}
+          <button
+            onClick={() => setTheme(isDark ? "light" : "dark")}
+            className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            {isDark ? <Sun className="w-3 h-3" /> : <Moon className="w-3 h-3" />}
+            {isDark ? t("pathways.common.lightMode") : t("pathways.common.darkMode")}
           </button>
-          <button onClick={handleLogout} className={`flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs ${navIdle}`}>
-            <LogOut className="w-3 h-3" /> Sign Out
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-xs text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <LogOut className="w-3 h-3" /> {t("pathways.common.signOut")}
           </button>
         </div>
       </nav>
@@ -65,30 +100,34 @@ export default function PathwaysLayout() {
       {/* Main content */}
       <main className="flex-1 min-h-screen overflow-y-auto">
         {/* Mobile top bar */}
-        <div className={`md:hidden flex items-center justify-between px-4 py-3 border-b ${sidebar}`}>
-          <p className="font-bold text-sm bg-gradient-to-r from-indigo-400 to-cyan-400 bg-clip-text text-transparent">
-            Pathways
+        <div className="md:hidden flex items-center justify-between px-4 py-3 border-b bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+          <p className="font-bold text-sm bg-gradient-to-r from-indigo-600 to-cyan-600 dark:from-indigo-400 dark:to-cyan-400 bg-clip-text text-transparent">
+            {t("pathways.layout.brand")}
           </p>
           <div className="flex items-center gap-3">
-            <LanguageToggle variant={dark ? "dark" : "light"} />
-            <button onClick={() => setDark((d) => !d)} className="p-1.5">
-              {dark ? <Sun className="w-4 h-4 text-slate-400" /> : <Moon className="w-4 h-4 text-slate-600" />}
+            <LanguageToggle variant={isDark ? "dark" : "light"} />
+            <button
+              onClick={() => setTheme(isDark ? "light" : "dark")}
+              className="p-1.5"
+              aria-label={isDark ? t("pathways.common.lightMode") : t("pathways.common.darkMode")}
+            >
+              {isDark ? <Sun className="w-4 h-4 text-slate-300" /> : <Moon className="w-4 h-4 text-slate-700" />}
             </button>
           </div>
         </div>
 
         {/* Page content */}
-        <div className="p-4 md:p-8 max-w-6xl mx-auto">
+        <div className="p-4 md:p-8 max-w-6xl mx-auto pb-24 md:pb-8">
           <Outlet />
         </div>
 
         {/* Mobile bottom nav */}
-        <div className={`md:hidden fixed bottom-0 inset-x-0 flex items-center justify-around py-2 border-t ${sidebar}`}>
-          <MobileNavLink to="/pathways" icon={<Home className="w-5 h-5" />} label="Home" dark={dark} end />
-          <MobileNavLink to="/pathways/tracks" icon={<Compass className="w-5 h-5" />} label="Tracks" dark={dark} />
-          <MobileNavLink to="/pathways/profile" icon={<User className="w-5 h-5" />} label="Profile" dark={dark} />
+        <div className="md:hidden fixed bottom-0 inset-x-0 flex items-center justify-around py-2 border-t bg-white border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+          <MobileNavLink to="/pathways" icon={<Home className="w-5 h-5" />} label={t("pathways.layout.nav.home")} end />
+          <MobileNavLink to="/pathways/tracks" icon={<Compass className="w-5 h-5" />} label={t("pathways.layout.nav.tracks")} />
+          <MobileNavLink to="/pathways/profile" icon={<User className="w-5 h-5" />} label={t("pathways.layout.nav.profile")} />
           {isFacilitator && (
-            <MobileNavLink to="/pathways/facilitator" icon={<Users className="w-5 h-5" />} label="Manage" dark={dark} />
+            <MobileNavLink to="/pathways/facilitator" icon={<Users className="w-5 h-5" />} label={t("pathways.layout.nav.manage")} />
           )}
         </div>
       </main>
@@ -96,18 +135,58 @@ export default function PathwaysLayout() {
   );
 }
 
-function SidebarLink({ to, icon, label, activeClass, idleClass, end }: { to: string; icon: React.ReactNode; label: string; activeClass: string; idleClass: string; end?: boolean }) {
+function SidebarLink({
+  to,
+  icon,
+  label,
+  end,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  end?: boolean;
+}) {
   return (
-    <NavLink to={to} end={end} className={({ isActive }) => `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${isActive ? activeClass : idleClass}`}>
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-indigo-50 text-indigo-700 border-l-2 border-indigo-500 dark:bg-indigo-600/20 dark:text-indigo-300 dark:border-indigo-500"
+            : "text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800"
+        }`
+      }
+    >
       {icon}
       {label}
     </NavLink>
   );
 }
 
-function MobileNavLink({ to, icon, label, dark, end }: { to: string; icon: React.ReactNode; label: string; dark: boolean; end?: boolean }) {
+function MobileNavLink({
+  to,
+  icon,
+  label,
+  end,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  end?: boolean;
+}) {
   return (
-    <NavLink to={to} end={end} className={({ isActive }) => `flex flex-col items-center gap-0.5 text-[10px] font-medium ${isActive ? (dark ? "text-indigo-400" : "text-indigo-600") : (dark ? "text-slate-500" : "text-slate-400")}`}>
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `flex flex-col items-center gap-0.5 text-[10px] font-medium ${
+          isActive
+            ? "text-indigo-700 dark:text-indigo-300"
+            : "text-slate-500 dark:text-slate-400"
+        }`
+      }
+    >
       {icon}
       {label}
     </NavLink>

--- a/src/components/pathways/PathwaysProfile.tsx
+++ b/src/components/pathways/PathwaysProfile.tsx
@@ -1,12 +1,14 @@
 /**
- * Pathways Profile — learner profile + portfolio.
+ * Pathways Profile — learner profile + portfolio. i18n + light/dark.
  */
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { CheckCircle2, Clock, Star } from "lucide-react";
 
 export default function PathwaysProfile() {
   const { user } = useAuth();
+  const { t } = useTranslation();
   const [milestones, setMilestones] = useState<any[]>([]);
 
   useEffect(() => {
@@ -20,61 +22,100 @@ export default function PathwaysProfile() {
 
   const completed = milestones.filter((m) => m.status === "completed");
   const inProgress = milestones.filter((m) => m.status === "in_progress");
-  const avgScore = completed.length > 0
-    ? Math.round(completed.reduce((s, m) => s + (m.score ?? 0), 0) / completed.length)
-    : 0;
+  const avgScore =
+    completed.length > 0
+      ? Math.round(completed.reduce((s, m) => s + (m.score ?? 0), 0) / completed.length)
+      : 0;
 
   return (
     <div className="space-y-6">
       {/* Profile Header */}
-      <div className="rounded-2xl border border-slate-700 bg-slate-800/80 p-6">
+      <div className="rounded-2xl border bg-white border-slate-200 dark:bg-slate-800/80 dark:border-slate-700 p-6 shadow-sm">
         <div className="flex items-center gap-4">
-          <div className="w-16 h-16 rounded-full bg-indigo-600/20 flex items-center justify-center text-2xl">
+          <div className="w-16 h-16 rounded-full bg-indigo-100 dark:bg-indigo-600/20 flex items-center justify-center text-2xl text-indigo-700 dark:text-indigo-300 font-bold">
             {user?.name?.[0]?.toUpperCase() ?? "?"}
           </div>
           <div>
-            <h1 className="text-xl font-bold text-slate-100">{user?.name ?? "Learner"}</h1>
-            <p className="text-sm text-slate-400">{user?.email}</p>
+            <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+              {user?.name ?? t("pathways.profile.learner")}
+            </h1>
+            <p className="text-sm text-slate-600 dark:text-slate-400">{user?.email}</p>
           </div>
         </div>
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-4">
-        <div className="p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 text-center">
-          <div className="flex justify-center text-emerald-400 mb-1"><CheckCircle2 className="w-5 h-5" /></div>
-          <p className="text-xl font-bold text-white">{completed.length}</p>
-          <p className="text-xs text-slate-400">Completed</p>
-        </div>
-        <div className="p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 text-center">
-          <div className="flex justify-center text-indigo-400 mb-1"><Clock className="w-5 h-5" /></div>
-          <p className="text-xl font-bold text-white">{inProgress.length}</p>
-          <p className="text-xs text-slate-400">In Progress</p>
-        </div>
-        <div className="p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 text-center">
-          <div className="flex justify-center text-amber-400 mb-1"><Star className="w-5 h-5" /></div>
-          <p className="text-xl font-bold text-white">{avgScore}%</p>
-          <p className="text-xs text-slate-400">Avg Score</p>
-        </div>
+        <StatBlock
+          icon={<CheckCircle2 className="w-5 h-5" />}
+          iconColor="text-emerald-600 dark:text-emerald-400"
+          value={completed.length}
+          label={t("pathways.profile.completed")}
+        />
+        <StatBlock
+          icon={<Clock className="w-5 h-5" />}
+          iconColor="text-indigo-600 dark:text-indigo-400"
+          value={inProgress.length}
+          label={t("pathways.profile.inProgress")}
+        />
+        <StatBlock
+          icon={<Star className="w-5 h-5" />}
+          iconColor="text-amber-600 dark:text-amber-400"
+          value={`${avgScore}%`}
+          label={t("pathways.profile.avgScore")}
+        />
       </div>
 
       {/* Completed Modules */}
       {completed.length > 0 && (
         <div>
-          <h2 className="text-lg font-semibold text-slate-200 mb-3">Completed Modules</h2>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-200 mb-3">
+            {t("pathways.profile.completedModules")}
+          </h2>
           <div className="space-y-2">
-            {completed.map((m) => (
-              <div key={m.id} className="flex items-center gap-3 p-3 rounded-lg bg-emerald-900/10 border border-emerald-800/20">
-                <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
-                <div className="flex-1">
-                  <p className="text-sm text-slate-200">{m.moduleSlug.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase())}</p>
-                  <p className="text-[10px] text-slate-500">{m.trackSlug} {m.score ? `• Score: ${m.score}%` : ""}</p>
+            {completed.map((m) => {
+              const moduleName = t(
+                `pathways.tracks.modules.${m.moduleSlug}.name`,
+                m.moduleSlug.replace(/-/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase()),
+              ) as string;
+              return (
+                <div
+                  key={m.id}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-emerald-50 border border-emerald-200 dark:bg-emerald-900/10 dark:border-emerald-800/20"
+                >
+                  <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-500 shrink-0" />
+                  <div className="flex-1">
+                    <p className="text-sm text-slate-800 dark:text-slate-200">{moduleName}</p>
+                    <p className="text-[10px] text-slate-500">
+                      {m.trackSlug} {m.score ? t("pathways.profile.scoreFmt", { score: m.score }) : ""}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function StatBlock({
+  icon,
+  iconColor,
+  value,
+  label,
+}: {
+  icon: React.ReactNode;
+  iconColor: string;
+  value: number | string;
+  label: string;
+}) {
+  return (
+    <div className="p-4 rounded-xl bg-white border border-slate-200 dark:bg-slate-800/50 dark:border-slate-700/50 text-center shadow-sm">
+      <div className={`flex justify-center mb-1 ${iconColor}`}>{icon}</div>
+      <p className="text-xl font-bold text-slate-900 dark:text-white">{value}</p>
+      <p className="text-xs text-slate-600 dark:text-slate-400">{label}</p>
     </div>
   );
 }

--- a/src/components/pathways/TrackDetail.tsx
+++ b/src/components/pathways/TrackDetail.tsx
@@ -1,10 +1,22 @@
 /**
  * Track Detail — module list as a vertical timeline with status indicators.
+ * i18n + light/dark.
  */
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { getTrackBySlug } from "@/constants/pathwayTracks";
-import { ArrowLeft, CheckCircle2, Clock, PlayCircle, ExternalLink, BookOpen, Wrench, FolderOpen, Lock } from "lucide-react";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Clock,
+  PlayCircle,
+  ExternalLink,
+  BookOpen,
+  Wrench,
+  FolderOpen,
+  Lock,
+} from "lucide-react";
 
 const TYPE_ICONS: Record<string, React.ReactNode> = {
   lesson: <BookOpen className="w-4 h-4" />,
@@ -17,6 +29,7 @@ const TYPE_ICONS: Record<string, React.ReactNode> = {
 export default function TrackDetail() {
   const { trackSlug } = useParams();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const track = getTrackBySlug(trackSlug ?? "");
   const [milestones, setMilestones] = useState<any[]>([]);
 
@@ -25,18 +38,28 @@ export default function TrackDetail() {
       headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
     })
       .then((r) => r.json())
-      .then((data) => setMilestones(Array.isArray(data) ? data.filter((m: any) => m.trackSlug === trackSlug) : []))
+      .then((data) =>
+        setMilestones(Array.isArray(data) ? data.filter((m: any) => m.trackSlug === trackSlug) : []),
+      )
       .catch(() => {});
   }, [trackSlug]);
 
   if (!track) {
     return (
       <div className="text-center py-20">
-        <p className="text-slate-400">Track not found.</p>
-        <button onClick={() => navigate("/pathways/tracks")} className="mt-4 text-indigo-400 text-sm">Back to Tracks</button>
+        <p className="text-slate-600 dark:text-slate-400">{t("pathways.trackDetail.notFound")}</p>
+        <button
+          onClick={() => navigate("/pathways/tracks")}
+          className="mt-4 text-indigo-700 dark:text-indigo-400 text-sm"
+        >
+          {t("pathways.trackDetail.backToTracks")}
+        </button>
       </div>
     );
   }
+
+  const trackName = t(`pathways.tracks.items.${track.slug}.name`, track.name);
+  const trackDescription = t(`pathways.tracks.items.${track.slug}.description`, track.description);
 
   const getStatus = (moduleSlug: string) => {
     const m = milestones.find((ms) => ms.moduleSlug === moduleSlug);
@@ -49,24 +72,37 @@ export default function TrackDetail() {
   return (
     <div className="space-y-6">
       {/* Back */}
-      <button onClick={() => navigate("/pathways/tracks")} className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200">
-        <ArrowLeft className="w-4 h-4" /> All Tracks
+      <button
+        onClick={() => navigate("/pathways/tracks")}
+        className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        <ArrowLeft className="w-4 h-4" /> {t("pathways.trackDetail.allTracks")}
       </button>
 
       {/* Track Hero */}
-      <div className="rounded-2xl border border-slate-700 bg-slate-800/80 p-6">
+      <div className="rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800/80 p-6 shadow-sm">
         <div className="flex items-start gap-4">
-          <div className="w-16 h-16 rounded-xl flex items-center justify-center shrink-0" style={{ backgroundColor: track.color + "20", color: track.color }}>
-            <span className="text-3xl">{track.icon === "Shield" ? "🛡" : track.icon === "Rocket" ? "🚀" : "📦"}</span>
+          <div
+            className="w-16 h-16 rounded-xl flex items-center justify-center shrink-0"
+            style={{ backgroundColor: track.color + "20", color: track.color }}
+          >
+            <span className="text-3xl">
+              {track.icon === "Shield" ? "🛡" : track.icon === "Rocket" ? "🚀" : "📦"}
+            </span>
           </div>
           <div className="flex-1">
-            <h1 className="text-2xl font-bold text-slate-100">{track.name}</h1>
-            <p className="text-sm text-slate-400 mt-1">{track.description}</p>
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{trackName}</h1>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">{trackDescription}</p>
             <div className="mt-3 flex items-center gap-4">
-              <div className="flex-1 h-2 bg-slate-700 rounded-full overflow-hidden max-w-xs">
-                <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: track.color }} />
+              <div className="flex-1 h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden max-w-xs">
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${pct}%`, backgroundColor: track.color }}
+                />
               </div>
-              <span className="text-xs text-slate-400">{completedCount}/{track.modules.length} completed</span>
+              <span className="text-xs text-slate-600 dark:text-slate-400">
+                {t("pathways.trackDetail.completedCount", { done: completedCount, total: track.modules.length })}
+              </span>
             </div>
           </div>
         </div>
@@ -78,38 +114,56 @@ export default function TrackDetail() {
           const status = getStatus(mod.slug);
           const isExternal = mod.type === "external";
           const isComingSoon = mod.status === "coming_soon";
+          const modName = t(`pathways.tracks.modules.${mod.slug}.name`, mod.name);
+          const modDesc = t(`pathways.tracks.modules.${mod.slug}.description`, mod.description);
 
           return (
             <div
               key={mod.slug}
               className={`flex items-start gap-4 p-4 rounded-xl border transition-colors ${
                 isComingSoon
-                  ? "border-slate-800 bg-slate-900/50 opacity-50"
+                  ? "border-slate-200 bg-slate-50 opacity-50 dark:border-slate-800 dark:bg-slate-900/50"
                   : status === "completed"
-                    ? "border-emerald-800/30 bg-emerald-900/10"
-                    : "border-slate-700 bg-slate-800/50 hover:bg-slate-800 cursor-pointer"
+                    ? "border-emerald-300 bg-emerald-50 dark:border-emerald-800/30 dark:bg-emerald-900/10"
+                    : "border-slate-200 bg-white hover:bg-slate-50 cursor-pointer dark:border-slate-700 dark:bg-slate-800/50 dark:hover:bg-slate-800"
               }`}
               onClick={() => {
                 if (isComingSoon) return;
                 if (isExternal && mod.externalUrl) {
                   window.open(mod.externalUrl, "_blank");
-                  // Mark as completed
                   fetch("/api/pathways/student/milestones", {
                     method: "POST",
-                    headers: { "Content-Type": "application/json", Authorization: `Bearer ${localStorage.getItem("token")}` },
-                    body: JSON.stringify({ trackSlug: track.slug, moduleSlug: mod.slug, status: "completed", score: 100 }),
-                  }).then(() => setMilestones((prev) => [...prev, { moduleSlug: mod.slug, status: "completed", score: 100, trackSlug: track.slug }]));
+                    headers: {
+                      "Content-Type": "application/json",
+                      Authorization: `Bearer ${localStorage.getItem("token")}`,
+                    },
+                    body: JSON.stringify({
+                      trackSlug: track.slug,
+                      moduleSlug: mod.slug,
+                      status: "completed",
+                      score: 100,
+                    }),
+                  }).then(() =>
+                    setMilestones((prev) => [
+                      ...prev,
+                      { moduleSlug: mod.slug, status: "completed", score: 100, trackSlug: track.slug },
+                    ]),
+                  );
                   return;
                 }
                 navigate(`/pathways/tracks/${track.slug}/${mod.slug}`);
               }}
             >
               {/* Step number / status */}
-              <div className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-xs font-bold ${
-                status === "completed" ? "bg-emerald-600 text-white" :
-                status === "in_progress" ? "bg-indigo-600 text-white" :
-                "bg-slate-700 text-slate-400"
-              }`}>
+              <div
+                className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-xs font-bold ${
+                  status === "completed"
+                    ? "bg-emerald-600 text-white"
+                    : status === "in_progress"
+                      ? "bg-indigo-600 text-white"
+                      : "bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-400"
+                }`}
+              >
                 {status === "completed" ? <CheckCircle2 className="w-4 h-4" /> : i + 1}
               </div>
 
@@ -117,22 +171,35 @@ export default function TrackDetail() {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="text-slate-500">{TYPE_ICONS[mod.type]}</span>
-                  <h3 className="font-medium text-slate-200 text-sm">{mod.name}</h3>
+                  <h3 className="font-medium text-slate-900 dark:text-slate-200 text-sm">{modName}</h3>
                   {isExternal && <ExternalLink className="w-3 h-3 text-slate-500" />}
-                  {isComingSoon && <Lock className="w-3 h-3 text-slate-600" />}
+                  {isComingSoon && <Lock className="w-3 h-3 text-slate-500 dark:text-slate-600" />}
                 </div>
-                <p className="text-xs text-slate-500 mt-0.5">{mod.description}</p>
-                <div className="flex items-center gap-3 mt-2 text-[10px] text-slate-500">
-                  <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{mod.duration}</span>
-                  <span className="capitalize px-2 py-0.5 rounded-full bg-slate-700/50">{mod.type}</span>
-                  {status === "completed" && <span className="text-emerald-400">Completed</span>}
-                  {status === "in_progress" && <span className="text-indigo-400">In Progress</span>}
+                <p className="text-xs text-slate-600 dark:text-slate-500 mt-0.5">{modDesc}</p>
+                <div className="flex items-center gap-3 mt-2 text-[10px] text-slate-600 dark:text-slate-500">
+                  <span className="flex items-center gap-1">
+                    <Clock className="w-3 h-3" />
+                    {mod.duration}
+                  </span>
+                  <span className="capitalize px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700/50">
+                    {mod.type}
+                  </span>
+                  {status === "completed" && (
+                    <span className="text-emerald-700 dark:text-emerald-400">
+                      {t("pathways.trackDetail.completedLabel")}
+                    </span>
+                  )}
+                  {status === "in_progress" && (
+                    <span className="text-indigo-700 dark:text-indigo-400">
+                      {t("pathways.trackDetail.inProgressLabel")}
+                    </span>
+                  )}
                 </div>
               </div>
 
               {/* Action */}
               {!isComingSoon && status !== "completed" && (
-                <PlayCircle className="w-5 h-5 text-indigo-400 shrink-0 mt-1" />
+                <PlayCircle className="w-5 h-5 text-indigo-600 dark:text-indigo-400 shrink-0 mt-1" />
               )}
             </div>
           );

--- a/src/components/pathways/TracksOverview.tsx
+++ b/src/components/pathways/TracksOverview.tsx
@@ -1,7 +1,8 @@
 /**
- * All Tracks browse page — grid of 5 track cards.
+ * All Tracks browse page — grid of 5 track cards. i18n + light/dark.
  */
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
 import { Shield, Rocket, DollarSign, Cpu, Film, Lock, ArrowRight } from "lucide-react";
 
@@ -15,56 +16,75 @@ const ICONS: Record<string, React.ReactNode> = {
 
 export default function TracksOverview() {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-100">All Tracks</h1>
-        <p className="text-sm text-slate-400 mt-1">Choose your pathway. Build real skills.</p>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.tracks.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.tracks.sub")}
+        </p>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {PATHWAY_TRACKS.map((track) => {
           const isActive = track.status === "active";
+          const name = t(`pathways.tracks.items.${track.slug}.name`, track.name);
+          const tagline = t(`pathways.tracks.items.${track.slug}.tagline`, track.tagline);
+          const description = t(`pathways.tracks.items.${track.slug}.description`, track.description);
+
           return (
             <div
               key={track.slug}
-              className={`rounded-2xl border p-6 transition-all flex flex-col ${
+              className={`rounded-2xl border p-6 transition-all flex flex-col shadow-sm ${
                 isActive
-                  ? "border-slate-700 bg-slate-800/80 hover:border-indigo-500/50 hover:shadow-lg hover:shadow-indigo-500/5 cursor-pointer"
-                  : "border-slate-800 bg-slate-900/50 opacity-60"
+                  ? "border-slate-200 bg-white hover:border-indigo-500/50 hover:shadow-lg hover:shadow-indigo-500/10 cursor-pointer dark:border-slate-700 dark:bg-slate-800/80 dark:hover:border-indigo-500/50 dark:hover:shadow-indigo-500/5"
+                  : "border-slate-200 bg-slate-50 opacity-60 dark:border-slate-800 dark:bg-slate-900/50"
               }`}
               onClick={isActive ? () => navigate(`/pathways/tracks/${track.slug}`) : undefined}
             >
               <div className="flex items-start justify-between mb-4">
-                <div className="w-14 h-14 rounded-xl flex items-center justify-center" style={{ backgroundColor: track.color + "15", color: track.color }}>
+                <div
+                  className="w-14 h-14 rounded-xl flex items-center justify-center"
+                  style={{ backgroundColor: track.color + "15", color: track.color }}
+                >
                   {ICONS[track.icon] ?? <Shield className="w-8 h-8" />}
                 </div>
                 {!isActive && (
-                  <span className="flex items-center gap-1 text-[10px] font-medium text-slate-500 bg-slate-800 px-2 py-1 rounded-full">
-                    <Lock className="w-3 h-3" /> Coming Soon
+                  <span className="flex items-center gap-1 text-[10px] font-medium text-slate-600 dark:text-slate-500 bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded-full">
+                    <Lock className="w-3 h-3" /> {t("pathways.common.comingSoon")}
                   </span>
                 )}
               </div>
 
-              <h3 className="font-bold text-lg text-slate-100 mb-1">{track.name}</h3>
-              <p className="text-sm text-slate-400 mb-1">{track.tagline}</p>
+              <h3 className="font-bold text-lg text-slate-900 dark:text-slate-100 mb-1">
+                {name}
+              </h3>
+              <p className="text-sm text-slate-700 dark:text-slate-400 mb-1">{tagline}</p>
 
               <div className="flex gap-1 mt-2 mb-4">
                 {track.bands.map((b) => (
-                  <span key={b} className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-indigo-500/10 text-indigo-400 capitalize">
+                  <span
+                    key={b}
+                    className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-400 capitalize"
+                  >
                     {b}
                   </span>
                 ))}
               </div>
 
-              <p className="text-xs text-slate-500 mb-4 flex-1">{track.description}</p>
+              <p className="text-xs text-slate-600 dark:text-slate-500 mb-4 flex-1">{description}</p>
 
-              <div className="flex items-center justify-between text-xs text-slate-500">
-                <span>{track.modules.length} modules</span>
+              <div className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-500">
+                <span>
+                  {t("pathways.tracks.modulesCount", { count: track.modules.length })}
+                </span>
                 {isActive && (
-                  <span className="flex items-center gap-1 text-indigo-400 font-medium">
-                    Start <ArrowRight className="w-3 h-3" />
+                  <span className="flex items-center gap-1 text-indigo-700 dark:text-indigo-400 font-medium">
+                    {t("pathways.tracks.start")} <ArrowRight className="w-3 h-3" />
                   </span>
                 )}
               </div>

--- a/src/components/pathways/facilitator/ProgramOverview.tsx
+++ b/src/components/pathways/facilitator/ProgramOverview.tsx
@@ -10,10 +10,11 @@
  *   6. Facilitation Tips     — situational guidance for facilitators
  *
  * Each tab is a self-contained component in ./tabs/, backed by data in ./data/.
- * The split keeps the entry file small and lets each tab be reviewed
- * independently as content evolves with partner feedback.
+ * Tab labels are i18n'd; tab contents are i18n'd where keys exist and fall back
+ * to English-from-TS otherwise (see ./data/ — those files keep English content).
  */
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   BookOpen,
   Calendar,
@@ -31,51 +32,54 @@ import FacilitationTipsTab from "./tabs/FacilitationTipsTab";
 
 type TabKey = "overview" | "modules" | "sessions" | "faqs" | "worksheets" | "tips";
 
-const TABS: { key: TabKey; label: string; icon: React.ReactNode }[] = [
-  { key: "overview", label: "Program Overview", icon: <BookOpen className="w-4 h-4" /> },
-  { key: "modules", label: "Module Guides", icon: <Layers className="w-4 h-4" /> },
-  { key: "sessions", label: "Session Guide", icon: <Calendar className="w-4 h-4" /> },
-  { key: "faqs", label: "FAQs", icon: <HelpCircle className="w-4 h-4" /> },
-  { key: "worksheets", label: "Worksheets", icon: <FileText className="w-4 h-4" /> },
-  { key: "tips", label: "Facilitation Tips", icon: <Lightbulb className="w-4 h-4" /> },
-];
-
 export default function ProgramOverview() {
+  const { t } = useTranslation();
   const [tab, setTab] = useState<TabKey>("overview");
+
+  const tabs: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+    { key: "overview", label: t("pathways.resources.tabs.overview"), icon: <BookOpen className="w-4 h-4" /> },
+    { key: "modules", label: t("pathways.resources.tabs.modules"), icon: <Layers className="w-4 h-4" /> },
+    { key: "sessions", label: t("pathways.resources.tabs.sessions"), icon: <Calendar className="w-4 h-4" /> },
+    { key: "faqs", label: t("pathways.resources.tabs.faqs"), icon: <HelpCircle className="w-4 h-4" /> },
+    { key: "worksheets", label: t("pathways.resources.tabs.worksheets"), icon: <FileText className="w-4 h-4" /> },
+    { key: "tips", label: t("pathways.resources.tabs.tips"), icon: <Lightbulb className="w-4 h-4" /> },
+  ];
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-100">Facilitator Resources</h1>
-        <p className="text-sm text-slate-400 mt-1">
-          Everything you need to run a strong Cyber Launch cohort.
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.resources.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.resources.subtitle")}
         </p>
       </div>
 
       {/* Tab nav — horizontally scrollable on mobile */}
       <div
         role="tablist"
-        aria-label="Facilitator resources sections"
-        className="flex gap-1 border-b border-slate-700 overflow-x-auto pb-px -mx-1 px-1"
+        aria-label={t("pathways.resources.title")}
+        className="flex gap-1 border-b border-slate-200 dark:border-slate-700 overflow-x-auto pb-px -mx-1 px-1"
       >
-        {TABS.map((t) => {
-          const active = tab === t.key;
+        {tabs.map((tt) => {
+          const active = tab === tt.key;
           return (
             <button
-              key={t.key}
+              key={tt.key}
               role="tab"
               aria-selected={active}
-              aria-controls={`panel-${t.key}`}
-              id={`tab-${t.key}`}
-              onClick={() => setTab(t.key)}
+              aria-controls={`panel-${tt.key}`}
+              id={`tab-${tt.key}`}
+              onClick={() => setTab(tt.key)}
               className={`flex items-center gap-2 px-3 sm:px-4 py-2 rounded-t-lg text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
                 active
-                  ? "text-indigo-300 border-indigo-500 bg-indigo-600/10"
-                  : "text-slate-400 border-transparent hover:text-slate-200 hover:bg-slate-800/50"
+                  ? "text-indigo-700 border-indigo-600 bg-indigo-50 dark:text-indigo-300 dark:border-indigo-500 dark:bg-indigo-600/10"
+                  : "text-slate-600 border-transparent hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800/50"
               }`}
             >
-              {t.icon}
-              <span>{t.label}</span>
+              {tt.icon}
+              <span>{tt.label}</span>
             </button>
           );
         })}

--- a/src/components/pathways/facilitator/tabs/FacilitationTipsTab.tsx
+++ b/src/components/pathways/facilitator/tabs/FacilitationTipsTab.tsx
@@ -1,25 +1,23 @@
+import { useTranslation } from "react-i18next";
 import { FACILITATION_TIPS } from "../data/facilitationTips";
 import Section from "./Section";
 
 export default function FacilitationTipsTab() {
+  const { t } = useTranslation();
+
   return (
     <div className="space-y-6">
-      <Section title="Facilitation Tips" subtitle="Practical guidance for the situations that arise in real cohorts.">
-        <p className="text-sm text-slate-400">
-          These tips were written by program staff with input from partner facilitators. They are
-          starting points, not strict rules. Adapt to your cohort, your site, and your own style.
-          Sensitive sections (trauma-informed practice, justice-impacted youth) are worth reviewing
-          with your partner organization's clinical or program leadership before applying at scale.
-        </p>
+      <Section title={t("pathways.resources.tips.title")} subtitle={t("pathways.resources.tips.sub")}>
+        <p className="text-sm text-slate-700 dark:text-slate-400">{t("pathways.resources.tips.intro")}</p>
       </Section>
 
       {FACILITATION_TIPS.map((section) => (
         <Section key={section.id} title={section.title} subtitle={section.intro} id={section.id}>
           <div className="space-y-4 mt-3">
             {section.bullets.map((b, i) => (
-              <div key={i} className="border-l-2 border-indigo-700/50 pl-4">
-                <p className="text-sm font-semibold text-slate-200">{b.heading}</p>
-                <p className="text-sm text-slate-400 mt-1 leading-relaxed">{b.body}</p>
+              <div key={i} className="border-l-2 border-indigo-300 dark:border-indigo-700/50 pl-4">
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">{b.heading}</p>
+                <p className="text-sm text-slate-700 dark:text-slate-400 mt-1 leading-relaxed">{b.body}</p>
               </div>
             ))}
           </div>

--- a/src/components/pathways/facilitator/tabs/FaqsTab.tsx
+++ b/src/components/pathways/facilitator/tabs/FaqsTab.tsx
@@ -1,34 +1,44 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 import { FAQ_CATEGORIES, type FaqCategory } from "../data/faqs";
 import Section from "./Section";
 
 export default function FaqsTab() {
+  const { t } = useTranslation();
   const [activeKey, setActiveKey] = useState<FaqCategory["key"]>("youth");
   const active = FAQ_CATEGORIES.find((c) => c.key === activeKey)!;
 
+  const localizedLabel = (key: FaqCategory["key"]) =>
+    t(`pathways.resources.faqs.categories.${key}.label`, FAQ_CATEGORIES.find((c) => c.key === key)?.label ?? key) as string;
+  const localizedDescription = (key: FaqCategory["key"]) =>
+    t(`pathways.resources.faqs.categories.${key}.description`, FAQ_CATEGORIES.find((c) => c.key === key)?.description ?? "") as string;
+
   return (
     <div className="space-y-6">
-      <Section title="Frequently Asked Questions" subtitle="Real questions from real audiences. Use the answers as starting points — make them your own.">
+      <Section
+        title={t("pathways.resources.faqs.title")}
+        subtitle={t("pathways.resources.faqs.sub")}
+      >
         <div className="flex flex-wrap gap-2">
           {FAQ_CATEGORIES.map((c) => (
             <button
               key={c.key}
               onClick={() => setActiveKey(c.key)}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border ${
                 activeKey === c.key
-                  ? "bg-indigo-600/20 text-indigo-300 border border-indigo-700/50"
-                  : "bg-slate-800 text-slate-400 border border-slate-700 hover:text-slate-200"
+                  ? "bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-600/20 dark:text-indigo-300 dark:border-indigo-700/50"
+                  : "bg-white text-slate-700 border-slate-200 hover:text-slate-900 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-700 dark:hover:text-slate-200"
               }`}
             >
-              {c.label}
+              {localizedLabel(c.key)}
               <span className="ml-2 text-xs text-slate-500">{c.items.length}</span>
             </button>
           ))}
         </div>
       </Section>
 
-      <Section title={active.label} subtitle={active.description}>
+      <Section title={localizedLabel(active.key)} subtitle={localizedDescription(active.key)}>
         <div className="space-y-2">
           {active.items.map((item, i) => (
             <FaqItemRow key={i} q={item.question} a={item.answer} />
@@ -42,21 +52,21 @@ export default function FaqsTab() {
 function FaqItemRow({ q, a }: { q: string; a: string }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="rounded-lg border border-slate-700/50 bg-slate-900/40 overflow-hidden">
+    <div className="rounded-lg border border-slate-200 bg-white dark:border-slate-700/50 dark:bg-slate-900/40 overflow-hidden">
       <button
         onClick={() => setOpen(!open)}
         aria-expanded={open}
-        className="w-full flex items-start gap-3 p-3 text-left hover:bg-slate-800/60 transition-colors"
+        className="w-full flex items-start gap-3 p-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/60 transition-colors"
       >
         <ChevronDown
           className={`w-4 h-4 text-slate-500 shrink-0 mt-0.5 transition-transform ${
             open ? "rotate-0" : "-rotate-90"
           }`}
         />
-        <span className="text-sm font-medium text-slate-200">{q}</span>
+        <span className="text-sm font-medium text-slate-900 dark:text-slate-200">{q}</span>
       </button>
       {open && (
-        <div className="px-4 pb-4 pl-11 text-sm text-slate-300 leading-relaxed">{a}</div>
+        <div className="px-4 pb-4 pl-11 text-sm text-slate-700 dark:text-slate-300 leading-relaxed">{a}</div>
       )}
     </div>
   );

--- a/src/components/pathways/facilitator/tabs/ModuleGuidesTab.tsx
+++ b/src/components/pathways/facilitator/tabs/ModuleGuidesTab.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { MODULE_GUIDES, type ModuleGuide } from "../data/moduleGuides";
 import Section from "./Section";
 
 export default function ModuleGuidesTab() {
+  const { t } = useTranslation();
   const [openSlug, setOpenSlug] = useState<string | null>(MODULE_GUIDES[0]?.slug ?? null);
 
   return (
     <div className="space-y-6">
-      <Section title="Detailed Module Guides" subtitle="One full guide per Cyber Launch module. Click a module to expand.">
-        <p className="text-sm text-slate-400">
-          Each guide includes what the module teaches, discussion questions for before and after, common
-          sticking points and how to coach through them, real-world context, vocabulary, and red flags
-          to watch for. Read the guide for next week's module BEFORE the session.
+      <Section
+        title={t("pathways.resources.moduleGuides.introTitle")}
+        subtitle={t("pathways.resources.moduleGuides.introSub")}
+      >
+        <p className="text-sm text-slate-700 dark:text-slate-400">
+          {t("pathways.resources.moduleGuides.introBody")}
         </p>
       </Section>
 
@@ -39,24 +42,29 @@ function GuideAccordion({
   open: boolean;
   onToggle: () => void;
 }) {
+  const { t } = useTranslation();
+  const translatedName = t(`pathways.tracks.modules.${guide.slug}.name`, guide.name) as string;
+
   return (
-    <div className="rounded-xl border border-slate-700 bg-slate-800/50 overflow-hidden">
+    <div className="rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800/50 overflow-hidden shadow-sm">
       <button
         onClick={onToggle}
         aria-expanded={open}
-        className="w-full flex items-center gap-3 p-4 text-left hover:bg-slate-800/80 transition-colors"
+        className="w-full flex items-center gap-3 p-4 text-left hover:bg-slate-50 dark:hover:bg-slate-800/80 transition-colors"
       >
         {open ? (
-          <ChevronDown className="w-4 h-4 text-indigo-400 shrink-0" />
+          <ChevronDown className="w-4 h-4 text-indigo-700 dark:text-indigo-400 shrink-0" />
         ) : (
           <ChevronRight className="w-4 h-4 text-slate-500 shrink-0" />
         )}
-        <span className="w-7 h-7 rounded-full bg-indigo-600/20 text-indigo-300 text-xs flex items-center justify-center font-bold shrink-0">
+        <span className="w-7 h-7 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300 text-xs flex items-center justify-center font-bold shrink-0">
           {guide.number}
         </span>
         <div className="flex-1 min-w-0">
-          <p className="font-semibold text-slate-100">{guide.name}</p>
-          <p className="text-xs text-slate-500 mt-0.5 truncate">{guide.whatItTeaches.split(".")[0]}.</p>
+          <p className="font-semibold text-slate-900 dark:text-slate-100">{translatedName}</p>
+          <p className="text-xs text-slate-600 dark:text-slate-500 mt-0.5 truncate">
+            {guide.whatItTeaches.split(".")[0]}.
+          </p>
         </div>
       </button>
 
@@ -66,48 +74,50 @@ function GuideAccordion({
 }
 
 function GuideBody({ guide }: { guide: ModuleGuide }) {
+  const { t } = useTranslation();
+
   return (
-    <div className="px-5 pb-5 pt-1 space-y-5 border-t border-slate-700/50">
-      <Block title="What This Module Teaches">
-        <p className="text-sm text-slate-300">{guide.whatItTeaches}</p>
+    <div className="px-5 pb-5 pt-1 space-y-5 border-t border-slate-200 dark:border-slate-700/50">
+      <Block title={t("pathways.resources.moduleGuides.blocks.whatItTeaches")}>
+        <p className="text-sm text-slate-700 dark:text-slate-300">{guide.whatItTeaches}</p>
       </Block>
 
-      <Block title="Why It Matters">
+      <Block title={t("pathways.resources.moduleGuides.blocks.whyItMatters")}>
         {guide.whyItMatters.map((p, i) => (
-          <p key={i} className="text-sm text-slate-300 mt-2 first:mt-0">
+          <p key={i} className="text-sm text-slate-700 dark:text-slate-300 mt-2 first:mt-0">
             {p}
           </p>
         ))}
       </Block>
 
-      <Block title="Time Required">
-        <p className="text-sm text-slate-300">{guide.timeRequired}</p>
+      <Block title={t("pathways.resources.moduleGuides.blocks.timeRequired")}>
+        <p className="text-sm text-slate-700 dark:text-slate-300">{guide.timeRequired}</p>
       </Block>
 
-      <Block title="What to Expect">
-        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-300">
+      <Block title={t("pathways.resources.moduleGuides.blocks.whatToExpect")}>
+        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-700 dark:text-slate-300">
           {guide.whatToExpect.map((b, i) => (
             <li key={i}>{b}</li>
           ))}
         </ul>
       </Block>
 
-      <Block title="Facilitator Role">
-        <RolePhase label="Before they start" items={guide.facilitatorRole.before} />
-        <RolePhase label="While they're working" items={guide.facilitatorRole.during} />
-        <RolePhase label="After they finish" items={guide.facilitatorRole.after} />
+      <Block title={t("pathways.resources.moduleGuides.blocks.facilitatorRole")}>
+        <RolePhase label={t("pathways.resources.moduleGuides.blocks.facilitatorBefore")} items={guide.facilitatorRole.before} />
+        <RolePhase label={t("pathways.resources.moduleGuides.blocks.facilitatorDuring")} items={guide.facilitatorRole.during} />
+        <RolePhase label={t("pathways.resources.moduleGuides.blocks.facilitatorAfter")} items={guide.facilitatorRole.after} />
       </Block>
 
       <div className="grid md:grid-cols-2 gap-4">
-        <Block title="Discussion Questions — Before">
-          <ol className="list-decimal list-outside pl-5 space-y-1.5 text-sm text-slate-300">
+        <Block title={t("pathways.resources.moduleGuides.blocks.discussionBefore")}>
+          <ol className="list-decimal list-outside pl-5 space-y-1.5 text-sm text-slate-700 dark:text-slate-300">
             {guide.discussionBefore.map((q, i) => (
               <li key={i}>{q}</li>
             ))}
           </ol>
         </Block>
-        <Block title="Discussion Questions — After">
-          <ol className="list-decimal list-outside pl-5 space-y-1.5 text-sm text-slate-300">
+        <Block title={t("pathways.resources.moduleGuides.blocks.discussionAfter")}>
+          <ol className="list-decimal list-outside pl-5 space-y-1.5 text-sm text-slate-700 dark:text-slate-300">
             {guide.discussionAfter.map((q, i) => (
               <li key={i}>{q}</li>
             ))}
@@ -115,42 +125,42 @@ function GuideBody({ guide }: { guide: ModuleGuide }) {
         </Block>
       </div>
 
-      <Block title="Common Sticking Points">
+      <Block title={t("pathways.resources.moduleGuides.blocks.stickingPoints")}>
         <div className="space-y-3">
           {guide.stickingPoints.map((sp, i) => (
-            <div key={i} className="p-3 rounded-lg bg-slate-900/50 border border-slate-700/50">
-              <p className="text-sm font-medium text-amber-300">{sp.point}</p>
-              <p className="text-sm text-slate-400 mt-1">{sp.guidance}</p>
+            <div key={i} className="p-3 rounded-lg bg-amber-50 border border-amber-200 dark:bg-slate-900/50 dark:border-slate-700/50">
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">{sp.point}</p>
+              <p className="text-sm text-slate-700 dark:text-slate-400 mt-1">{sp.guidance}</p>
             </div>
           ))}
         </div>
       </Block>
 
-      <Block title="Extension Activities">
-        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-300">
+      <Block title={t("pathways.resources.moduleGuides.blocks.extensions")}>
+        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-700 dark:text-slate-300">
           {guide.extensions.map((e, i) => (
             <li key={i}>{e}</li>
           ))}
         </ul>
       </Block>
 
-      <Block title="Real-World Connection">
-        <p className="text-sm text-slate-300 italic">{guide.realWorld}</p>
+      <Block title={t("pathways.resources.moduleGuides.blocks.realWorld")}>
+        <p className="text-sm text-slate-700 dark:text-slate-300 italic">{guide.realWorld}</p>
       </Block>
 
-      <Block title="Vocabulary">
+      <Block title={t("pathways.resources.moduleGuides.blocks.vocabulary")}>
         <dl className="grid sm:grid-cols-2 gap-x-4 gap-y-2 text-sm">
           {guide.vocabulary.map((v, i) => (
             <div key={i}>
-              <dt className="font-semibold text-cyan-300">{v.term}</dt>
-              <dd className="text-slate-400 text-xs">{v.definition}</dd>
+              <dt className="font-semibold text-cyan-700 dark:text-cyan-300">{v.term}</dt>
+              <dd className="text-slate-600 dark:text-slate-400 text-xs">{v.definition}</dd>
             </div>
           ))}
         </dl>
       </Block>
 
-      <Block title="Red Flags / When to Worry">
-        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-rose-300/90">
+      <Block title={t("pathways.resources.moduleGuides.blocks.redFlags")}>
+        <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-rose-700 dark:text-rose-300/90">
           {guide.redFlags.map((rf, i) => (
             <li key={i}>{rf}</li>
           ))}
@@ -163,7 +173,9 @@ function GuideBody({ guide }: { guide: ModuleGuide }) {
 function Block({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-2">{title}</h4>
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-500 mb-2">
+        {title}
+      </h4>
       {children}
     </div>
   );
@@ -172,8 +184,8 @@ function Block({ title, children }: { title: string; children: React.ReactNode }
 function RolePhase({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="mb-3 last:mb-0">
-      <p className="text-xs font-medium text-indigo-300 mb-1">{label}</p>
-      <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-300">
+      <p className="text-xs font-medium text-indigo-700 dark:text-indigo-300 mb-1">{label}</p>
+      <ul className="list-disc list-outside pl-5 space-y-1 text-sm text-slate-700 dark:text-slate-300">
         {items.map((b, i) => (
           <li key={i}>{b}</li>
         ))}

--- a/src/components/pathways/facilitator/tabs/OverviewTab.tsx
+++ b/src/components/pathways/facilitator/tabs/OverviewTab.tsx
@@ -1,102 +1,95 @@
+import { useTranslation } from "react-i18next";
 import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
 import Section from "./Section";
 
 export default function OverviewTab() {
-  const cyberTrack = PATHWAY_TRACKS.find((t) => t.slug === "cyber-launch");
+  const { t } = useTranslation();
+  const cyberTrack = PATHWAY_TRACKS.find((track) => track.slug === "cyber-launch");
+  const howSteps = t("pathways.resources.overview.howSteps", { returnObjects: true }) as string[];
+  const talkingPoints = t("pathways.resources.overview.talkingPoints", { returnObjects: true }) as string[];
+  const newFacilitatorSteps = t("pathways.resources.overview.newFacilitatorSteps", { returnObjects: true }) as string[];
 
   return (
     <div className="space-y-6">
-      <Section title="What is Bright Boost Pathways?">
-        <p>
-          Bright Boost Pathways is a career-connected learning program for youth ages 14-17. It delivers hands-on, project-based modules across five tracks: cybersecurity, entrepreneurship, financial literacy, technology, and creative media.
-        </p>
-        <p>
-          The program is designed for delivery in community settings, correctional education, workforce programs, and alternative schools — anywhere young people need real skills and real pathways forward.
-        </p>
+      <Section title={t("pathways.resources.overview.whatIsTitle")}>
+        <p>{t("pathways.resources.overview.whatIsBody1")}</p>
+        <p>{t("pathways.resources.overview.whatIsBody2")}</p>
       </Section>
 
-      <Section title="Two Bands">
+      <Section title={t("pathways.resources.overview.bandsTitle")}>
         <div className="grid md:grid-cols-2 gap-4">
-          <div className="p-4 rounded-xl border border-indigo-800/30 bg-indigo-900/10">
-            <h4 className="font-semibold text-indigo-300">Explorer (Ages 14-15)</h4>
-            <p className="text-sm text-slate-400 mt-1">
-              Foundation skills, exposure, and discovery. Build confidence with hands-on activities.
+          <div className="p-4 rounded-xl border border-indigo-200 bg-indigo-50 dark:border-indigo-800/30 dark:bg-indigo-900/10">
+            <h4 className="font-semibold text-indigo-700 dark:text-indigo-300">
+              {t("pathways.resources.overview.explorerLabel")}
+            </h4>
+            <p className="text-sm text-slate-700 dark:text-slate-400 mt-1">
+              {t("pathways.resources.overview.explorerDesc")}
             </p>
           </div>
-          <div className="p-4 rounded-xl border border-cyan-800/30 bg-cyan-900/10">
-            <h4 className="font-semibold text-cyan-300">Launch (Ages 16-17)</h4>
-            <p className="text-sm text-slate-400 mt-1">
-              Credential prep, portfolio building, and career planning. Get ready for what comes next.
+          <div className="p-4 rounded-xl border border-cyan-200 bg-cyan-50 dark:border-cyan-800/30 dark:bg-cyan-900/10">
+            <h4 className="font-semibold text-cyan-700 dark:text-cyan-300">
+              {t("pathways.resources.overview.launchLabel")}
+            </h4>
+            <p className="text-sm text-slate-700 dark:text-slate-400 mt-1">
+              {t("pathways.resources.overview.launchDesc")}
             </p>
           </div>
         </div>
       </Section>
 
-      <Section title="How It Works">
+      <Section title={t("pathways.resources.overview.howTitle")}>
         <div className="flex flex-wrap gap-3 text-sm">
-          {[
-            "Enroll in cohort",
-            "Pick tracks",
-            "Complete modules",
-            "Earn milestones",
-            "Build capstone",
-            "Next steps",
-          ].map((step, i) => (
+          {howSteps?.map((step, i) => (
             <div key={i} className="flex items-center gap-2">
-              <span className="w-6 h-6 rounded-full bg-indigo-600/20 text-indigo-400 text-xs flex items-center justify-center font-bold">
+              <span className="w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-400 text-xs flex items-center justify-center font-bold">
                 {i + 1}
               </span>
-              <span className="text-slate-300">{step}</span>
-              {i < 5 && <span className="text-slate-600">→</span>}
+              <span className="text-slate-800 dark:text-slate-300">{step}</span>
+              {i < howSteps.length - 1 && <span className="text-slate-400 dark:text-slate-600">→</span>}
             </div>
           ))}
         </div>
       </Section>
 
       {cyberTrack && (
-        <Section title="Cyber Launch Track (Active)" subtitle={cyberTrack.description}>
+        <Section
+          title={t("pathways.resources.overview.trackActiveTitle")}
+          subtitle={t(`pathways.tracks.items.${cyberTrack.slug}.description`, cyberTrack.description) as string}
+        >
           <div className="space-y-2">
-            {cyberTrack.modules.map((m, i) => (
-              <div
-                key={m.slug}
-                className="flex items-center gap-3 p-3 rounded-lg bg-slate-800/50 border border-slate-700/50"
-              >
-                <span className="w-6 h-6 rounded-full bg-slate-700 text-slate-300 text-xs flex items-center justify-center font-bold">
-                  {i + 1}
-                </span>
-                <div>
-                  <p className="text-sm font-medium text-slate-200">{m.name}</p>
-                  <p className="text-xs text-slate-500">
-                    {m.description} • {m.duration}
-                  </p>
+            {cyberTrack.modules.map((m, i) => {
+              const name = t(`pathways.tracks.modules.${m.slug}.name`, m.name) as string;
+              const description = t(`pathways.tracks.modules.${m.slug}.description`, m.description) as string;
+              return (
+                <div
+                  key={m.slug}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-slate-50 border border-slate-200 dark:bg-slate-800/50 dark:border-slate-700/50"
+                >
+                  <span className="w-6 h-6 rounded-full bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-300 text-xs flex items-center justify-center font-bold">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-200">{name}</p>
+                    <p className="text-xs text-slate-600 dark:text-slate-500">
+                      {description} • {m.duration}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </Section>
       )}
 
-      <Section title="Key Talking Points">
-        <ul className="space-y-2 text-sm text-slate-400 list-disc list-inside">
-          <li>Nearly 470,000 cybersecurity jobs are open in the U.S. right now (NIST CyberSeek).</li>
-          <li>
-            You don't need a 4-year degree to start — free industry certifications like ISC2 Certified in Cybersecurity open real doors.
-          </li>
-          <li>This program builds real skills students can put on a resume — not just enrichment.</li>
-          <li>
-            Major employers — IBM, Apple, Amazon — have dropped degree requirements for many tech roles.
-          </li>
+      <Section title={t("pathways.resources.overview.talkingPointsTitle")}>
+        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-400 list-disc list-inside">
+          {talkingPoints?.map((point, i) => <li key={i}>{point}</li>)}
         </ul>
       </Section>
 
-      <Section title="Where to Start as a New Facilitator">
-        <ol className="space-y-2 text-sm text-slate-400 list-decimal list-inside">
-          <li>Read this Program Overview tab end to end.</li>
-          <li>Read the Module Guide for Module 1 (Cyber Foundations) — it sets tone for the whole program.</li>
-          <li>Read the Facilitation Tips tab, especially "Setting Tone Day One."</li>
-          <li>Print the worksheets you'll need for week 1 and 2 ahead of time.</li>
-          <li>Create your own Cisco NetAcad account so you can guide students through it.</li>
-          <li>Have the partner organization's support contacts handy for referrals.</li>
+      <Section title={t("pathways.resources.overview.newFacilitatorTitle")}>
+        <ol className="space-y-2 text-sm text-slate-700 dark:text-slate-400 list-decimal list-inside">
+          {newFacilitatorSteps?.map((step, i) => <li key={i}>{step}</li>)}
         </ol>
       </Section>
     </div>

--- a/src/components/pathways/facilitator/tabs/Section.tsx
+++ b/src/components/pathways/facilitator/tabs/Section.tsx
@@ -1,5 +1,6 @@
 /**
  * Shared Section card used across all facilitator resource tabs.
+ * Light/dark aware via Tailwind dark: variants.
  */
 import type { ReactNode } from "react";
 
@@ -15,10 +16,13 @@ export default function Section({
   id?: string;
 }) {
   return (
-    <div id={id} className="rounded-xl border border-slate-700 bg-slate-800/50 p-5 scroll-mt-20">
-      <h3 className="font-semibold text-slate-200 mb-1">{title}</h3>
-      {subtitle && <p className="text-xs text-slate-500 mb-3">{subtitle}</p>}
-      <div className="text-sm text-slate-300 space-y-2">{children}</div>
+    <div
+      id={id}
+      className="rounded-xl border bg-white border-slate-200 dark:border-slate-700 dark:bg-slate-800/50 p-5 scroll-mt-20 shadow-sm"
+    >
+      <h3 className="font-semibold text-slate-900 dark:text-slate-200 mb-1">{title}</h3>
+      {subtitle && <p className="text-xs text-slate-600 dark:text-slate-500 mb-3">{subtitle}</p>}
+      <div className="text-sm text-slate-700 dark:text-slate-300 space-y-2">{children}</div>
     </div>
   );
 }

--- a/src/components/pathways/facilitator/tabs/SessionGuideTab.tsx
+++ b/src/components/pathways/facilitator/tabs/SessionGuideTab.tsx
@@ -1,79 +1,43 @@
+import { useTranslation } from "react-i18next";
 import Section from "./Section";
 
 const WEEKS = [
-  {
-    week: 1,
-    focus: "Orientation + Foundations",
-    modules: "Cyber Foundations",
-    notes:
-      "Introductions, program overview, cohort norms, why cyber matters. Establish the 'many ways in' framing early.",
-    minutes: 60,
-  },
-  {
-    week: 2,
-    focus: "Hands-On Safety",
-    modules: "Digital Safety Sim + Worksheet 3 (Account Audit)",
-    notes:
-      "Let students discover phishing first, then debrief. Every student leaves with at least one MFA enabled.",
-    minutes: 75,
-  },
-  {
-    week: 3,
-    focus: "How the Internet Works",
-    modules: "Network Basics + Worksheet 4 (Network Map)",
-    notes:
-      "Hardest module — pace slowly. Use the packet-tracing group activity. Plan a mid-session stretch break.",
-    minutes: 75,
-  },
-  {
-    week: 4,
-    focus: "Be the Analyst",
-    modules: "Threat Detective + Worksheet 5 (IR Tabletop)",
-    notes:
-      "Pair students for log analysis. Walk through one entry together before letting them work alone.",
-    minutes: 75,
-  },
-  {
-    week: 5,
-    focus: "Career Exploration + Cisco Bridge",
-    modules: "Cyber Career Map + Cisco NetAcad setup + Worksheet 1 (Career Interest)",
-    notes:
-      "Create NetAcad accounts in session — not as homework. Capture each student's top role on the tracker.",
-    minutes: 90,
-  },
-  {
-    week: 6,
-    focus: "Capstone + Showcase",
-    modules: "Capstone + Worksheet 6 (Planning Doc) + Worksheet 7 (Roadmap)",
-    notes:
-      "Plan a showcase — invite partner staff, family, community. Students present their security plans.",
-    minutes: 90,
-  },
+  { week: 1, focus: "Orientation + Foundations", modules: "Cyber Foundations", notes: "Introductions, program overview, cohort norms, why cyber matters. Establish the 'many ways in' framing early.", minutes: 60 },
+  { week: 2, focus: "Hands-On Safety", modules: "Digital Safety Sim + Worksheet 3 (Account Audit)", notes: "Let students discover phishing first, then debrief. Every student leaves with at least one MFA enabled.", minutes: 75 },
+  { week: 3, focus: "How the Internet Works", modules: "Network Basics + Worksheet 4 (Network Map)", notes: "Hardest module — pace slowly. Use the packet-tracing group activity. Plan a mid-session stretch break.", minutes: 75 },
+  { week: 4, focus: "Be the Analyst", modules: "Threat Detective + Worksheet 5 (IR Tabletop)", notes: "Pair students for log analysis. Walk through one entry together before letting them work alone.", minutes: 75 },
+  { week: 5, focus: "Career Exploration + Cisco Bridge", modules: "Cyber Career Map + Cisco NetAcad setup + Worksheet 1 (Career Interest)", notes: "Create NetAcad accounts in session — not as homework. Capture each student's top role on the tracker.", minutes: 90 },
+  { week: 6, focus: "Capstone + Showcase", modules: "Capstone + Worksheet 6 (Planning Doc) + Worksheet 7 (Roadmap)", notes: "Plan a showcase — invite partner staff, family, community. Students present their security plans.", minutes: 90 },
 ];
 
 export default function SessionGuideTab() {
+  const { t } = useTranslation();
+
   return (
     <div className="space-y-6">
-      <Section title="6-Week Pacing Guide" subtitle="Pair each week's module with the matching worksheet for stronger outcomes.">
+      <Section
+        title={t("pathways.resources.sessions.pacingTitle")}
+        subtitle={t("pathways.resources.sessions.pacingSub")}
+      >
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-            <thead className="bg-slate-800">
-              <tr className="text-left text-xs text-slate-400 uppercase tracking-wider">
-                <th className="px-4 py-3">Week</th>
-                <th className="px-4 py-3">Focus</th>
-                <th className="px-4 py-3">Modules + Worksheets</th>
-                <th className="px-4 py-3">Facilitation Notes</th>
-                <th className="px-4 py-3">Min</th>
+            <thead className="bg-slate-100 dark:bg-slate-800">
+              <tr className="text-left text-xs text-slate-600 dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-4 py-3">{t("pathways.resources.sessions.tableHead.week")}</th>
+                <th className="px-4 py-3">{t("pathways.resources.sessions.tableHead.focus")}</th>
+                <th className="px-4 py-3">{t("pathways.resources.sessions.tableHead.modules")}</th>
+                <th className="px-4 py-3">{t("pathways.resources.sessions.tableHead.notes")}</th>
+                <th className="px-4 py-3">{t("pathways.resources.sessions.tableHead.minutes")}</th>
               </tr>
             </thead>
             <tbody>
               {WEEKS.map((w) => (
-                <tr key={w.week} className="border-t border-slate-700/50 align-top">
-                  <td className="px-4 py-3 font-bold text-indigo-400">{w.week}</td>
-                  <td className="px-4 py-3 text-slate-200">{w.focus}</td>
-                  <td className="px-4 py-3 text-slate-300 text-xs">{w.modules}</td>
-                  <td className="px-4 py-3 text-slate-400 text-xs">{w.notes}</td>
-                  <td className="px-4 py-3 text-slate-400 text-xs">{w.minutes}</td>
+                <tr key={w.week} className="border-t border-slate-200 dark:border-slate-700/50 align-top">
+                  <td className="px-4 py-3 font-bold text-indigo-700 dark:text-indigo-400">{w.week}</td>
+                  <td className="px-4 py-3 text-slate-900 dark:text-slate-200">{w.focus}</td>
+                  <td className="px-4 py-3 text-slate-700 dark:text-slate-300 text-xs">{w.modules}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 text-xs">{w.notes}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 text-xs">{w.minutes}</td>
                 </tr>
               ))}
             </tbody>
@@ -81,27 +45,37 @@ export default function SessionGuideTab() {
         </div>
       </Section>
 
-      <Section title="Pacing Variations">
-        <ul className="space-y-2 text-sm text-slate-400 list-disc list-inside">
+      <Section title={t("pathways.resources.sessions.variationsTitle")}>
+        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-400 list-disc list-inside">
           <li>
-            <strong className="text-slate-300">Compressed (intensive):</strong> Two 90-minute sessions per week for 3 weeks. Best for summer programs and dedicated weeks.
+            <strong className="text-slate-900 dark:text-slate-300">Compressed (intensive):</strong> Two 90-minute sessions per week for 3 weeks. Best for summer programs and dedicated weeks.
           </li>
           <li>
-            <strong className="text-slate-300">Extended (every other week):</strong> One session every two weeks for 12 weeks. Best when the site has other competing programming.
+            <strong className="text-slate-900 dark:text-slate-300">Extended (every other week):</strong> One session every two weeks for 12 weeks. Best when the site has other competing programming.
           </li>
           <li>
-            <strong className="text-slate-300">Drop-in (open lab):</strong> Self-paced with facilitator office hours. Best for older Launch-band cohorts who want flexibility.
+            <strong className="text-slate-900 dark:text-slate-300">Drop-in (open lab):</strong> Self-paced with facilitator office hours. Best for older Launch-band cohorts who want flexibility.
           </li>
         </ul>
       </Section>
 
-      <Section title="Each Session — Suggested Structure">
-        <ol className="space-y-2 text-sm text-slate-400 list-decimal list-inside">
-          <li><strong className="text-slate-300">Check-in (5-10 min):</strong> What did you do with last week's work? Anything come up?</li>
-          <li><strong className="text-slate-300">Frame (5 min):</strong> Today's module, why it matters, what students will leave with.</li>
-          <li><strong className="text-slate-300">Module work (25-35 min):</strong> Individual or paired work in the platform.</li>
-          <li><strong className="text-slate-300">Worksheet or discussion (15-25 min):</strong> Pair the digital work with a tactile or conversational follow-up.</li>
-          <li><strong className="text-slate-300">Close (5-10 min):</strong> One thing you learned, one thing you'll do this week, one question.</li>
+      <Section title={t("pathways.resources.sessions.structureTitle")}>
+        <ol className="space-y-2 text-sm text-slate-700 dark:text-slate-400 list-decimal list-inside">
+          <li>
+            <strong className="text-slate-900 dark:text-slate-300">Check-in (5-10 min):</strong> What did you do with last week's work? Anything come up?
+          </li>
+          <li>
+            <strong className="text-slate-900 dark:text-slate-300">Frame (5 min):</strong> Today's module, why it matters, what students will leave with.
+          </li>
+          <li>
+            <strong className="text-slate-900 dark:text-slate-300">Module work (25-35 min):</strong> Individual or paired work in the platform.
+          </li>
+          <li>
+            <strong className="text-slate-900 dark:text-slate-300">Worksheet or discussion (15-25 min):</strong> Pair the digital work with a tactile or conversational follow-up.
+          </li>
+          <li>
+            <strong className="text-slate-900 dark:text-slate-300">Close (5-10 min):</strong> One thing you learned, one thing you'll do this week, one question.
+          </li>
         </ol>
       </Section>
     </div>

--- a/src/components/pathways/facilitator/tabs/WorksheetsTab.tsx
+++ b/src/components/pathways/facilitator/tabs/WorksheetsTab.tsx
@@ -1,16 +1,19 @@
+import { useTranslation } from "react-i18next";
 import { FileText, Printer } from "lucide-react";
 import { WORKSHEETS, openWorksheetPrint } from "../data/worksheets";
 import Section from "./Section";
 
 export default function WorksheetsTab() {
+  const { t } = useTranslation();
+  const printTips = t("pathways.resources.worksheets.printTips", { returnObjects: true }) as string[];
+
   return (
     <div className="space-y-6">
-      <Section title="Printable Worksheets" subtitle="Each opens in a new tab as a print-ready document. Facilitator notes are visible on screen but hidden in print.">
-        <p className="text-sm text-slate-400">
-          Worksheets are designed to pair with specific modules. The Session Guide tab shows which
-          worksheet matches each week. Print ahead of session — students who fill them out by hand
-          retain more than those who type.
-        </p>
+      <Section
+        title={t("pathways.resources.worksheets.title")}
+        subtitle={t("pathways.resources.worksheets.sub")}
+      >
+        <p className="text-sm text-slate-700 dark:text-slate-400">{t("pathways.resources.worksheets.body")}</p>
       </Section>
 
       <div className="grid gap-3 md:grid-cols-2">
@@ -19,13 +22,9 @@ export default function WorksheetsTab() {
         ))}
       </div>
 
-      <Section title="Print Tips">
-        <ul className="text-sm text-slate-400 list-disc list-inside space-y-1">
-          <li>Worksheets open in a new tab and auto-trigger the browser print dialog.</li>
-          <li>If the print dialog doesn't open, press Ctrl/Cmd+P in the new tab.</li>
-          <li>Facilitator notes (in dashed cyan boxes) are hidden when printing.</li>
-          <li>For double-sided printing, choose "Long edge" binding in your printer settings.</li>
-          <li>If you want a clean PDF, choose "Save as PDF" instead of a physical printer.</li>
+      <Section title={t("pathways.resources.worksheets.printTipsTitle")}>
+        <ul className="text-sm text-slate-700 dark:text-slate-400 list-disc list-inside space-y-1">
+          {printTips?.map((tip, i) => <li key={i}>{tip}</li>)}
         </ul>
       </Section>
     </div>
@@ -45,28 +44,31 @@ function WorksheetCard({
   duration: string;
   buildHtml: () => string;
 }) {
+  const { t } = useTranslation();
   const handlePrint = () => {
     openWorksheetPrint(buildHtml());
   };
 
   return (
-    <div className="p-4 rounded-xl border border-slate-700 bg-slate-800/50 flex items-start gap-3">
-      <div className="w-9 h-9 rounded-lg bg-indigo-600/20 flex items-center justify-center shrink-0">
-        <FileText className="w-4 h-4 text-indigo-400" />
+    <div className="p-4 rounded-xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 flex items-start gap-3 shadow-sm">
+      <div className="w-9 h-9 rounded-lg bg-indigo-100 dark:bg-indigo-600/20 flex items-center justify-center shrink-0">
+        <FileText className="w-4 h-4 text-indigo-700 dark:text-indigo-400" />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-xs text-slate-500">Worksheet {number}</p>
-        <p className="font-medium text-slate-200 text-sm">{title}</p>
-        <p className="text-xs text-slate-400 mt-1 leading-relaxed">{description}</p>
+        <p className="text-xs text-slate-600 dark:text-slate-500">
+          {t("pathways.resources.worksheets.worksheetLabel", { n: number })}
+        </p>
+        <p className="font-medium text-slate-900 dark:text-slate-200 text-sm">{title}</p>
+        <p className="text-xs text-slate-600 dark:text-slate-400 mt-1 leading-relaxed">{description}</p>
         <p className="text-xs text-slate-500 mt-1">{duration}</p>
       </div>
       <button
         onClick={handlePrint}
-        aria-label={`Print worksheet ${title}`}
-        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-200 text-xs font-medium transition-colors shrink-0"
+        aria-label={t("pathways.resources.worksheets.printLabel") + " " + title}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-700 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-200 text-xs font-medium transition-colors shrink-0"
       >
         <Printer className="w-3.5 h-3.5" />
-        Print
+        {t("pathways.resources.worksheets.printLabel")}
       </button>
     </div>
   );

--- a/src/components/pathways/modules/CyberLaunchModules.tsx
+++ b/src/components/pathways/modules/CyberLaunchModules.tsx
@@ -3,9 +3,16 @@
  *
  * 7 self-contained modules for teens (14-17).
  * Each exports a named component accepting { onComplete, onBack }.
- * Dark, clean, modern UI — indigo/teal/slate palette.
+ * Light/dark aware via Tailwind `dark:` variants — inherits the `.dark`
+ * class scope from PathwaysLayout.
+ *
+ * i18n: Module 1 (CyberFoundations) slide/role/quiz content reads from
+ * the `pathways.modules.foundations.*` keys. Modules 2-7 are wired for
+ * UI chrome (titles, buttons) but interior scenario content remains in
+ * English — see docs/pathways-translation-status.md for the path forward.
  */
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 // ── Shared types & helpers ────────────────────────────────────────────────
 
@@ -17,9 +24,9 @@ interface ModuleProps {
 function ProgressBar({ current, total }: { current: number; total: number }) {
   const pct = Math.round((current / total) * 100);
   return (
-    <div className="w-full bg-slate-700 rounded h-1.5">
+    <div className="w-full bg-slate-200 dark:bg-slate-700 rounded h-1.5">
       <div
-        className="bg-indigo-500 h-1.5 rounded transition-all duration-300"
+        className="bg-indigo-600 dark:bg-indigo-500 h-1.5 rounded transition-all duration-300"
         style={{ width: `${pct}%` }}
       />
     </div>
@@ -39,17 +46,18 @@ function ModuleShell({
   onBack: () => void;
   children: React.ReactNode;
 }) {
+  const { t } = useTranslation();
   return (
-    <div className="min-h-screen bg-slate-900 text-white p-4 sm:p-6">
+    <div className="bg-white text-slate-900 dark:bg-slate-900 dark:text-white p-4 sm:p-6 rounded-2xl border border-slate-200 dark:border-slate-800">
       <div className="max-w-2xl mx-auto space-y-4">
         <div className="flex items-center justify-between">
           <button
             onClick={onBack}
-            className="text-sm text-slate-400 hover:text-white transition-colors"
+            className="text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors"
           >
-            &larr; Back
+            &larr; {t("pathways.common.back")}
           </button>
-          <span className="text-xs text-slate-500">
+          <span className="text-xs text-slate-500 dark:text-slate-500">
             {step}/{totalSteps}
           </span>
         </div>
@@ -75,10 +83,10 @@ function Card({
   const base =
     "border rounded-lg p-4 transition-all duration-200 " +
     (selected
-      ? "border-indigo-500 bg-indigo-900/40 shadow-lg shadow-indigo-500/10"
-      : "border-slate-700 bg-slate-800 shadow-lg");
+      ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/40 shadow-lg shadow-indigo-500/10"
+      : "border-slate-200 bg-white dark:border-slate-200 dark:border-slate-700 dark:bg-white dark:bg-slate-800 shadow-sm");
   const interactive = onClick
-    ? " cursor-pointer hover:border-indigo-400 hover:bg-slate-750 active:scale-[0.98]"
+    ? " cursor-pointer hover:border-indigo-400 hover:bg-slate-50 dark:hover:bg-slate-750 active:scale-[0.98]"
     : "";
   return (
     <div className={`${base}${interactive} ${className}`} onClick={onClick}>
@@ -100,7 +108,7 @@ function PrimaryButton({
     <button
       onClick={onClick}
       disabled={disabled}
-      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 disabled:bg-slate-700 disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
+      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 disabled:text-slate-500 dark:hover:bg-indigo-500 dark:disabled:bg-slate-700 dark:disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
     >
       {children}
     </button>
@@ -180,11 +188,17 @@ const CYBER_QUIZ = [
 ];
 
 export function CyberFoundations({ onComplete, onBack }: ModuleProps) {
+  const { t } = useTranslation();
   const [step, setStep] = useState(0);
   const [quizIdx, setQuizIdx] = useState(0);
   const [quizScore, setQuizScore] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
   const [answered, setAnswered] = useState(false);
+
+  // Read translated slide/role/quiz content via i18n with TS fallbacks.
+  const slides = t("pathways.modules.foundations.slides", { returnObjects: true }) as Array<{ title: string; body?: string }>;
+  const roles = t("pathways.modules.foundations.roles", { returnObjects: true }) as Array<{ name: string; desc: string; pay: string }>;
+  const quizItems = t("pathways.modules.foundations.quiz", { returnObjects: true }) as Array<{ q: string; opts: string[] }>;
 
   const totalSlides = CYBER_SLIDES.length;
   const inQuiz = step >= totalSlides;
@@ -214,61 +228,76 @@ export function CyberFoundations({ onComplete, onBack }: ModuleProps) {
   };
 
   const currentStep = step + 1;
-  const slide = !inQuiz ? CYBER_SLIDES[step] : null;
-  const quiz = inQuiz ? CYBER_QUIZ[quizIdx] : null;
+  const englishSlide = !inQuiz ? CYBER_SLIDES[step] : null;
+  const localizedSlide = !inQuiz ? slides?.[step] : null;
+  const englishQuiz = inQuiz ? CYBER_QUIZ[quizIdx] : null;
+  const localizedQuiz = inQuiz ? quizItems?.[quizIdx] : null;
+
+  const slideTitle = localizedSlide?.title ?? englishSlide?.title ?? "";
+  const slideBody = localizedSlide?.body ?? (englishSlide && "body" in englishSlide ? englishSlide.body : "");
+  const slideHasRoles = englishSlide && "roles" in englishSlide && Array.isArray(englishSlide.roles);
 
   return (
-    <ModuleShell title="Cyber Foundations" step={currentStep} totalSteps={totalSteps} onBack={onBack}>
-      {slide && !("roles" in slide && slide.roles) && (
+    <ModuleShell title={t("pathways.modules.foundations.title")} step={currentStep} totalSteps={totalSteps} onBack={onBack}>
+      {englishSlide && !slideHasRoles && (
         <Card className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-300">{slide.title}</h2>
-          <p className="text-sm text-slate-300 leading-relaxed">{slide.body}</p>
+          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-700 dark:text-indigo-300">{slideTitle}</h2>
+          <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">{slideBody}</p>
         </Card>
       )}
 
-      {slide && "roles" in slide && slide.roles && (
+      {englishSlide && slideHasRoles && (
         <div className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-300">{slide.title}</h2>
+          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-700 dark:text-indigo-300">{slideTitle}</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {slide.roles.map((r) => (
-              <Card key={r.name} className="space-y-1">
-                <p className="text-sm font-semibold text-white">{r.name}</p>
-                <p className="text-xs text-slate-400">{r.desc}</p>
-                <p className="text-xs text-teal-400 font-medium">{r.pay}</p>
-              </Card>
-            ))}
+            {englishSlide.roles!.map((r, i) => {
+              const lr = roles?.[i] ?? r;
+              return (
+                <Card key={r.name} className="space-y-1">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{lr.name}</p>
+                  <p className="text-xs text-slate-700 dark:text-slate-400">{lr.desc}</p>
+                  <p className="text-xs text-teal-700 dark:text-teal-400 font-medium">{lr.pay}</p>
+                </Card>
+              );
+            })}
           </div>
         </div>
       )}
 
-      {quiz && (
+      {englishQuiz && (
         <div className="mt-4 space-y-4">
           <Card className="space-y-1">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">Knowledge Check</p>
-            <p className="text-sm font-medium text-white">{quiz.q}</p>
+            <p className="text-xs text-slate-500 uppercase tracking-wider">
+              {t("pathways.common.knowledgeCheck")}
+            </p>
+            <p className="text-sm font-medium text-slate-900 dark:text-white">
+              {localizedQuiz?.q ?? englishQuiz.q}
+            </p>
           </Card>
           <div className="space-y-2">
-            {quiz.opts.map((opt, i) => {
-              let border = "border-slate-700";
-              if (answered && i === quiz.ans) border = "border-teal-500";
-              else if (answered && i === selected && i !== quiz.ans) border = "border-red-500";
+            {englishQuiz.opts.map((opt, i) => {
+              let border = "border-slate-200 dark:border-slate-200 dark:border-slate-700";
+              if (answered && i === englishQuiz.ans) border = "border-teal-500";
+              else if (answered && i === selected && i !== englishQuiz.ans) border = "border-red-500";
               return (
                 <button
                   key={i}
                   onClick={() => handleAnswer(i)}
                   disabled={answered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-slate-800 text-sm text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-700 transition-colors ${
+                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-white dark:bg-slate-800 text-sm text-slate-800 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-300 dark:disabled:hover:border-slate-200 dark:border-slate-700 transition-colors ${
                     selected === i ? "ring-1 ring-indigo-500" : ""
                   }`}
                 >
-                  {opt}
+                  {localizedQuiz?.opts?.[i] ?? opt}
                 </button>
               );
             })}
           </div>
           {answered && (
-            <p className="text-xs text-slate-400">
-              {selected === quiz.ans ? "Correct." : `Incorrect. The answer is: ${quiz.opts[quiz.ans]}`}
+            <p className="text-xs text-slate-700 dark:text-slate-400">
+              {selected === englishQuiz.ans
+                ? t("pathways.common.correct")
+                : t("pathways.common.incorrect", { answer: localizedQuiz?.opts?.[englishQuiz.ans] ?? englishQuiz.opts[englishQuiz.ans] })}
             </p>
           )}
         </div>
@@ -277,37 +306,37 @@ export function CyberFoundations({ onComplete, onBack }: ModuleProps) {
       <div className="flex justify-end mt-6">
         {!inQuiz && (
           <PrimaryButton onClick={handleNext}>
-            {step < totalSlides - 1 ? "Next" : "Start Quiz"}
+            {step < totalSlides - 1 ? t("pathways.common.next") : t("pathways.common.startQuiz")}
           </PrimaryButton>
         )}
         {inQuiz && answered && (
           <PrimaryButton onClick={handleNext}>
-            {quizIdx < CYBER_QUIZ.length - 1 ? "Next Question" : "Finish"}
+            {quizIdx < CYBER_QUIZ.length - 1 ? t("pathways.common.nextQuestion") : t("pathways.common.finish")}
           </PrimaryButton>
         )}
       </div>
 
       {/* Sources — visible on every slide so claims are verifiable */}
       <details className="mt-8 group">
-        <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-300 select-none">
-          Sources &amp; further reading
+        <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 select-none">
+          {t("pathways.common.sourcesHeading")}
         </summary>
-        <ul className="mt-2 space-y-1 pl-3 border-l border-slate-700">
+        <ul className="mt-2 space-y-1 pl-3 border-l border-slate-200 dark:border-slate-200 dark:border-slate-700">
           {CYBER_SOURCES.map((s) => (
-            <li key={s.url} className="text-xs text-slate-400">
+            <li key={s.url} className="text-xs text-slate-700 dark:text-slate-400">
               <a
                 href={s.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hover:text-indigo-300 hover:underline"
+                className="hover:text-indigo-700 dark:hover:text-indigo-700 dark:text-indigo-300 hover:underline"
               >
                 {s.label}
               </a>
             </li>
           ))}
         </ul>
-        <p className="text-[10px] text-slate-600 mt-2 pl-3">
-          Job-market and salary figures cited above are point-in-time references; verify against current BLS/CyberSeek data before quoting in partner materials.
+        <p className="text-[10px] text-slate-500 dark:text-slate-600 mt-2 pl-3">
+          {t("pathways.modules.foundations.sourcesDisclaimer")}
         </p>
       </details>
     </ModuleShell>
@@ -476,7 +505,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
       {/* Scenario 1: Phishing */}
       {step === 0 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">Identify the phishing email, then tap the red flags.</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Identify the phishing email, then tap the red flags.</p>
           <div className="space-y-3">
             {PHISH_EMAILS.map((email, i) => (
               <Card
@@ -488,11 +517,11 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
                 <div className="flex justify-between">
                   <p className="text-xs text-slate-500">From: {email.from}</p>
                   {phishSubmitted && email.isPhish && (
-                    <span className="text-xs text-red-400 font-medium">PHISHING</span>
+                    <span className="text-xs text-red-700 dark:text-red-400 font-medium">PHISHING</span>
                   )}
                 </div>
                 <p className="text-sm font-medium">{email.subject}</p>
-                <p className="text-xs text-slate-400">{email.body}</p>
+                <p className="text-xs text-slate-600 dark:text-slate-400">{email.body}</p>
               </Card>
             ))}
           </div>
@@ -512,7 +541,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
                   className={`w-full text-left p-2 rounded-lg border text-xs transition-colors ${
                     flagsFound.has(i)
                       ? "border-red-500 bg-red-900/20 text-red-300"
-                      : "border-slate-700 bg-slate-800 text-slate-400"
+                      : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400"
                   }`}
                 >
                   {flag}
@@ -525,7 +554,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handlePhishSubmit}>Submit</PrimaryButton>
           )}
           {phishSubmitted && (
-            <p className="text-xs text-teal-400">
+            <p className="text-xs text-teal-700 dark:text-teal-400">
               {phishSelected === 0 ? "Correct! You spotted the phishing email." : "Not quite — the first email was the phishing attempt."}
             </p>
           )}
@@ -535,11 +564,11 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
       {/* Scenario 2: Passwords */}
       {step === 1 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">Rate each password as weak or strong.</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Rate each password as weak or strong.</p>
           <div className="space-y-3">
             {PASSWORDS.map((p, i) => (
               <Card key={i} className="flex items-center justify-between">
-                <code className="text-sm text-slate-300 font-mono">{p.pw}</code>
+                <code className="text-sm text-slate-700 dark:text-slate-300 font-mono">{p.pw}</code>
                 <div className="flex gap-2">
                   {["weak", "strong"].map((rating) => (
                     <button
@@ -565,7 +594,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handlePwSubmit}>Submit</PrimaryButton>
           )}
           {pwSubmitted && (
-            <div className="text-xs text-teal-400 space-y-1">
+            <div className="text-xs text-teal-700 dark:text-teal-400 space-y-1">
               <p>Modern NIST guidance (SP 800-63B): length beats complexity. A long passphrase like four random words is stronger than a short scramble — and you don't have to rotate passwords on a schedule if they aren't compromised.</p>
               <p className="text-slate-500">A password manager lets you use a unique, long password for every account without memorizing them.</p>
             </div>
@@ -578,11 +607,11 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
         <div className="space-y-4 mt-4">
           <Card className="space-y-2">
             <p className="text-xs text-slate-500 uppercase tracking-wider">Incoming Call</p>
-            <p className="text-sm text-slate-300">
+            <p className="text-sm text-slate-700 dark:text-slate-300">
               "Hi, this is Mike from IT Support. We detected suspicious activity on your account. I need your password to reset it right now, or your account could be compromised."
             </p>
           </Card>
-          <p className="text-sm text-slate-400">What do you do?</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">What do you do?</p>
           <div className="grid grid-cols-2 gap-3">
             <Card
               onClick={() => !seChoice && handleSeChoice("comply")}
@@ -614,11 +643,11 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
       {/* Scenario 4: Public Wi-Fi */}
       {step === 3 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">You're on public Wi-Fi. Mark each action as safe or unsafe.</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">You're on public Wi-Fi. Mark each action as safe or unsafe.</p>
           <div className="space-y-3">
             {WIFI_ACTIONS.map((a, i) => (
               <Card key={i} className="flex items-center justify-between">
-                <p className="text-sm text-slate-300">{a.action}</p>
+                <p className="text-sm text-slate-700 dark:text-slate-300">{a.action}</p>
                 <div className="flex gap-2">
                   {[true, false].map((val) => (
                     <button
@@ -644,7 +673,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handleWifiSubmit}>Submit</PrimaryButton>
           )}
           {wifiSubmitted && (
-            <p className="text-xs text-teal-400">
+            <p className="text-xs text-teal-700 dark:text-teal-400">
               On public Wi-Fi: use a VPN, avoid banking and unencrypted logins.
             </p>
           )}
@@ -654,7 +683,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
       {/* Scenario 5: Breach Response */}
       {step === 4 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Your email was in a data breach. Order the response steps (tap in order):
           </p>
           <div className="space-y-2">
@@ -666,8 +695,8 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
                   onClick={() => toggleBreachItem(i)}
                   className={`w-full text-left p-3 rounded-lg border text-sm transition-colors flex items-center gap-3 ${
                     orderIdx >= 0
-                      ? "border-indigo-500 bg-indigo-900/20 text-white"
-                      : "border-slate-700 bg-slate-800 text-slate-400 hover:border-slate-500"
+                      ? "border-indigo-500 bg-indigo-900/20 text-slate-900 dark:text-white"
+                      : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-slate-500"
                   }`}
                 >
                   <span
@@ -686,7 +715,7 @@ export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handleBreachSubmit}>Submit</PrimaryButton>
           )}
           {breachSubmitted && (
-            <p className="text-xs text-teal-400">
+            <p className="text-xs text-teal-700 dark:text-teal-400">
               The ideal order: change password, enable 2FA, check other accounts, then monitor.
             </p>
           )}
@@ -833,14 +862,14 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
     <ModuleShell title="Network Basics" step={currentStep} totalSteps={totalSteps} onBack={onBack}>
       {inSlides && (
         <Card className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-300">{NET_SLIDES[step].title}</h2>
-          <p className="text-sm text-slate-300 leading-relaxed whitespace-pre-line">{NET_SLIDES[step].body}</p>
+          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-300">{NET_SLIDES[step].title}</h2>
+          <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-line">{NET_SLIDES[step].body}</p>
         </Card>
       )}
 
       {inTrace && (
         <div className="mt-4 space-y-4">
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Trace the packet: click the network nodes in the correct order.
           </p>
           <div className="flex flex-wrap gap-3 justify-center">
@@ -848,7 +877,7 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
             {[3, 0, 4, 1, 2].map((id) => {
               const node = TRACE_NODES[id];
               const orderIdx = traceClicked.indexOf(id);
-              let borderColor = "border-slate-700";
+              let borderColor = "border-slate-200 dark:border-slate-700";
               if (traceSubmitted) {
                 const correctPos = traceClicked.indexOf(id);
                 borderColor = correctPos === id ? "border-teal-500" : "border-red-500";
@@ -858,7 +887,7 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
                 <button
                   key={id}
                   onClick={() => handleTraceClick(id)}
-                  className={`px-4 py-3 rounded-lg border ${borderColor} bg-slate-800 text-sm transition-colors hover:border-indigo-400 flex items-center gap-2`}
+                  className={`px-4 py-3 rounded-lg border ${borderColor} bg-white dark:bg-slate-800 text-sm transition-colors hover:border-indigo-400 flex items-center gap-2`}
                 >
                   {orderIdx >= 0 && (
                     <span className="w-5 h-5 rounded bg-indigo-600 text-white text-xs flex items-center justify-center font-bold">
@@ -874,7 +903,7 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
             <PrimaryButton onClick={handleTraceSubmit}>Check Order</PrimaryButton>
           )}
           {traceSubmitted && (
-            <p className="text-xs text-teal-400">
+            <p className="text-xs text-teal-700 dark:text-teal-400">
               Correct path: Your Device &rarr; DNS Server &rarr; Web Server &rarr; Firewall &rarr; Your Device (Response)
             </p>
           )}
@@ -885,11 +914,11 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
         <div className="mt-4 space-y-4">
           <Card className="space-y-1">
             <p className="text-xs text-slate-500 uppercase tracking-wider">Knowledge Check</p>
-            <p className="text-sm font-medium text-white">{NET_QUIZ[quizIdx].q}</p>
+            <p className="text-sm font-medium text-slate-900 dark:text-white">{NET_QUIZ[quizIdx].q}</p>
           </Card>
           <div className="space-y-2">
             {NET_QUIZ[quizIdx].opts.map((opt, i) => {
-              let border = "border-slate-700";
+              let border = "border-slate-200 dark:border-slate-700";
               if (answered && i === NET_QUIZ[quizIdx].ans) border = "border-teal-500";
               else if (answered && i === selected) border = "border-red-500";
               return (
@@ -897,7 +926,7 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
                   key={i}
                   onClick={() => handleAnswer(i)}
                   disabled={answered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-slate-800 text-sm text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-700 transition-colors`}
+                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-slate-800 text-sm text-slate-700 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-200 dark:border-slate-700 transition-colors`}
                 >
                   {opt}
                 </button>
@@ -905,7 +934,7 @@ export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
             })}
           </div>
           {answered && (
-            <p className="text-xs text-slate-400">
+            <p className="text-xs text-slate-600 dark:text-slate-400">
               {selected === NET_QUIZ[quizIdx].ans ? "Correct." : `Incorrect. Answer: ${NET_QUIZ[quizIdx].opts[NET_QUIZ[quizIdx].ans]}`}
             </p>
           )}
@@ -1040,7 +1069,7 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
       {/* Phase 1: Log Analysis */}
       {phase === 0 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">Review the server logs. Select the suspicious entries.</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Review the server logs. Select the suspicious entries.</p>
           <div className="space-y-2">
             {LOG_ENTRIES.map((entry, i) => (
               <button
@@ -1049,14 +1078,14 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
                 className={`w-full text-left p-3 rounded-lg border text-xs font-mono transition-colors ${
                   selectedLogs.has(i)
                     ? "border-red-500 bg-red-900/20 text-red-300"
-                    : "border-slate-700 bg-slate-800 text-slate-400 hover:border-slate-500"
+                    : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-slate-500"
                 }`}
               >
                 <span className="text-slate-500">[{entry.time}]</span>{" "}
                 <span className="text-slate-500">{entry.ip}</span>{" "}
                 {entry.action}
                 {logsSubmitted && entry.suspicious && (
-                  <span className="ml-2 text-red-400">SUSPICIOUS</span>
+                  <span className="ml-2 text-red-700 dark:text-red-400">SUSPICIOUS</span>
                 )}
               </button>
             ))}
@@ -1079,11 +1108,11 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
             <p className="text-xs text-slate-500 uppercase tracking-wider">
               Question {qIdx + 1} of {LOG_QUESTIONS.length}
             </p>
-            <p className="text-sm font-medium text-white">{LOG_QUESTIONS[qIdx].q}</p>
+            <p className="text-sm font-medium text-slate-900 dark:text-white">{LOG_QUESTIONS[qIdx].q}</p>
           </Card>
           <div className="space-y-2">
             {LOG_QUESTIONS[qIdx].opts.map((opt, i) => {
-              let border = "border-slate-700";
+              let border = "border-slate-200 dark:border-slate-700";
               if (qAnswered && i === LOG_QUESTIONS[qIdx].ans) border = "border-teal-500";
               else if (qAnswered && i === qSelected) border = "border-red-500";
               return (
@@ -1091,7 +1120,7 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
                   key={i}
                   onClick={() => handleAnswer(i)}
                   disabled={qAnswered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-slate-800 text-sm text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-700 transition-colors`}
+                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-slate-800 text-sm text-slate-700 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-200 dark:border-slate-700 transition-colors`}
                 >
                   {opt}
                 </button>
@@ -1111,14 +1140,14 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
       {/* Phase 3: Incident Report */}
       {phase === 2 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">Complete the incident report.</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Complete the incident report.</p>
           <Card className="space-y-4">
             <div>
               <label className="text-xs text-slate-500 block mb-1">Severity</label>
               <select
                 value={severity}
                 onChange={(e) => setSeverity(e.target.value)}
-                className="w-full p-2 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white"
+                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
               >
                 <option value="">Select...</option>
                 {SEVERITY_OPTS.map((o) => (
@@ -1131,7 +1160,7 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
               <select
                 value={attackType}
                 onChange={(e) => setAttackType(e.target.value)}
-                className="w-full p-2 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white"
+                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
               >
                 <option value="">Select...</option>
                 {TYPE_OPTS.map((o) => (
@@ -1144,7 +1173,7 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
               <select
                 value={recAction}
                 onChange={(e) => setRecAction(e.target.value)}
-                className="w-full p-2 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white"
+                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
               >
                 <option value="">Select...</option>
                 {ACTION_OPTS.map((o) => (
@@ -1158,7 +1187,7 @@ export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
                 value={summary}
                 onChange={(e) => setSummary(e.target.value)}
                 placeholder="Describe the incident in 1-2 sentences..."
-                className="w-full p-2 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white resize-none h-20"
+                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white resize-none h-20"
               />
             </div>
           </Card>
@@ -1278,17 +1307,17 @@ export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
       <ModuleShell title="Cyber Career Map" step={2} totalSteps={2} onBack={() => setShowSummary(false)}>
         <div className="space-y-6 mt-4">
           <div>
-            <h2 className="text-lg font-semibold text-indigo-300 mb-3">Your Top Interests</h2>
+            <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-300 mb-3">Your Top Interests</h2>
             <div className="space-y-3">
               {picks.map((career) => (
                 <Card key={career.role} className="space-y-2">
-                  <p className="text-sm font-semibold text-white">{career.role}</p>
-                  <p className="text-xs text-teal-400">{career.salary}</p>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{career.role}</p>
+                  <p className="text-xs text-teal-700 dark:text-teal-400">{career.salary}</p>
                   <div>
                     <p className="text-xs text-slate-500 mb-1">Next Steps:</p>
                     <ul className="space-y-1">
                       {nextSteps[career.role]?.map((step) => (
-                        <li key={step} className="text-xs text-slate-400 flex items-start gap-2">
+                        <li key={step} className="text-xs text-slate-600 dark:text-slate-400 flex items-start gap-2">
                           <span className="text-indigo-400 mt-0.5">-</span> {step}
                         </li>
                       ))}
@@ -1311,7 +1340,7 @@ export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
   return (
     <ModuleShell title="Cyber Career Map" step={1} totalSteps={2} onBack={onBack}>
       <div className="space-y-4 mt-4">
-        <p className="text-sm text-slate-400">
+        <p className="text-sm text-slate-600 dark:text-slate-400">
           Explore the roles below. Star 1-3 that interest you most.
           <span className="text-indigo-400 ml-1">{starred.size}/3 selected</span>
         </p>
@@ -1324,19 +1353,19 @@ export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
               className="space-y-2"
             >
               <div className="flex items-start justify-between">
-                <p className="text-sm font-semibold text-white">{career.role}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-white">{career.role}</p>
                 <span className={`text-lg ${starred.has(i) ? "text-yellow-400" : "text-slate-600"}`}>
                   {starred.has(i) ? "\u2605" : "\u2606"}
                 </span>
               </div>
-              <p className="text-xs text-slate-400 leading-relaxed">{career.what}</p>
-              <p className="text-xs text-teal-400 font-medium">{career.salary}</p>
+              <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">{career.what}</p>
+              <p className="text-xs text-teal-700 dark:text-teal-400 font-medium">{career.salary}</p>
               <p className="text-xs text-slate-500">{career.education}</p>
               <div className="flex flex-wrap gap-1">
                 {career.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="px-2 py-0.5 text-[10px] rounded bg-slate-700 text-slate-400 border border-slate-600"
+                    className="px-2 py-0.5 text-[10px] rounded bg-slate-700 text-slate-600 dark:text-slate-400 border border-slate-600"
                   >
                     {tag}
                   </span>
@@ -1393,20 +1422,20 @@ export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
           <div className="text-center space-y-3">
             {/* Cisco logo placeholder */}
             <div className="w-16 h-16 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
-              <span className="text-2xl font-bold text-teal-400">C</span>
+              <span className="text-2xl font-bold text-teal-700 dark:text-teal-400">C</span>
             </div>
-            <h2 className="text-lg font-semibold text-white">Cisco Networking Academy</h2>
-            <p className="text-sm text-slate-400 leading-relaxed">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Cisco Networking Academy</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
               Cisco NetAcad offers free, industry-recognized courses in networking, cybersecurity, and IT fundamentals. Build skills that employers actively look for.
             </p>
           </div>
 
-          <div className="space-y-2 pt-2 border-t border-slate-700">
+          <div className="space-y-2 pt-2 border-t border-slate-200 dark:border-slate-700">
             <p className="text-xs text-slate-500 uppercase tracking-wider">Recommended after this module</p>
             {RECOMMENDED_NETACAD_COURSES.map((c) => (
               <div key={c.name} className="text-left">
                 <p className="text-sm font-medium text-slate-200">{c.name}</p>
-                <p className="text-xs text-slate-400">{c.detail}</p>
+                <p className="text-xs text-slate-600 dark:text-slate-400">{c.detail}</p>
               </div>
             ))}
           </div>
@@ -1419,7 +1448,7 @@ export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
               Open Cisco NetAcad
             </button>
             {clicked && (
-              <p className="text-xs text-teal-400 text-center">
+              <p className="text-xs text-teal-700 dark:text-teal-400 text-center">
                 Link opened. Module complete.
               </p>
             )}
@@ -1552,7 +1581,7 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
       {/* Step 1: Pick Business */}
       {step === 0 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             You're building a security plan. Pick a business to protect:
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -1566,8 +1595,8 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
                 <div className="w-10 h-10 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
                   <span className="text-lg font-bold text-indigo-400">{biz.icon}</span>
                 </div>
-                <p className="text-sm font-semibold text-white">{biz.name}</p>
-                <p className="text-xs text-slate-400">{biz.desc}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-white">{biz.name}</p>
+                <p className="text-xs text-slate-600 dark:text-slate-400">{biz.desc}</p>
               </Card>
             ))}
           </div>
@@ -1577,7 +1606,7 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
       {/* Step 2: Pick Risks */}
       {step === 1 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Select the 3 biggest risks for {business?.name}:
             <span className="text-indigo-400 ml-1">{selectedRisks.size}/3</span>
           </p>
@@ -1600,7 +1629,7 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
                     <span className="text-white text-xs font-bold">{"\u2713"}</span>
                   )}
                 </div>
-                <span className="text-sm text-slate-300">{risk}</span>
+                <span className="text-sm text-slate-700 dark:text-slate-300">{risk}</span>
               </Card>
             ))}
           </div>
@@ -1610,15 +1639,15 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
       {/* Step 3: Match Protections */}
       {step === 2 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">Match each risk to the best protection:</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Match each risk to the best protection:</p>
           <div className="space-y-3">
             {riskArr.map((riskIdx) => (
               <Card key={riskIdx} className="space-y-2">
-                <p className="text-sm font-medium text-red-400">{RISKS[riskIdx]}</p>
+                <p className="text-sm font-medium text-red-700 dark:text-red-400">{RISKS[riskIdx]}</p>
                 <select
                   value={protections[riskIdx] || ""}
                   onChange={(e) => setProtection(riskIdx, e.target.value)}
-                  className="w-full p-2 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white"
+                  className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
                 >
                   <option value="">Select protection...</option>
                   {PROTECTIONS.map((p) => (
@@ -1634,7 +1663,7 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
       {/* Step 4: Executive Summary */}
       {step === 3 && (
         <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-400">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Write a 3-sentence executive summary for your security plan:
           </p>
           <Card className="space-y-2">
@@ -1642,7 +1671,7 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
               value={summaryText}
               onChange={(e) => setSummaryText(e.target.value)}
               rows={6}
-              className="w-full p-3 rounded-lg bg-slate-700 border border-slate-600 text-sm text-white resize-none leading-relaxed"
+              className="w-full p-3 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white resize-none leading-relaxed"
             />
             <p className="text-xs text-slate-500">
               Use the sentence starters as a guide. Replace them with your analysis.
@@ -1655,14 +1684,14 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
       {step === 4 && (
         <div className="space-y-4 mt-4">
           <Card className="space-y-5 p-6">
-            <div className="border-b border-slate-700 pb-3">
+            <div className="border-b border-slate-200 dark:border-slate-700 pb-3">
               <p className="text-xs text-slate-500 uppercase tracking-wider">Security Plan</p>
-              <h2 className="text-lg font-bold text-white">{business?.name} Security Assessment</h2>
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white">{business?.name} Security Assessment</h2>
             </div>
 
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">Business Profile</p>
-              <p className="text-sm text-slate-300">{business?.desc}</p>
+              <p className="text-sm text-slate-700 dark:text-slate-300">{business?.desc}</p>
             </div>
 
             <div>
@@ -1680,10 +1709,10 @@ export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
 
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">Executive Summary</p>
-              <p className="text-sm text-slate-300 whitespace-pre-line leading-relaxed">{summaryText}</p>
+              <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-line leading-relaxed">{summaryText}</p>
             </div>
 
-            <div className="border-t border-slate-700 pt-3">
+            <div className="border-t border-slate-200 dark:border-slate-700 pt-3">
               <p className="text-xs text-slate-500">
                 Prepared by: Student &middot; BrightBoost Cyber Launch Track
               </p>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,9 +2,15 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import enCommon from "./locales/en/common.json";
 import esCommon from "./locales/es/common.json";
+import enPathways from "./locales/en/pathways.json";
+import esPathways from "./locales/es/pathways.json";
 
 // Lazy-loaded locales (vi, zh-CN) are fetched on demand below.
 // This keeps the main bundle lean for the common EN/ES case.
+// Pathways content is merged into the same `translation` namespace so
+// existing `useTranslation()` calls pick up `pathways.*` keys without
+// extra namespace wiring. Missing translations in vi/zh-CN fall through
+// to en via the fallbackLng config.
 
 const LANGUAGE_KEY = "preferredLanguage";
 
@@ -23,8 +29,8 @@ const initialLang = stored ? normalizeLocale(stored) : "en";
 
 i18n.use(initReactI18next).init({
   resources: {
-    en: { translation: enCommon },
-    es: { translation: esCommon },
+    en: { translation: { ...enCommon, ...enPathways } },
+    es: { translation: { ...esCommon, ...esPathways } },
     // vi and zh-CN added lazily below
   },
   lng: initialLang,

--- a/src/locales/en/pathways.json
+++ b/src/locales/en/pathways.json
@@ -1,0 +1,394 @@
+{
+  "pathways": {
+    "common": {
+      "back": "Back",
+      "next": "Next",
+      "continue": "Continue",
+      "finish": "Finish",
+      "submit": "Submit",
+      "loading": "Loading…",
+      "comingSoon": "Coming Soon",
+      "lightMode": "Light Mode",
+      "darkMode": "Dark Mode",
+      "signOut": "Sign Out",
+      "refresh": "Refresh",
+      "exportCsv": "Export CSV",
+      "sourcesHeading": "Sources & further reading",
+      "correct": "Correct.",
+      "incorrect": "Incorrect. The answer is: {{answer}}",
+      "knowledgeCheck": "Knowledge Check",
+      "startQuiz": "Start Quiz",
+      "nextQuestion": "Next Question",
+      "logInOrJoin": "Log In or Join",
+      "requestPilot": "Request a Pilot"
+    },
+    "layout": {
+      "eyebrow": "Bright Boost",
+      "brand": "Pathways",
+      "nav": {
+        "home": "Home",
+        "tracks": "Tracks",
+        "profile": "Profile",
+        "dashboard": "Dashboard",
+        "resources": "Resources",
+        "manage": "Manage"
+      }
+    },
+    "home": {
+      "explorerEyebrow": "Explorer Band",
+      "launchEyebrow": "Launch Band",
+      "explorerTitle": "Your Pathway Starts Here",
+      "launchTitle": "Build Your Launch Plan",
+      "stats": {
+        "completed": "Completed",
+        "inProgress": "In Progress",
+        "streak": "Streak"
+      },
+      "sections": {
+        "yourTracks": "Your Tracks",
+        "recentActivity": "Recent Activity"
+      },
+      "modulesProgress": "{{done}}/{{total}} modules • {{pct}}%"
+    },
+    "about": {
+      "hero": {
+        "eyebrow": "Bright Boost",
+        "tagline": "Real pathways for real futures.",
+        "sub1": "Career-connected learning for opportunity and justice-impacted youth ages 14-17.",
+        "sub2": "Cybersecurity, entrepreneurship, financial literacy, tech, and creative media — delivered through cohort-based programs with facilitator support."
+      },
+      "tracksSection": {
+        "title": "Five Tracks. Your Choice.",
+        "sub": "Each track builds real skills and connects to real careers."
+      },
+      "bands": {
+        "explorerTitle": "Explorer Band (Ages 14-15)",
+        "explorerDesc": "Foundation skills, exposure, and discovery. Build confidence with hands-on activities and find what excites you.",
+        "launchTitle": "Launch Band (Ages 16-17)",
+        "launchDesc": "Credential prep, portfolio building, and career planning. Get ready for what comes next — college, certification, or career."
+      },
+      "outcomes": {
+        "title": "What Outcomes Look Like",
+        "sub": "Each learner leaves the program with concrete artifacts and a next-step plan, not just attendance.",
+        "portfolioTitle": "Portfolio Artifacts",
+        "portfolioDesc": "Capstone security plan, career interest profile, and module completion records — concrete proof of skill.",
+        "certTitle": "Certification Prep",
+        "certDesc": "Direct on-ramps to Cisco NetAcad, ISC2 Certified in Cybersecurity (CC), and CompTIA Security+.",
+        "nextStepTitle": "Next-Step Plan",
+        "nextStepDesc": "Every learner ends with a concrete next action: a cert to pursue, an internship to apply for, or a credential pathway."
+      },
+      "delivery": {
+        "title": "Delivery Models",
+        "sub": "Built to fit how your program actually runs.",
+        "siteLedTitle": "Site-Led",
+        "siteLedDesc": "Your staff facilitate using our curriculum, dashboard, and resources. We provide training and support.",
+        "hybridTitle": "Hybrid",
+        "hybridDesc": "Shared delivery — your staff lead in-person sessions, we run virtual deep-dives and credential coaching.",
+        "fullServiceTitle": "Full-Service",
+        "fullServiceDesc": "We staff the cohort end-to-end. You provide the space, recruitment, and on-site relationships."
+      },
+      "partners": {
+        "title": "For Program Partners",
+        "sub": "Built for correctional education, workforce development, community-based organizations, and alternative schools.",
+        "cohortTitle": "Cohort Delivery",
+        "cohortDesc": "Create cohorts, assign tracks, and manage enrollment with join codes.",
+        "dashTitle": "Facilitator Dashboard",
+        "dashDesc": "Track learner progress, completion rates, and engagement in real time. Export CSVs for reporting.",
+        "credTitle": "Credential Prep",
+        "credDesc": "Cisco NetAcad integration, ISC2 CC pathway, and portfolio artifacts.",
+        "fundingTitle": "Funding Fit",
+        "fundingIntro": "Pathways content and delivery is designed to align with common youth-serving funding streams:",
+        "funding": [
+          "WIOA Youth (Title I)",
+          "Reentry Employment Opportunities (REO)",
+          "Illinois Youth Investment Program",
+          "Reaching Youth, Delivering Success (RYDS)",
+          "Perkins V / CTE Programs of Study",
+          "Local workforce board contracts"
+        ]
+      },
+      "footer": "Bright Boost Pathways — A program of Bright Bots Initiative"
+    },
+    "tracks": {
+      "title": "All Tracks",
+      "sub": "Choose your pathway. Build real skills.",
+      "modulesCount": "{{count}} modules",
+      "start": "Start",
+      "items": {
+        "cyber-launch": {
+          "name": "Cyber Launch",
+          "tagline": "Your entry point to cybersecurity careers",
+          "description": "Digital safety, networking basics, career awareness, and certification prep. Start with free Cisco coursework and build toward ISC2 CC eligibility."
+        },
+        "build-your-own-lane": {
+          "name": "Build Your Own Lane",
+          "tagline": "Ownership, entrepreneurship, and opportunity",
+          "description": "Opportunity mapping, customer thinking, value propositions, and pitching your own venture."
+        },
+        "money-moves": {
+          "name": "Money Moves",
+          "tagline": "Budgets, banking, credit, and economic power",
+          "description": "Budgeting, banking, credit, pricing, taxes, and economic mobility framing."
+        },
+        "future-tech-lab": {
+          "name": "Future Tech Lab",
+          "tagline": "AI, data, and digital problem-solving",
+          "description": "AI literacy, digital problem-solving, basic coding and data challenges, and STEM pathway exposure."
+        },
+        "creative-media-lab": {
+          "name": "Creative Media Lab",
+          "tagline": "Tell your story. Build your platform.",
+          "description": "Digital storytelling, media production, audio/video concepts, and project-based expression."
+        }
+      },
+      "modules": {
+        "cyber-foundations": { "name": "Cyber Foundations", "description": "What is cybersecurity? Why does it matter? Who works in this field?" },
+        "digital-safety-sim": { "name": "Digital Safety Sim", "description": "Interactive simulation: spot phishing, protect passwords, secure a network." },
+        "network-basics": { "name": "Network Basics", "description": "How the internet works: packets, protocols, and pathways." },
+        "threat-detective": { "name": "Threat Detective", "description": "Analyze logs, find the breach, write an incident report." },
+        "career-map": { "name": "Cyber Career Map", "description": "Explore cybersecurity roles, salaries, and pathways." },
+        "cisco-netacad-link": { "name": "Cisco Networking Academy", "description": "Free external coursework to deepen your networking and security skills." },
+        "capstone-security-plan": { "name": "Capstone: My Security Plan", "description": "Create a security assessment for a real scenario. Present your findings." }
+      }
+    },
+    "trackDetail": {
+      "notFound": "Track not found.",
+      "backToTracks": "Back to Tracks",
+      "allTracks": "All Tracks",
+      "completedCount": "{{done}}/{{total}} completed",
+      "completedLabel": "Completed",
+      "inProgressLabel": "In Progress"
+    },
+    "modulePlayer": {
+      "notFound": "Module not found.",
+      "backToTracks": "Back to Tracks",
+      "backToTrack": "Back to {{trackName}}",
+      "moduleComplete": "Module Complete",
+      "finishedFmt": "{{moduleName}} — finished!",
+      "loading": "Loading module…",
+      "backToTrackCta": "Back to Track"
+    },
+    "profile": {
+      "learner": "Learner",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "avgScore": "Avg Score",
+      "completedModules": "Completed Modules",
+      "scoreFmt": "• Score: {{score}}%"
+    },
+    "facilitator": {
+      "loading": "Loading your dashboard…",
+      "noGroups": "No Groups Yet",
+      "noGroupsDesc": "Create a cohort to start tracking learner progress.",
+      "yourCohort": "Your Cohort",
+      "learnersEnrolled": "{{count}} learners enrolled",
+      "joinCodeLabel": "Join code for new learners:",
+      "learnersHeading": "Learners",
+      "moduleProgress": "Module Progress",
+      "modulesCompletedFmt": "{{done}} of {{total}} modules completed",
+      "backToRoster": "Back to roster",
+      "noLearners": "No learners enrolled yet. Share the join code above.",
+      "notes": {
+        "title": "Your Notes",
+        "placeholder": "Add a private note about this learner…",
+        "disclaimer": "Notes are saved locally in this browser. Server-side persistence is on the roadmap."
+      },
+      "status": {
+        "onTrack": "On Track",
+        "needsCheckIn": "Needs Check-In",
+        "notStarted": "Not Started"
+      },
+      "module": {
+        "notStarted": "Not started",
+        "inProgress": "In progress",
+        "done": "Done",
+        "doneScoreFmt": "Done ({{score}}%)"
+      },
+      "band": {
+        "explorer": "Explorer (14–15)",
+        "launch": "Launch (16–17)"
+      },
+      "resourcesTitle": "Program overview, session guide, printables"
+    },
+    "modules": {
+      "foundations": {
+        "title": "Cyber Foundations",
+        "slides": [
+          { "title": "What is Cybersecurity?", "body": "Cybersecurity is the practice of protecting systems, networks, and data from digital attacks. Every device connected to the internet is a potential target — and defending them is a growing global priority." },
+          { "title": "Why It Matters", "body": "Data breaches cost businesses an average of $4.45 million per incident (IBM Cost of a Data Breach Report, 2023). Personal data — passwords, financial info, medical records — is constantly at risk. Critical infrastructure like power grids and hospitals depends on strong cyber defense." },
+          { "title": "Real Breaches", "body": "In 2017, a single breach exposed the personal data of 147 million people — names, Social Security numbers, birth dates. In 2020, a ransomware attack shut down a major hospital network, diverting emergency patients and delaying care for days. Real incidents like these are why every organization now treats cybersecurity as a business risk, not just an IT problem." },
+          { "title": "Who Works in Cyber?" },
+          { "title": "Many Ways In", "body": "You don't need a four-year degree to start a cyber career. People enter the field through bootcamps, free industry certifications (CompTIA Security+, ISC2 Certified in Cybersecurity), military service, IT help desk roles, and self-study with home labs. Employers care about what you can do, not just what's on your diploma." },
+          { "title": "The Opportunity", "body": "The U.S. had roughly 470,000 unfilled cybersecurity job openings as of mid-2024 (NIST CyberSeek). The U.S. Bureau of Labor Statistics projects Information Security Analyst employment to grow about 33% from 2023 to 2033 — much faster than the average for all occupations. The field rewards curiosity, problem-solving, and persistence over any single background." }
+        ],
+        "roles": [
+          { "name": "Security Analyst", "desc": "Monitors networks for threats and investigates alerts", "pay": "$75K–$110K" },
+          { "name": "Penetration Tester", "desc": "Legally hacks systems to find vulnerabilities before attackers do", "pay": "$85K–$130K" },
+          { "name": "Incident Responder", "desc": "Investigates breaches and leads the recovery effort", "pay": "$70K–$105K" },
+          { "name": "Security Engineer", "desc": "Designs and builds security architecture and tools", "pay": "$95K–$145K" },
+          { "name": "GRC Analyst", "desc": "Manages governance, risk, and compliance frameworks", "pay": "$65K–$100K" },
+          { "name": "Digital Forensics", "desc": "Recovers evidence from devices after breaches and crimes", "pay": "$75K–$120K" },
+          { "name": "Security Architect", "desc": "Designs the overall security strategy for an organization", "pay": "$120K–$180K" },
+          { "name": "CISO", "desc": "Chief Information Security Officer — leads the entire security program", "pay": "$150K–$250K" }
+        ],
+        "quiz": [
+          { "q": "What does cybersecurity protect?", "opts": ["Only passwords", "Systems, networks, and data", "Just websites", "Hardware only"] },
+          { "q": "Why is demand for cyber workers growing?", "opts": ["Companies are reducing tech budgets", "Attacks are decreasing", "Digital threats are increasing and there aren't enough defenders", "Cybersecurity is being automated away"] },
+          { "q": "Which role investigates breaches?", "opts": ["GRC Analyst", "CISO", "Incident Responder", "Penetration Tester"] }
+        ],
+        "sourcesDisclaimer": "Job-market and salary figures cited above are point-in-time references; verify against current BLS/CyberSeek data before quoting in partner materials."
+      },
+      "digitalSafety": {
+        "title": "Digital Safety Sim",
+        "phishingPrompt": "Identify the phishing email, then tap the red flags.",
+        "tapFlags": "Tap the red flags in this email:",
+        "phishingCorrect": "Correct! You spotted the phishing email.",
+        "phishingWrong": "Not quite — the first email was the phishing attempt.",
+        "phishingLabel": "PHISHING",
+        "fromLabel": "From: {{addr}}",
+        "passwordPrompt": "Rate each password as weak or strong.",
+        "ratingWeak": "weak",
+        "ratingStrong": "strong",
+        "socialPrompt": "An unknown caller says they're from IT support and need your password to fix an issue. What do you do?",
+        "socialChoices": {
+          "give": "Give them the password",
+          "hangup": "Hang up immediately",
+          "verify": "Hang up and verify through known channels"
+        },
+        "wifiPrompt": "On a public Wi-Fi network, which actions are safe?",
+        "wifiSafe": "Safe",
+        "wifiUnsafe": "Risky",
+        "breachPrompt": "Number these breach-response steps in order from FIRST to LAST.",
+        "breachLabel": "Step {{n}}"
+      },
+      "networkBasics": {
+        "title": "Network Basics",
+        "completedMsg": "Module placeholder — content coming soon. Marked as complete for demo."
+      },
+      "threatDetective": {
+        "title": "Threat Detective",
+        "completedMsg": "Module placeholder — content coming soon. Marked as complete for demo."
+      },
+      "careerMap": {
+        "title": "Cyber Career Map",
+        "completedMsg": "Module placeholder — content coming soon. Marked as complete for demo."
+      },
+      "ciscoNetacad": {
+        "title": "Cisco Networking Academy",
+        "completedMsg": "Module placeholder — content coming soon. Marked as complete for demo."
+      },
+      "capstone": {
+        "title": "Capstone: My Security Plan",
+        "completedMsg": "Module placeholder — content coming soon. Marked as complete for demo."
+      }
+    },
+    "resources": {
+      "title": "Facilitator Resources",
+      "subtitle": "Everything you need to run a strong Cyber Launch cohort.",
+      "tabs": {
+        "overview": "Program Overview",
+        "modules": "Module Guides",
+        "sessions": "Session Guide",
+        "faqs": "FAQs",
+        "worksheets": "Worksheets",
+        "tips": "Facilitation Tips"
+      },
+      "overview": {
+        "whatIsTitle": "What is Bright Boost Pathways?",
+        "whatIsBody1": "Bright Boost Pathways is a career-connected learning program for youth ages 14-17. It delivers hands-on, project-based modules across five tracks: cybersecurity, entrepreneurship, financial literacy, technology, and creative media.",
+        "whatIsBody2": "The program is designed for delivery in community settings, correctional education, workforce programs, and alternative schools — anywhere young people need real skills and real pathways forward.",
+        "bandsTitle": "Two Bands",
+        "explorerLabel": "Explorer (Ages 14-15)",
+        "explorerDesc": "Foundation skills, exposure, and discovery. Build confidence with hands-on activities.",
+        "launchLabel": "Launch (Ages 16-17)",
+        "launchDesc": "Credential prep, portfolio building, and career planning. Get ready for what comes next.",
+        "howTitle": "How It Works",
+        "howSteps": ["Enroll in cohort", "Pick tracks", "Complete modules", "Earn milestones", "Build capstone", "Next steps"],
+        "trackActiveTitle": "Cyber Launch Track (Active)",
+        "talkingPointsTitle": "Key Talking Points",
+        "talkingPoints": [
+          "Nearly 470,000 cybersecurity jobs are open in the U.S. right now (NIST CyberSeek).",
+          "You don't need a 4-year degree to start — free industry certifications like ISC2 Certified in Cybersecurity open real doors.",
+          "This program builds real skills students can put on a resume — not just enrichment.",
+          "Major employers — IBM, Apple, Amazon — have dropped degree requirements for many tech roles."
+        ],
+        "newFacilitatorTitle": "Where to Start as a New Facilitator",
+        "newFacilitatorSteps": [
+          "Read this Program Overview tab end to end.",
+          "Read the Module Guide for Module 1 (Cyber Foundations) — it sets tone for the whole program.",
+          "Read the Facilitation Tips tab, especially \"Setting Tone Day One.\"",
+          "Print the worksheets you'll need for week 1 and 2 ahead of time.",
+          "Create your own Cisco NetAcad account so you can guide students through it.",
+          "Have the partner organization's support contacts handy for referrals."
+        ]
+      },
+      "sessions": {
+        "pacingTitle": "6-Week Pacing Guide",
+        "pacingSub": "Pair each week's module with the matching worksheet for stronger outcomes.",
+        "tableHead": { "week": "Week", "focus": "Focus", "modules": "Modules + Worksheets", "notes": "Facilitation Notes", "minutes": "Min" },
+        "variationsTitle": "Pacing Variations",
+        "structureTitle": "Each Session — Suggested Structure"
+      },
+      "moduleGuides": {
+        "introTitle": "Detailed Module Guides",
+        "introSub": "One full guide per Cyber Launch module. Click a module to expand.",
+        "introBody": "Each guide includes what the module teaches, discussion questions for before and after, common sticking points and how to coach through them, real-world context, vocabulary, and red flags to watch for. Read the guide for next week's module BEFORE the session.",
+        "blocks": {
+          "whatItTeaches": "What This Module Teaches",
+          "whyItMatters": "Why It Matters",
+          "timeRequired": "Time Required",
+          "whatToExpect": "What to Expect",
+          "facilitatorRole": "Facilitator Role",
+          "facilitatorBefore": "Before they start",
+          "facilitatorDuring": "While they're working",
+          "facilitatorAfter": "After they finish",
+          "discussionBefore": "Discussion Questions — Before",
+          "discussionAfter": "Discussion Questions — After",
+          "stickingPoints": "Common Sticking Points",
+          "extensions": "Extension Activities",
+          "realWorld": "Real-World Connection",
+          "vocabulary": "Vocabulary",
+          "redFlags": "Red Flags / When to Worry"
+        }
+      },
+      "faqs": {
+        "title": "Frequently Asked Questions",
+        "sub": "Real questions from real audiences. Use the answers as starting points — make them your own.",
+        "categories": {
+          "youth": {
+            "label": "From Youth",
+            "description": "Real questions teenagers ask. Answers facilitators can use word-for-word, or adapt to their voice."
+          },
+          "parents": {
+            "label": "From Parents / Guardians",
+            "description": "Questions guardians ask before letting their teen enroll. Answer them with calm specificity."
+          },
+          "partners": {
+            "label": "From Partner Organizations",
+            "description": "Questions community partners and site leaders ask before signing on to host a cohort."
+          }
+        }
+      },
+      "worksheets": {
+        "title": "Printable Worksheets",
+        "sub": "Each opens in a new tab as a print-ready document. Facilitator notes are visible on screen but hidden in print.",
+        "body": "Worksheets are designed to pair with specific modules. The Session Guide tab shows which worksheet matches each week. Print ahead of session — students who fill them out by hand retain more than those who type.",
+        "printLabel": "Print",
+        "worksheetLabel": "Worksheet {{n}}",
+        "printTipsTitle": "Print Tips",
+        "printTips": [
+          "Worksheets open in a new tab and auto-trigger the browser print dialog.",
+          "If the print dialog doesn't open, press Ctrl/Cmd+P in the new tab.",
+          "Facilitator notes (in dashed cyan boxes) are hidden when printing.",
+          "For double-sided printing, choose \"Long edge\" binding in your printer settings.",
+          "If you want a clean PDF, choose \"Save as PDF\" instead of a physical printer."
+        ]
+      },
+      "tips": {
+        "title": "Facilitation Tips",
+        "sub": "Practical guidance for the situations that arise in real cohorts.",
+        "intro": "These tips were written by program staff with input from partner facilitators. They are starting points, not strict rules. Adapt to your cohort, your site, and your own style. Sensitive sections (trauma-informed practice, justice-impacted youth) are worth reviewing with your partner organization's clinical or program leadership before applying at scale."
+      }
+    }
+  }
+}

--- a/src/locales/es/pathways.json
+++ b/src/locales/es/pathways.json
@@ -1,0 +1,394 @@
+{
+  "pathways": {
+    "common": {
+      "back": "Atrás",
+      "next": "Siguiente",
+      "continue": "Continuar",
+      "finish": "Finalizar",
+      "submit": "Enviar",
+      "loading": "Cargando…",
+      "comingSoon": "Próximamente",
+      "lightMode": "Modo Claro",
+      "darkMode": "Modo Oscuro",
+      "signOut": "Cerrar Sesión",
+      "refresh": "Actualizar",
+      "exportCsv": "Exportar CSV",
+      "sourcesHeading": "Fuentes y lecturas adicionales",
+      "correct": "Correcto.",
+      "incorrect": "Incorrecto. La respuesta es: {{answer}}",
+      "knowledgeCheck": "Comprobación de Conocimiento",
+      "startQuiz": "Comenzar Quiz",
+      "nextQuestion": "Siguiente Pregunta",
+      "logInOrJoin": "Inicia Sesión o Únete",
+      "requestPilot": "Solicitar un Piloto"
+    },
+    "layout": {
+      "eyebrow": "Bright Boost",
+      "brand": "Pathways",
+      "nav": {
+        "home": "Inicio",
+        "tracks": "Rutas",
+        "profile": "Perfil",
+        "dashboard": "Panel",
+        "resources": "Recursos",
+        "manage": "Gestionar"
+      }
+    },
+    "home": {
+      "explorerEyebrow": "Nivel Explorador",
+      "launchEyebrow": "Nivel Lanzamiento",
+      "explorerTitle": "Tu Camino Comienza Aquí",
+      "launchTitle": "Construye Tu Plan de Lanzamiento",
+      "stats": {
+        "completed": "Completados",
+        "inProgress": "En Progreso",
+        "streak": "Racha"
+      },
+      "sections": {
+        "yourTracks": "Tus Rutas",
+        "recentActivity": "Actividad Reciente"
+      },
+      "modulesProgress": "{{done}}/{{total}} módulos • {{pct}}%"
+    },
+    "about": {
+      "hero": {
+        "eyebrow": "Bright Boost",
+        "tagline": "Caminos reales para futuros reales.",
+        "sub1": "Aprendizaje conectado con carreras para jóvenes de 14 a 17 años con oportunidades de crecimiento y reintegración.",
+        "sub2": "Ciberseguridad, emprendimiento, educación financiera, tecnología y medios creativos — entregado a través de programas en grupo con apoyo de facilitadores."
+      },
+      "tracksSection": {
+        "title": "Cinco Rutas. Tú Eliges.",
+        "sub": "Cada ruta construye habilidades reales y conecta con carreras reales."
+      },
+      "bands": {
+        "explorerTitle": "Nivel Explorador (14-15 años)",
+        "explorerDesc": "Habilidades fundamentales, exposición y descubrimiento. Construye confianza con actividades prácticas y encuentra lo que te emociona.",
+        "launchTitle": "Nivel Lanzamiento (16-17 años)",
+        "launchDesc": "Preparación de credenciales, construcción de portafolio y planificación de carrera. Prepárate para lo que sigue — universidad, certificación o carrera."
+      },
+      "outcomes": {
+        "title": "Cómo Se Ven los Resultados",
+        "sub": "Cada estudiante sale del programa con artefactos concretos y un plan claro de siguientes pasos, no solo asistencia.",
+        "portfolioTitle": "Artefactos de Portafolio",
+        "portfolioDesc": "Plan de seguridad final, perfil de intereses de carrera y registros de finalización de módulos — prueba concreta de habilidad.",
+        "certTitle": "Preparación para Certificación",
+        "certDesc": "Rutas directas a Cisco NetAcad, ISC2 Certified in Cybersecurity (CC) y CompTIA Security+.",
+        "nextStepTitle": "Plan de Siguientes Pasos",
+        "nextStepDesc": "Cada estudiante termina con una acción concreta: una certificación que perseguir, una pasantía que solicitar o una ruta de credenciales."
+      },
+      "delivery": {
+        "title": "Modelos de Entrega",
+        "sub": "Diseñados para adaptarse a cómo funciona tu programa en la práctica.",
+        "siteLedTitle": "Liderado por el Sitio",
+        "siteLedDesc": "Tu personal facilita usando nuestro currículo, panel y recursos. Nosotros proporcionamos entrenamiento y apoyo.",
+        "hybridTitle": "Híbrido",
+        "hybridDesc": "Entrega compartida — tu personal lidera las sesiones presenciales, nosotros hacemos profundizaciones virtuales y coaching de credenciales.",
+        "fullServiceTitle": "Servicio Completo",
+        "fullServiceDesc": "Nosotros operamos el grupo de principio a fin. Tú proporcionas el espacio, el reclutamiento y las relaciones locales."
+      },
+      "partners": {
+        "title": "Para Organizaciones Aliadas",
+        "sub": "Diseñado para educación en centros correccionales, desarrollo de fuerza laboral, organizaciones comunitarias y escuelas alternativas.",
+        "cohortTitle": "Entrega por Grupos",
+        "cohortDesc": "Crea grupos, asigna rutas y gestiona la inscripción con códigos de acceso.",
+        "dashTitle": "Panel del Facilitador",
+        "dashDesc": "Sigue el progreso de los estudiantes, las tasas de finalización y la participación en tiempo real. Exporta CSVs para reportes.",
+        "credTitle": "Preparación de Credenciales",
+        "credDesc": "Integración con Cisco NetAcad, ruta hacia ISC2 CC y artefactos de portafolio.",
+        "fundingTitle": "Alineación con Financiamiento",
+        "fundingIntro": "El contenido y entrega de Pathways está diseñado para alinearse con fuentes comunes de financiamiento juvenil:",
+        "funding": [
+          "WIOA Youth (Título I)",
+          "Reentry Employment Opportunities (REO)",
+          "Illinois Youth Investment Program",
+          "Reaching Youth, Delivering Success (RYDS)",
+          "Perkins V / Programas CTE de Estudio",
+          "Contratos locales de fuerza laboral"
+        ]
+      },
+      "footer": "Bright Boost Pathways — Un programa de Bright Bots Initiative"
+    },
+    "tracks": {
+      "title": "Todas las Rutas",
+      "sub": "Elige tu camino. Construye habilidades reales.",
+      "modulesCount": "{{count}} módulos",
+      "start": "Comenzar",
+      "items": {
+        "cyber-launch": {
+          "name": "Cyber Launch",
+          "tagline": "Tu punto de entrada a carreras en ciberseguridad",
+          "description": "Seguridad digital, fundamentos de redes, conciencia de carrera y preparación para certificaciones. Empieza con cursos gratuitos de Cisco y avanza hacia ISC2 CC."
+        },
+        "build-your-own-lane": {
+          "name": "Construye Tu Propio Camino",
+          "tagline": "Propiedad, emprendimiento y oportunidad",
+          "description": "Mapeo de oportunidades, pensamiento centrado en el cliente, propuestas de valor y presentación de tu propio emprendimiento."
+        },
+        "money-moves": {
+          "name": "Movidas de Dinero",
+          "tagline": "Presupuestos, banca, crédito y poder económico",
+          "description": "Presupuesto, banca, crédito, precios, impuestos y movilidad económica."
+        },
+        "future-tech-lab": {
+          "name": "Laboratorio del Futuro",
+          "tagline": "IA, datos y resolución de problemas digitales",
+          "description": "Alfabetización en IA, resolución de problemas digitales, programación básica, retos de datos y exposición a rutas STEM."
+        },
+        "creative-media-lab": {
+          "name": "Laboratorio de Medios Creativos",
+          "tagline": "Cuenta tu historia. Construye tu plataforma.",
+          "description": "Narrativa digital, producción de medios, conceptos de audio/video y expresión basada en proyectos."
+        }
+      },
+      "modules": {
+        "cyber-foundations": { "name": "Fundamentos de Ciberseguridad", "description": "¿Qué es la ciberseguridad? ¿Por qué importa? ¿Quién trabaja en este campo?" },
+        "digital-safety-sim": { "name": "Simulación de Seguridad Digital", "description": "Simulación interactiva: detecta phishing, protege contraseñas, asegura una red." },
+        "network-basics": { "name": "Fundamentos de Redes", "description": "Cómo funciona internet: paquetes, protocolos y rutas." },
+        "threat-detective": { "name": "Detective de Amenazas", "description": "Analiza registros, encuentra la brecha y escribe un reporte de incidente." },
+        "career-map": { "name": "Mapa de Carreras Cibernéticas", "description": "Explora roles, salarios y rutas en ciberseguridad." },
+        "cisco-netacad-link": { "name": "Cisco Networking Academy", "description": "Cursos externos gratuitos para profundizar tus habilidades de redes y seguridad." },
+        "capstone-security-plan": { "name": "Proyecto Final: Mi Plan de Seguridad", "description": "Crea una evaluación de seguridad para un escenario real. Presenta tus hallazgos." }
+      }
+    },
+    "trackDetail": {
+      "notFound": "Ruta no encontrada.",
+      "backToTracks": "Volver a Rutas",
+      "allTracks": "Todas las Rutas",
+      "completedCount": "{{done}}/{{total}} completados",
+      "completedLabel": "Completado",
+      "inProgressLabel": "En Progreso"
+    },
+    "modulePlayer": {
+      "notFound": "Módulo no encontrado.",
+      "backToTracks": "Volver a Rutas",
+      "backToTrack": "Volver a {{trackName}}",
+      "moduleComplete": "Módulo Completado",
+      "finishedFmt": "{{moduleName}} — ¡terminado!",
+      "loading": "Cargando módulo…",
+      "backToTrackCta": "Volver a la Ruta"
+    },
+    "profile": {
+      "learner": "Estudiante",
+      "completed": "Completados",
+      "inProgress": "En Progreso",
+      "avgScore": "Puntaje Promedio",
+      "completedModules": "Módulos Completados",
+      "scoreFmt": "• Puntaje: {{score}}%"
+    },
+    "facilitator": {
+      "loading": "Cargando tu panel…",
+      "noGroups": "Aún No Hay Grupos",
+      "noGroupsDesc": "Crea un grupo para empezar a seguir el progreso de los estudiantes.",
+      "yourCohort": "Tu Grupo",
+      "learnersEnrolled": "{{count}} estudiantes inscritos",
+      "joinCodeLabel": "Código de acceso para nuevos estudiantes:",
+      "learnersHeading": "Estudiantes",
+      "moduleProgress": "Progreso de Módulos",
+      "modulesCompletedFmt": "{{done}} de {{total}} módulos completados",
+      "backToRoster": "Volver a la lista",
+      "noLearners": "Aún no hay estudiantes inscritos. Comparte el código de acceso arriba.",
+      "notes": {
+        "title": "Tus Notas",
+        "placeholder": "Añade una nota privada sobre este estudiante…",
+        "disclaimer": "Las notas se guardan localmente en este navegador. La persistencia en servidor está en el roadmap."
+      },
+      "status": {
+        "onTrack": "En Camino",
+        "needsCheckIn": "Necesita Seguimiento",
+        "notStarted": "No Empezó"
+      },
+      "module": {
+        "notStarted": "No empezado",
+        "inProgress": "En progreso",
+        "done": "Listo",
+        "doneScoreFmt": "Listo ({{score}}%)"
+      },
+      "band": {
+        "explorer": "Explorador (14–15)",
+        "launch": "Lanzamiento (16–17)"
+      },
+      "resourcesTitle": "Resumen del programa, guía de sesiones, imprimibles"
+    },
+    "modules": {
+      "foundations": {
+        "title": "Fundamentos de Ciberseguridad",
+        "slides": [
+          { "title": "¿Qué es la Ciberseguridad?", "body": "La ciberseguridad es la práctica de proteger sistemas, redes y datos contra ataques digitales. Cada dispositivo conectado a internet es un blanco potencial — y defenderlos es una prioridad global creciente." },
+          { "title": "Por Qué Importa", "body": "Las brechas de datos le cuestan a las empresas un promedio de $4.45 millones por incidente (Reporte IBM Cost of a Data Breach, 2023). Los datos personales — contraseñas, información financiera, historiales médicos — están constantemente en riesgo. Infraestructuras críticas como redes eléctricas y hospitales dependen de una fuerte defensa cibernética." },
+          { "title": "Brechas Reales", "body": "En 2017, una sola brecha expuso los datos personales de 147 millones de personas — nombres, números de seguridad social, fechas de nacimiento. En 2020, un ataque de ransomware cerró una red hospitalaria importante, desviando pacientes de emergencia y retrasando atención por días. Incidentes reales como estos son la razón por la que toda organización ahora trata la ciberseguridad como un riesgo de negocio, no solo un problema de TI." },
+          { "title": "¿Quién Trabaja en Ciber?" },
+          { "title": "Muchas Formas de Entrar", "body": "No necesitas un título universitario de cuatro años para empezar una carrera en ciber. Las personas entran al campo a través de bootcamps, certificaciones gratuitas de la industria (CompTIA Security+, ISC2 Certified in Cybersecurity), servicio militar, roles de mesa de ayuda de TI, y estudio autodidacta con laboratorios caseros. A los empleadores les importa lo que sabes hacer, no solo lo que dice tu diploma." },
+          { "title": "La Oportunidad", "body": "EE.UU. tenía aproximadamente 470,000 vacantes sin cubrir en ciberseguridad a mediados de 2024 (NIST CyberSeek). La Oficina de Estadísticas Laborales proyecta que el empleo de Analistas de Seguridad de la Información crecerá alrededor del 33% de 2023 a 2033 — mucho más rápido que el promedio de todas las ocupaciones. El campo premia la curiosidad, la resolución de problemas y la persistencia por encima de cualquier trasfondo." }
+        ],
+        "roles": [
+          { "name": "Analista de Seguridad", "desc": "Monitorea redes para amenazas e investiga alertas", "pay": "$75K–$110K" },
+          { "name": "Pen Tester (Probador de Penetración)", "desc": "Hackea sistemas legalmente para encontrar vulnerabilidades antes que los atacantes", "pay": "$85K–$130K" },
+          { "name": "Respondedor de Incidentes", "desc": "Investiga brechas y lidera el esfuerzo de recuperación", "pay": "$70K–$105K" },
+          { "name": "Ingeniero de Seguridad", "desc": "Diseña y construye arquitectura y herramientas de seguridad", "pay": "$95K–$145K" },
+          { "name": "Analista GRC", "desc": "Gestiona marcos de gobernanza, riesgo y cumplimiento", "pay": "$65K–$100K" },
+          { "name": "Forense Digital", "desc": "Recupera evidencia de dispositivos después de brechas y crímenes", "pay": "$75K–$120K" },
+          { "name": "Arquitecto de Seguridad", "desc": "Diseña la estrategia general de seguridad de una organización", "pay": "$120K–$180K" },
+          { "name": "CISO", "desc": "Director de Seguridad de la Información — lidera todo el programa de seguridad", "pay": "$150K–$250K" }
+        ],
+        "quiz": [
+          { "q": "¿Qué protege la ciberseguridad?", "opts": ["Solo contraseñas", "Sistemas, redes y datos", "Solo sitios web", "Solo hardware"] },
+          { "q": "¿Por qué crece la demanda de trabajadores de ciber?", "opts": ["Las empresas reducen presupuestos tecnológicos", "Los ataques están disminuyendo", "Las amenazas digitales aumentan y no hay suficientes defensores", "La ciberseguridad se está automatizando"] },
+          { "q": "¿Qué rol investiga las brechas?", "opts": ["Analista GRC", "CISO", "Respondedor de Incidentes", "Pen Tester"] }
+        ],
+        "sourcesDisclaimer": "Las cifras del mercado laboral y salarios citadas arriba son referencias puntuales; verifica contra datos actuales de BLS/CyberSeek antes de citar en materiales para socios."
+      },
+      "digitalSafety": {
+        "title": "Simulación de Seguridad Digital",
+        "phishingPrompt": "Identifica el correo de phishing, luego marca las señales de alerta.",
+        "tapFlags": "Marca las señales de alerta en este correo:",
+        "phishingCorrect": "¡Correcto! Detectaste el correo de phishing.",
+        "phishingWrong": "Casi — el primer correo era el intento de phishing.",
+        "phishingLabel": "PHISHING",
+        "fromLabel": "De: {{addr}}",
+        "passwordPrompt": "Califica cada contraseña como débil o fuerte.",
+        "ratingWeak": "débil",
+        "ratingStrong": "fuerte",
+        "socialPrompt": "Un llamador desconocido dice ser de soporte de TI y necesita tu contraseña para arreglar un problema. ¿Qué haces?",
+        "socialChoices": {
+          "give": "Dales la contraseña",
+          "hangup": "Cuelga inmediatamente",
+          "verify": "Cuelga y verifica por canales conocidos"
+        },
+        "wifiPrompt": "En una red Wi-Fi pública, ¿qué acciones son seguras?",
+        "wifiSafe": "Seguro",
+        "wifiUnsafe": "Riesgoso",
+        "breachPrompt": "Numera estos pasos de respuesta a una brecha en orden de PRIMERO a ÚLTIMO.",
+        "breachLabel": "Paso {{n}}"
+      },
+      "networkBasics": {
+        "title": "Fundamentos de Redes",
+        "completedMsg": "Marcador de posición del módulo — contenido próximamente. Marcado como completo para la demostración."
+      },
+      "threatDetective": {
+        "title": "Detective de Amenazas",
+        "completedMsg": "Marcador de posición del módulo — contenido próximamente. Marcado como completo para la demostración."
+      },
+      "careerMap": {
+        "title": "Mapa de Carreras Cibernéticas",
+        "completedMsg": "Marcador de posición del módulo — contenido próximamente. Marcado como completo para la demostración."
+      },
+      "ciscoNetacad": {
+        "title": "Cisco Networking Academy",
+        "completedMsg": "Marcador de posición del módulo — contenido próximamente. Marcado como completo para la demostración."
+      },
+      "capstone": {
+        "title": "Proyecto Final: Mi Plan de Seguridad",
+        "completedMsg": "Marcador de posición del módulo — contenido próximamente. Marcado como completo para la demostración."
+      }
+    },
+    "resources": {
+      "title": "Recursos del Facilitador",
+      "subtitle": "Todo lo que necesitas para dirigir un grupo de Cyber Launch sólido.",
+      "tabs": {
+        "overview": "Resumen del Programa",
+        "modules": "Guías de Módulos",
+        "sessions": "Guía de Sesiones",
+        "faqs": "Preguntas Frecuentes",
+        "worksheets": "Hojas de Trabajo",
+        "tips": "Consejos de Facilitación"
+      },
+      "overview": {
+        "whatIsTitle": "¿Qué es Bright Boost Pathways?",
+        "whatIsBody1": "Bright Boost Pathways es un programa de aprendizaje conectado con carreras para jóvenes de 14 a 17 años. Entrega módulos prácticos basados en proyectos a través de cinco rutas: ciberseguridad, emprendimiento, educación financiera, tecnología y medios creativos.",
+        "whatIsBody2": "El programa está diseñado para entregarse en entornos comunitarios, educación correccional, programas de fuerza laboral y escuelas alternativas — donde sea que los jóvenes necesiten habilidades reales y caminos reales hacia adelante.",
+        "bandsTitle": "Dos Niveles",
+        "explorerLabel": "Explorador (14-15 años)",
+        "explorerDesc": "Habilidades fundamentales, exposición y descubrimiento. Construye confianza con actividades prácticas.",
+        "launchLabel": "Lanzamiento (16-17 años)",
+        "launchDesc": "Preparación para credenciales, construcción de portafolio y planificación de carrera. Prepárate para lo que sigue.",
+        "howTitle": "Cómo Funciona",
+        "howSteps": ["Inscribirse en grupo", "Elegir rutas", "Completar módulos", "Ganar logros", "Construir proyecto final", "Siguientes pasos"],
+        "trackActiveTitle": "Ruta Cyber Launch (Activa)",
+        "talkingPointsTitle": "Puntos Clave de Conversación",
+        "talkingPoints": [
+          "Casi 470,000 empleos en ciberseguridad están abiertos en EE.UU. ahora mismo (NIST CyberSeek).",
+          "No necesitas un título de 4 años para empezar — certificaciones gratuitas como ISC2 Certified in Cybersecurity abren puertas reales.",
+          "Este programa construye habilidades reales que los estudiantes pueden poner en un currículum — no solo enriquecimiento.",
+          "Grandes empleadores — IBM, Apple, Amazon — han eliminado los requisitos de título para muchos roles tecnológicos."
+        ],
+        "newFacilitatorTitle": "Dónde Empezar como Facilitador Nuevo",
+        "newFacilitatorSteps": [
+          "Lee esta pestaña de Resumen del Programa de principio a fin.",
+          "Lee la Guía de Módulo para el Módulo 1 (Fundamentos de Ciberseguridad) — establece el tono para todo el programa.",
+          "Lee la pestaña de Consejos de Facilitación, especialmente \"Estableciendo el Tono el Primer Día\".",
+          "Imprime las hojas de trabajo que necesitarás para las semanas 1 y 2 con anticipación.",
+          "Crea tu propia cuenta de Cisco NetAcad para poder guiar a los estudiantes a través de ella.",
+          "Ten a la mano los contactos de apoyo de la organización aliada para referencias."
+        ]
+      },
+      "sessions": {
+        "pacingTitle": "Guía de Ritmo de 6 Semanas",
+        "pacingSub": "Combina el módulo de cada semana con la hoja de trabajo correspondiente para mejores resultados.",
+        "tableHead": { "week": "Semana", "focus": "Enfoque", "modules": "Módulos + Hojas de Trabajo", "notes": "Notas de Facilitación", "minutes": "Min" },
+        "variationsTitle": "Variaciones de Ritmo",
+        "structureTitle": "Cada Sesión — Estructura Sugerida"
+      },
+      "moduleGuides": {
+        "introTitle": "Guías Detalladas de Módulos",
+        "introSub": "Una guía completa por cada módulo de Cyber Launch. Haz clic en un módulo para expandir.",
+        "introBody": "Cada guía incluye lo que enseña el módulo, preguntas de discusión antes y después, puntos comunes de dificultad y cómo entrenar para superarlos, contexto del mundo real, vocabulario y señales de alerta a observar. Lee la guía del módulo de la próxima semana ANTES de la sesión.",
+        "blocks": {
+          "whatItTeaches": "Lo Que Enseña Este Módulo",
+          "whyItMatters": "Por Qué Importa",
+          "timeRequired": "Tiempo Requerido",
+          "whatToExpect": "Qué Esperar",
+          "facilitatorRole": "Rol del Facilitador",
+          "facilitatorBefore": "Antes de que empiecen",
+          "facilitatorDuring": "Mientras trabajan",
+          "facilitatorAfter": "Después de que terminen",
+          "discussionBefore": "Preguntas de Discusión — Antes",
+          "discussionAfter": "Preguntas de Discusión — Después",
+          "stickingPoints": "Puntos Comunes de Dificultad",
+          "extensions": "Actividades de Extensión",
+          "realWorld": "Conexión con el Mundo Real",
+          "vocabulary": "Vocabulario",
+          "redFlags": "Señales de Alerta / Cuándo Preocuparse"
+        }
+      },
+      "faqs": {
+        "title": "Preguntas Frecuentes",
+        "sub": "Preguntas reales de audiencias reales. Usa las respuestas como puntos de partida — hazlas tuyas.",
+        "categories": {
+          "youth": {
+            "label": "De los Jóvenes",
+            "description": "Preguntas reales que hacen los adolescentes. Respuestas que los facilitadores pueden usar palabra por palabra o adaptar a su voz."
+          },
+          "parents": {
+            "label": "De Padres / Tutores",
+            "description": "Preguntas que hacen los tutores antes de permitir que su adolescente se inscriba. Respóndelas con especificidad y calma."
+          },
+          "partners": {
+            "label": "De Organizaciones Aliadas",
+            "description": "Preguntas que hacen los aliados comunitarios y líderes de sitio antes de comprometerse a hospedar un grupo."
+          }
+        }
+      },
+      "worksheets": {
+        "title": "Hojas de Trabajo Imprimibles",
+        "sub": "Cada una se abre en una pestaña nueva como un documento listo para imprimir. Las notas del facilitador son visibles en pantalla pero se ocultan al imprimir.",
+        "body": "Las hojas de trabajo están diseñadas para emparejarse con módulos específicos. La pestaña de Guía de Sesiones muestra qué hoja corresponde a cada semana. Imprime antes de la sesión — los estudiantes que las llenan a mano retienen más que los que escriben en computadora.",
+        "printLabel": "Imprimir",
+        "worksheetLabel": "Hoja de Trabajo {{n}}",
+        "printTipsTitle": "Consejos de Impresión",
+        "printTips": [
+          "Las hojas de trabajo se abren en una pestaña nueva y activan el diálogo de impresión automáticamente.",
+          "Si el diálogo de impresión no se abre, presiona Ctrl/Cmd+P en la pestaña nueva.",
+          "Las notas del facilitador (en cajas cyan punteadas) se ocultan al imprimir.",
+          "Para impresión a doble cara, elige encuadernación \"Borde Largo\" en la configuración de tu impresora.",
+          "Si quieres un PDF limpio, elige \"Guardar como PDF\" en lugar de una impresora física."
+        ]
+      },
+      "tips": {
+        "title": "Consejos de Facilitación",
+        "sub": "Guía práctica para las situaciones que surgen en grupos reales.",
+        "intro": "Estos consejos fueron escritos por el personal del programa con aportes de facilitadores aliados. Son puntos de partida, no reglas estrictas. Adáptalos a tu grupo, tu sitio y tu propio estilo. Las secciones sensibles (práctica informada por el trauma, jóvenes impactados por el sistema de justicia) merecen revisión con el liderazgo clínico o de programa de tu organización aliada antes de aplicarse a gran escala."
+      }
+    }
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,9 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  // Use the `class` strategy so we can toggle dark mode via a `.dark` class
+  // on a Pathways-scoped wrapper instead of following the OS preference.
+  darkMode: "class",
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary

Two issues fixed in one PR:

1. **Language switching didn't work on Pathways.** No component used `useTranslation()`; the entire Pathways product layer was hardcoded English. This PR wires every Pathways component to the existing `react-i18next` instance.

2. **Light mode was broken on Pathways.** The layout had a stub light/dark toggle, but nested components had no `dark:` variants, so the theme switch did almost nothing. This PR converts to Tailwind's class-strategy dark mode and pairs every styled surface with WCAG-AA light variants.

## What's in scope

### i18n
- New locale files: `src/locales/{en,es}/pathways.json` — a single `pathways.*` namespace, merged into the existing `translation` namespace in `src/i18n.ts`.
- ~340 keys per locale.
- VI/ZH-CN intentionally have no new files. The existing `fallbackLng: "en"` config catches missing keys gracefully — the UI **never** shows raw key strings.
- Real Latin American Spanish translations for all UI chrome and Module 1 (Cyber Foundations) slide/role/quiz content.
- Wired components (every Pathways component):
  - `PathwaysLayout`, `PathwaysHome`, `PathwaysAbout`, `TracksOverview`, `TrackDetail`, `ModulePlayer`, `PathwaysProfile`, `FacilitatorDashboard`
  - `CyberLaunchModules` (Module 1 fully + UI chrome for Modules 2-7)
  - `ProgramOverview` + all 6 Resources tabs (`Section`, `OverviewTab`, `ModuleGuidesTab`, `SessionGuideTab`, `FaqsTab`, `WorksheetsTab`, `FacilitationTipsTab`)
- Track names/taglines/descriptions and per-module name/description are looked up via `t(\`pathways.tracks.items.{slug}.*\`, fallback)` so the constants file stays English while the UI renders localized.

### Light mode
- `tailwind.config.ts`: switched to `darkMode: "class"`. Safe — only 3 files in the codebase use `dark:` variants and they're all in scope here.
- `PathwaysLayout` toggles `.dark` on its root div and persists preference to `localStorage` under `bb_pathways_theme`. `PathwaysAbout` (standalone, no layout wrapper) reads the same key.
- WCAG AA contrast targets applied:
  - Body text: `text-slate-700 dark:text-slate-300` (7.04:1 on white ✓)
  - Captions: `text-slate-600 dark:text-slate-400` (≥4.5:1 ✓)
  - Accent (indigo/cyan/teal/red): `*-700` in light, `*-300/400` in dark
  - Buttons with solid colored backgrounds (bg-indigo-600, bg-teal-600) keep `text-white` in both modes
  - Cards: `bg-white dark:bg-slate-800` with explicit `border` for definition
- Track cards in light mode use white surface + colored border accent rather than full color fills (cleaner against white than the dark mode glassmorphism would be).

## What's NOT in scope

Documented in `docs/pathways-translation-status.md`:

- Deep translation of CyberLaunchModules Modules 2-7 (phishing scenarios, log entries, career cards, capstone businesses). UI chrome is wired; Module 1 demonstrates the full pattern. Migration path documented.
- Translation of the Resources data files (`moduleGuides.ts`, `faqs.ts`, `worksheets.ts`, `facilitationTips.ts`). UI chrome and section titles are done. The content arrays remain English-only TS. Migration path documented.
- VI / ZH-CN translations. They fall back to English via i18n config.

## Dependency

This PR is stacked on top of **#576** (facilitator resources expansion) because it imports and wires the tabs created there. Merge #576 first, then this.

## Verification

- [x] `tsc --noEmit`: 0 new errors. 6 pre-existing errors from PR #567 (`ControlInstructions` casing/missing export) unchanged.
- [x] `eslint src/components/pathways/ src/i18n.ts`: clean.
- [x] No K-8 surfaces modified — `darkMode: "class"` change only affects code that uses `dark:` prefixes, which is now scoped to Pathways.

## Test plan

### Language tests
- [ ] Log in as Marcus (`marcus@test.com / marcus123`) → toggle EN → ES → all Pathways UI in Spanish (sidebar, home, tracks, profile, module player chrome, completion screen, Module 1 slide content).
- [ ] Open `/pathways/about` → toggle ES → entire landing page including all 7 sections in Spanish.
- [ ] Open `/pathways/facilitator/resources` as Coach Davis → all 6 tab labels in Spanish, tab content in Spanish where keyed.
- [ ] Toggle VI → text stays English (no raw keys shown anywhere).
- [ ] Toggle ZH-CN → same — graceful fallback.
- [ ] Refresh after toggle → language persists (via the existing `preferredLanguage` localStorage key).

### Light mode tests
- [ ] `/pathways/about` in light mode → readable text, clean white background, partner-presentation-ready.
- [ ] `/pathways` home → light mode shows track cards on white with colored accents, all text passes contrast.
- [ ] `/pathways/tracks/cyber-launch` → track timeline cards readable in light mode.
- [ ] Open Cyber Foundations module → slides render cleanly in light mode, quiz options readable.
- [ ] `/pathways/facilitator` → dashboard table rows distinguishable, status badges readable.
- [ ] `/pathways/facilitator/resources` → all 6 tabs render in light mode.
- [ ] Toggle theme → preference persists across reload (check `bb_pathways_theme` in localStorage).

### Dark mode regression
- [ ] All the above pages still work in dark mode.
- [ ] Track color accents still pop against dark background.
- [ ] No accidental light-mode-only styles bled through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)