### PR TITLE
fix: Pathways dark mode — move .dark class to ancestor element

### DIFF
--- a/src/components/pathways/PathwaysAbout.tsx
+++ b/src/components/pathways/PathwaysAbout.tsx
@@ -64,7 +64,8 @@ export default function PathwaysAbout() {
   const fundingItems = t("pathways.about.partners.funding", { returnObjects: true }) as string[];
 
   return (
-    <div className={`${isDark ? "dark" : ""} min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100`}>
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       {/* Top controls — language + theme */}
       <div className="absolute top-4 right-4 z-20 flex items-center gap-3">
         <LanguageToggle variant={isDark ? "dark" : "light"} />
@@ -281,6 +282,7 @@ export default function PathwaysAbout() {
       {/* Footer */}
       <div className="border-t border-slate-200 dark:border-slate-800 py-8 text-center text-xs text-slate-500 dark:text-slate-600">
         {t("pathways.about.footer")}
+      </div>
       </div>
     </div>
   );

--- a/src/components/pathways/PathwaysLayout.tsx
+++ b/src/components/pathways/PathwaysLayout.tsx
@@ -1,10 +1,12 @@
 /**
  * Pathways Layout — mature shell for secondary-age (14-17) users.
  *
- * Theme: toggles a `.dark` class on the Pathways root <div> so Tailwind
- * `dark:` variants apply only inside Pathways. The K-8 surfaces stay
- * unaffected. Preference is persisted under `bb_pathways_theme` so it
- * survives reload.
+ * Theme: toggles a `.dark` class on an OUTER wrapper div so Tailwind's
+ * class strategy can resolve `dark:` variants on the descendants below.
+ * (Tailwind's selector is `.dark .dark\\:foo`, which requires `.dark` on
+ * an ancestor — putting both on the same element doesn't work.) The
+ * wrapper is Pathways-scoped, so K-8 surfaces stay unaffected.
+ * Preference is persisted under `bb_pathways_theme`.
  *
  * i18n: every label is keyed under `pathways.layout.*` and falls back
  * to English via i18n.ts fallbackLng.
@@ -51,9 +53,8 @@ export default function PathwaysLayout() {
   const isFacilitator = user?.role === "teacher";
 
   return (
-    <div
-      className={`${isDark ? "dark" : ""} min-h-screen flex bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors`}
-    >
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen flex bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors">
       {/* Sidebar */}
       <nav className="hidden md:flex flex-col w-56 border-r shrink-0 bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
         <div className="p-4 border-b border-slate-200 dark:border-slate-800">
@@ -131,6 +132,7 @@ export default function PathwaysLayout() {
           )}
         </div>
       </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PR #578 put both the \`.dark\` class and the \`dark:\` utility classes on the **same root element**. Tailwind's class strategy generates selectors like \`.dark .dark\:foo\` (descendant), so a same-element \`.dark\` doesn't match and none of the variants on that element actually fire. The dark mode toggle's state persisted, but the page rendered as if it were always in light mode.

## Fix

Split into outer wrapper (carries \`.dark\`) and inner content (carries the \`dark:\` utilities). Tiny change — 2 files, 12 line edits total.

## Affected files

- \`src/components/pathways/PathwaysLayout.tsx\` — wraps the layout shell
- \`src/components/pathways/PathwaysAbout.tsx\` — wraps the public landing page

## Test plan

- [ ] After deploy, log in as Marcus (\`marcus@test.com / marcus123\`) → dark mode renders dark by default
- [ ] Toggle to light → page goes light
- [ ] Toggle back to dark → page returns to dark
- [ ] Reload → preference persists
- [ ] \`/pathways/about\` (logged out) shows the same toggle behavior
- [ ] K-8 surfaces (/teacher/dashboard, /student/dashboard) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)