### PR TITLE
feat: operational facilitator dashboard — cohorts, tracks, learners, reports

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -692,11 +692,17 @@ model PathwayCohort {
   endDate       DateTime?
   trackIds      String[]
   joinCode      String   @unique
+  description   String?
+  maxEnrollment Int?     @default(25)
+  status        String   @default("draft")
+  notes         Json?
   createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   enrollments   PathwayEnrollment[]
 
   @@index([facilitatorId])
+  @@index([status])
 }
 
 model PathwayEnrollment {

--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -1571,18 +1571,41 @@ async function main() {
   }
   console.log("Seeded Aisha:", aisha.email);
 
-  // Cohort
+  // ── Active cohort: ETO Spring 2026 ──
   const cohort = await prisma.pathwayCohort.upsert({
     where: { joinCode: "ETO2026" },
     create: {
       name: "ETO Spring 2026 — Cyber Cohort",
       band: "launch",
-      sitePartner: "Escape The Odds",
+      sitePartner: "Escape The Odds — South Side",
       facilitatorId: facilitator.id,
       trackIds: ["cyber-launch"],
       joinCode: "ETO2026",
+      status: "active",
+      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+      maxEnrollment: 12,
+      startDate: new Date("2026-03-02"),
+      endDate: new Date("2026-04-13"),
+      notes: [
+        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
+        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
+        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
+      ],
     },
-    update: { facilitatorId: facilitator.id },
+    update: {
+      facilitatorId: facilitator.id,
+      status: "active",
+      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+      maxEnrollment: 12,
+      startDate: new Date("2026-03-02"),
+      endDate: new Date("2026-04-13"),
+      sitePartner: "Escape The Odds — South Side",
+      notes: [
+        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
+        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
+        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
+      ],
+    },
   });
 
   // Enroll Marcus and Aisha
@@ -1616,7 +1639,96 @@ async function main() {
       update: { status: m.status, score: m.score },
     });
   }
-  console.log("Seeded Pathways cohort, enrollments, and milestones.");
+
+  // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
+  const endedCohort = await prisma.pathwayCohort.upsert({
+    where: { joinCode: "ETO2025F" },
+    create: {
+      name: "ETO Fall 2025 — Pilot Cohort",
+      band: "launch",
+      sitePartner: "Escape The Odds — West Side",
+      facilitatorId: facilitator.id,
+      trackIds: ["cyber-launch"],
+      joinCode: "ETO2025F",
+      status: "ended",
+      description: "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
+      maxEnrollment: 8,
+      startDate: new Date("2025-10-06"),
+      endDate: new Date("2025-11-17"),
+      notes: [
+        { text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.", author: "Coach Davis", ts: new Date("2025-11-20").toISOString() },
+      ],
+    },
+    update: { facilitatorId: facilitator.id, status: "ended" },
+  });
+
+  // Fictional graduates of the Fall 2025 pilot
+  const graduates = [
+    { name: "Jasmine", email: "grad-jasmine@brightboost.local", scores: [88, 92, 81, 79, 85, 100, 90] },
+    { name: "DeShawn", email: "grad-deshawn@brightboost.local", scores: [82, 95, 87, 84, 91, 100, 95] },
+    { name: "Reina", email: "grad-reina@brightboost.local", scores: [76, 88, 92, 89, 78, 100, 87] },
+  ];
+  const moduleSlugs = ["cyber-foundations", "digital-safety-sim", "network-basics", "threat-detective", "career-map", "cisco-netacad-link", "capstone-security-plan"];
+  const gradHash = await bcrypt.hash("graduate", 10);
+  for (const g of graduates) {
+    let gu = await prisma.user.findUnique({ where: { email: g.email } });
+    if (!gu) {
+      gu = await prisma.user.create({
+        data: {
+          name: g.name,
+          email: g.email,
+          password: gradHash,
+          role: "student",
+          userType: "pathways",
+          ageBand: "launch",
+          birthYear: 2008,
+        },
+      });
+    }
+    await prisma.pathwayEnrollment.upsert({
+      where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
+      create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
+      update: { status: "completed" },
+    });
+    // Realistic completion milestones (each module completed during the Fall pilot)
+    for (let i = 0; i < moduleSlugs.length; i++) {
+      const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+      await prisma.pathwayMilestone.upsert({
+        where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
+        create: {
+          userId: gu.id,
+          trackSlug: "cyber-launch",
+          moduleSlug: moduleSlugs[i],
+          status: "completed",
+          score: g.scores[i],
+          completedAt: completedDate,
+        },
+        update: { status: "completed", score: g.scores[i], completedAt: completedDate },
+      });
+    }
+  }
+
+  // ── Draft cohort: ETO Summer 2026 — Planning ──
+  await prisma.pathwayCohort.upsert({
+    where: { joinCode: "ETO2026S" },
+    create: {
+      name: "ETO Summer 2026 — Planning",
+      band: "mixed",
+      sitePartner: "Escape The Odds — TBD",
+      facilitatorId: facilitator.id,
+      trackIds: ["cyber-launch"],
+      joinCode: "ETO2026S",
+      status: "draft",
+      description: "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
+      maxEnrollment: 16,
+      startDate: new Date("2026-06-15"),
+      endDate: new Date("2026-07-27"),
+      notes: [],
+    },
+    update: { facilitatorId: facilitator.id, status: "draft" },
+  });
+
+  console.log("Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.");
   } catch (e) {
     console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
   }

--- a/backend/src/routes/pathways.ts
+++ b/backend/src/routes/pathways.ts
@@ -13,12 +13,24 @@ const router = Router();
 
 const createCohortSchema = z.object({
   name: z.string().min(1).max(200),
-  band: z.enum(["explorer", "launch"]),
+  band: z.enum(["explorer", "launch", "mixed"]),
   sitePartner: z.string().optional(),
   trackIds: z.array(z.string()).min(1),
   startDate: z.string().datetime().optional(),
   endDate: z.string().datetime().optional(),
+  description: z.string().max(2000).optional(),
+  maxEnrollment: z.number().int().min(1).max(500).optional(),
 });
+
+const updateCohortSchema = createCohortSchema.partial();
+
+const noteSchema = z.object({
+  text: z.string().min(1).max(2000),
+});
+
+function randomJoinCode(): string {
+  return Math.random().toString(36).substring(2, 8).toUpperCase();
+}
 
 const milestoneSchema = z.object({
   trackSlug: z.string().min(1),
@@ -38,7 +50,7 @@ router.post(
     const parsed = createCohortSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
 
-    const joinCode = Math.random().toString(36).substring(2, 8).toUpperCase();
+    const joinCode = randomJoinCode();
     const cohort = await prisma.pathwayCohort.create({
       data: {
         name: parsed.data.name,
@@ -49,6 +61,9 @@ router.post(
         joinCode,
         startDate: parsed.data.startDate ? new Date(parsed.data.startDate) : null,
         endDate: parsed.data.endDate ? new Date(parsed.data.endDate) : null,
+        description: parsed.data.description,
+        maxEnrollment: parsed.data.maxEnrollment ?? 25,
+        status: "draft",
       },
     });
     res.status(201).json(cohort);
@@ -244,6 +259,550 @@ router.get(
       where: { userId: req.user!.id },
     });
     res.json(milestones);
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Facilitator: cohort lifecycle and operations
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Verify cohort exists and belongs to the requesting facilitator. */
+async function ownedCohort(id: string, facilitatorId: string) {
+  return prisma.pathwayCohort.findFirst({
+    where: { id, facilitatorId },
+  });
+}
+
+// Update cohort metadata
+router.put(
+  "/pathways/facilitator/cohorts/:id",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const parsed = updateCohortSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
+
+    const cohort = await ownedCohort(req.params.id, req.user!.id);
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    const data: Record<string, unknown> = {};
+    if (parsed.data.name !== undefined) data.name = parsed.data.name;
+    if (parsed.data.band !== undefined) data.band = parsed.data.band;
+    if (parsed.data.sitePartner !== undefined) data.sitePartner = parsed.data.sitePartner;
+    if (parsed.data.trackIds !== undefined) data.trackIds = parsed.data.trackIds;
+    if (parsed.data.startDate !== undefined) data.startDate = parsed.data.startDate ? new Date(parsed.data.startDate) : null;
+    if (parsed.data.endDate !== undefined) data.endDate = parsed.data.endDate ? new Date(parsed.data.endDate) : null;
+    if (parsed.data.description !== undefined) data.description = parsed.data.description;
+    if (parsed.data.maxEnrollment !== undefined) data.maxEnrollment = parsed.data.maxEnrollment;
+
+    const updated = await prisma.pathwayCohort.update({
+      where: { id: cohort.id },
+      data,
+    });
+    res.json(updated);
+  },
+);
+
+// Lifecycle: start / pause / end / archive
+const LIFECYCLE_TRANSITIONS: Record<string, string> = {
+  start: "active",
+  pause: "paused",
+  end: "ended",
+  archive: "archived",
+};
+
+for (const [action, newStatus] of Object.entries(LIFECYCLE_TRANSITIONS)) {
+  router.post(
+    `/pathways/facilitator/cohorts/:id/${action}`,
+    requireAuth,
+    requireRole("teacher"),
+    async (req: Request, res: Response) => {
+      const cohort = await ownedCohort(req.params.id, req.user!.id);
+      if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+      const updated = await prisma.pathwayCohort.update({
+        where: { id: cohort.id },
+        data: { status: newStatus },
+      });
+      res.json(updated);
+    },
+  );
+}
+
+// Regenerate join code
+router.post(
+  "/pathways/facilitator/cohorts/:id/regenerate-code",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohort = await ownedCohort(req.params.id, req.user!.id);
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    // Retry on collision (extremely rare)
+    let joinCode = randomJoinCode();
+    for (let i = 0; i < 5; i++) {
+      const conflict = await prisma.pathwayCohort.findUnique({ where: { joinCode } });
+      if (!conflict) break;
+      joinCode = randomJoinCode();
+    }
+    const updated = await prisma.pathwayCohort.update({
+      where: { id: cohort.id },
+      data: { joinCode },
+    });
+    res.json({ joinCode: updated.joinCode });
+  },
+);
+
+// Add facilitator note to cohort
+router.post(
+  "/pathways/facilitator/cohorts/:id/notes",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const parsed = noteSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
+
+    const cohort = await ownedCohort(req.params.id, req.user!.id);
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    const existing = (cohort.notes as Array<{ text: string; author: string; ts: string }>) ?? [];
+    const author = await prisma.user.findUnique({
+      where: { id: req.user!.id },
+      select: { name: true },
+    });
+    const note = {
+      text: parsed.data.text,
+      author: author?.name ?? "Facilitator",
+      ts: new Date().toISOString(),
+    };
+    const updated = await prisma.pathwayCohort.update({
+      where: { id: cohort.id },
+      data: { notes: [...existing, note] },
+    });
+    res.json(updated.notes);
+  },
+);
+
+// Add learner by email (must already have a user account)
+router.post(
+  "/pathways/facilitator/cohorts/:id/learners",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const { email } = req.body;
+    if (!email || typeof email !== "string") return res.status(400).json({ error: "Email required" });
+
+    const cohort = await ownedCohort(req.params.id, req.user!.id);
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    const user = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+    if (!user) return res.status(404).json({ error: "No learner account found for that email. The learner must register first." });
+
+    const enrollment = await prisma.pathwayEnrollment.upsert({
+      where: { userId_cohortId: { userId: user.id, cohortId: cohort.id } },
+      create: { userId: user.id, cohortId: cohort.id },
+      update: { status: "active" },
+    });
+    res.status(201).json(enrollment);
+  },
+);
+
+// Remove learner from cohort
+router.delete(
+  "/pathways/facilitator/cohorts/:id/learners/:userId",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohort = await ownedCohort(req.params.id, req.user!.id);
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    await prisma.pathwayEnrollment.deleteMany({
+      where: { cohortId: cohort.id, userId: req.params.userId },
+    });
+    res.status(204).end();
+  },
+);
+
+// Export cohort roster as CSV
+router.get(
+  "/pathways/facilitator/cohorts/:id/export",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohort = await prisma.pathwayCohort.findFirst({
+      where: { id: req.params.id, facilitatorId: req.user!.id },
+      include: { enrollments: { include: { user: true } } },
+    });
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    const userIds = cohort.enrollments.map((e) => e.user.id);
+    const milestones = await prisma.pathwayMilestone.findMany({
+      where: { userId: { in: userIds } },
+    });
+
+    const rows = [
+      ["Name", "Email", "Band", "Modules Completed", "Avg Score", "Last Active", "Enrollment Status"],
+      ...cohort.enrollments.map((e) => {
+        const userMs = milestones.filter((m) => m.userId === e.user.id);
+        const completed = userMs.filter((m) => m.status === "completed");
+        const avgScore = completed.length > 0
+          ? Math.round(completed.reduce((s, m) => s + (m.score ?? 0), 0) / completed.length)
+          : 0;
+        const lastActive = userMs.reduce<Date | null>((latest, m) => {
+          const d = m.completedAt ?? m.createdAt;
+          return !latest || d > latest ? d : latest;
+        }, null);
+        return [
+          e.user.name ?? "",
+          e.user.email ?? "",
+          e.user.ageBand ?? "",
+          String(completed.length),
+          String(avgScore),
+          lastActive ? lastActive.toISOString().slice(0, 10) : "",
+          e.status,
+        ];
+      }),
+    ];
+    const csv = rows.map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(",")).join("\n");
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${cohort.name.replace(/[^a-zA-Z0-9]/g, "_")}_roster.csv"`,
+    );
+    res.send(csv);
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Facilitator: cross-cohort learners
+// ═══════════════════════════════════════════════════════════════════════════
+
+router.get(
+  "/pathways/facilitator/learners",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      include: {
+        enrollments: {
+          include: { user: { select: { id: true, name: true, email: true, ageBand: true } } },
+        },
+      },
+    });
+
+    // Flatten enrollments and collapse per-user (user may be in multiple cohorts)
+    const byUserId = new Map<
+      string,
+      {
+        id: string;
+        name: string | null;
+        email: string | null;
+        ageBand: string | null;
+        cohorts: { id: string; name: string; status: string }[];
+        enrollmentStatuses: string[];
+      }
+    >();
+    for (const cohort of cohorts) {
+      for (const e of cohort.enrollments) {
+        const existing = byUserId.get(e.user.id);
+        if (existing) {
+          existing.cohorts.push({ id: cohort.id, name: cohort.name, status: cohort.status });
+          existing.enrollmentStatuses.push(e.status);
+        } else {
+          byUserId.set(e.user.id, {
+            id: e.user.id,
+            name: e.user.name,
+            email: e.user.email,
+            ageBand: e.user.ageBand,
+            cohorts: [{ id: cohort.id, name: cohort.name, status: cohort.status }],
+            enrollmentStatuses: [e.status],
+          });
+        }
+      }
+    }
+    const userIds = Array.from(byUserId.keys());
+    const milestones = await prisma.pathwayMilestone.findMany({
+      where: { userId: { in: userIds } },
+    });
+
+    const learners = Array.from(byUserId.values()).map((u) => {
+      const ms = milestones.filter((m) => m.userId === u.id);
+      const completed = ms.filter((m) => m.status === "completed").length;
+      const lastActive = ms.reduce<Date | null>((latest, m) => {
+        const d = m.completedAt ?? m.createdAt;
+        return !latest || d > latest ? d : latest;
+      }, null);
+      const enrollmentStatus = u.enrollmentStatuses.includes("active")
+        ? "active"
+        : u.enrollmentStatuses.includes("completed")
+          ? "completed"
+          : u.enrollmentStatuses[0] ?? "inactive";
+      return {
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        ageBand: u.ageBand,
+        cohorts: u.cohorts,
+        completedCount: completed,
+        totalModules: ms.length,
+        lastActive,
+        status: enrollmentStatus,
+      };
+    });
+
+    res.json(learners);
+  },
+);
+
+router.get(
+  "/pathways/facilitator/learners/:userId",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    // Verify the learner is in one of this facilitator's cohorts
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      select: { id: true, name: true, status: true },
+    });
+    const cohortIds = cohorts.map((c) => c.id);
+    const enrollments = await prisma.pathwayEnrollment.findMany({
+      where: { userId: req.params.userId, cohortId: { in: cohortIds } },
+      include: { cohort: { select: { id: true, name: true, status: true } } },
+    });
+    if (enrollments.length === 0) return res.status(404).json({ error: "Learner not found in your cohorts" });
+
+    const user = await prisma.user.findUnique({
+      where: { id: req.params.userId },
+      select: { id: true, name: true, email: true, ageBand: true, birthYear: true },
+    });
+    const milestones = await prisma.pathwayMilestone.findMany({
+      where: { userId: req.params.userId },
+    });
+
+    res.json({ user, enrollments, milestones });
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Facilitator: tracks catalog with stats
+// ═══════════════════════════════════════════════════════════════════════════
+
+router.get(
+  "/pathways/facilitator/tracks",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      select: { id: true, trackIds: true, name: true, status: true },
+    });
+    // Per-track: which cohorts use it, total enrolled, completion stats
+    const trackUsage: Record<string, { cohorts: { id: string; name: string; status: string }[]; learnerCount: number; completionCount: number }> = {};
+    for (const cohort of cohorts) {
+      for (const trackId of cohort.trackIds) {
+        if (!trackUsage[trackId]) trackUsage[trackId] = { cohorts: [], learnerCount: 0, completionCount: 0 };
+        trackUsage[trackId].cohorts.push({ id: cohort.id, name: cohort.name, status: cohort.status });
+      }
+    }
+
+    // Cross-cohort milestone counts per track
+    const cohortIds = cohorts.map((c) => c.id);
+    const enrollments = await prisma.pathwayEnrollment.findMany({
+      where: { cohortId: { in: cohortIds } },
+      select: { userId: true, cohort: { select: { trackIds: true } } },
+    });
+    const trackUserIds: Record<string, Set<string>> = {};
+    for (const e of enrollments) {
+      for (const trackId of e.cohort.trackIds) {
+        if (!trackUserIds[trackId]) trackUserIds[trackId] = new Set();
+        trackUserIds[trackId].add(e.userId);
+      }
+    }
+    for (const [trackId, uids] of Object.entries(trackUserIds)) {
+      if (!trackUsage[trackId]) trackUsage[trackId] = { cohorts: [], learnerCount: 0, completionCount: 0 };
+      trackUsage[trackId].learnerCount = uids.size;
+    }
+
+    const allMilestones = await prisma.pathwayMilestone.findMany({
+      where: { status: "completed", userId: { in: enrollments.map((e) => e.userId) } },
+    });
+    for (const m of allMilestones) {
+      if (!trackUsage[m.trackSlug]) trackUsage[m.trackSlug] = { cohorts: [], learnerCount: 0, completionCount: 0 };
+      trackUsage[m.trackSlug].completionCount += 1;
+    }
+
+    res.json(trackUsage);
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Facilitator: reports
+// ═══════════════════════════════════════════════════════════════════════════
+
+router.get(
+  "/pathways/facilitator/reports/weekly",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const since = new Date(Date.now() - 7 * 86400000);
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      include: {
+        enrollments: { select: { userId: true, enrolledAt: true } },
+      },
+    });
+    const userIds = cohorts.flatMap((c) => c.enrollments.map((e) => e.userId));
+
+    const milestones = await prisma.pathwayMilestone.findMany({
+      where: {
+        userId: { in: userIds },
+        completedAt: { gte: since },
+      },
+    });
+    const newEnrollments = cohorts.flatMap((c) =>
+      c.enrollments.filter((e) => e.enrolledAt >= since),
+    );
+    const recentMs = await prisma.pathwayMilestone.findMany({
+      where: { userId: { in: userIds } },
+      orderBy: { createdAt: "desc" },
+      take: 10,
+      include: { user: { select: { name: true } } },
+    });
+
+    // Learners with no activity in the last 7 days
+    const allRecent = await prisma.pathwayMilestone.findMany({
+      where: { userId: { in: userIds }, OR: [{ createdAt: { gte: since } }, { completedAt: { gte: since } }] },
+      select: { userId: true },
+    });
+    const activeUserIds = new Set(allRecent.map((m) => m.userId));
+    const inactiveLearners = await prisma.user.findMany({
+      where: { id: { in: userIds.filter((id) => !activeUserIds.has(id)) } },
+      select: { id: true, name: true },
+    });
+
+    res.json({
+      windowDays: 7,
+      modulesCompleted: milestones.length,
+      newEnrollments: newEnrollments.length,
+      inactiveLearners,
+      capstonesInProgress: await prisma.pathwayMilestone.count({
+        where: { userId: { in: userIds }, moduleSlug: "capstone-security-plan", status: "in_progress" },
+      }),
+      recentActivity: recentMs,
+    });
+  },
+);
+
+router.get(
+  "/pathways/facilitator/reports/cohort/:id",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohort = await prisma.pathwayCohort.findFirst({
+      where: { id: req.params.id, facilitatorId: req.user!.id },
+      include: { enrollments: { include: { user: { select: { id: true, name: true, ageBand: true } } } } },
+    });
+    if (!cohort) return res.status(404).json({ error: "Cohort not found" });
+
+    const userIds = cohort.enrollments.map((e) => e.user.id);
+    const milestones = await prisma.pathwayMilestone.findMany({ where: { userId: { in: userIds } } });
+    const moduleStats: Record<string, { completed: number; avgScore: number; count: number }> = {};
+    for (const m of milestones) {
+      if (m.status === "completed") {
+        const stats = moduleStats[m.moduleSlug] ?? { completed: 0, avgScore: 0, count: 0 };
+        stats.completed += 1;
+        stats.count += 1;
+        stats.avgScore = Math.round(((stats.avgScore * (stats.count - 1)) + (m.score ?? 0)) / stats.count);
+        moduleStats[m.moduleSlug] = stats;
+      }
+    }
+    res.json({
+      cohort: {
+        id: cohort.id,
+        name: cohort.name,
+        sitePartner: cohort.sitePartner,
+        startDate: cohort.startDate,
+        endDate: cohort.endDate,
+        status: cohort.status,
+      },
+      enrolledCount: cohort.enrollments.length,
+      completedEnrollments: cohort.enrollments.filter((e) => e.status === "completed").length,
+      moduleStats,
+    });
+  },
+);
+
+router.get(
+  "/pathways/facilitator/reports/outcomes",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      include: { enrollments: true },
+    });
+    const userIds = cohorts.flatMap((c) => c.enrollments.map((e) => e.userId));
+
+    const allMs = await prisma.pathwayMilestone.findMany({ where: { userId: { in: userIds } } });
+    const completed = allMs.filter((m) => m.status === "completed");
+    const capstones = completed.filter((m) => m.moduleSlug === "capstone-security-plan").length;
+    const certExternal = completed.filter((m) => m.moduleSlug === "cisco-netacad-link").length;
+
+    res.json({
+      totalCohorts: cohorts.length,
+      activeCohorts: cohorts.filter((c) => c.status === "active").length,
+      endedCohorts: cohorts.filter((c) => c.status === "ended").length,
+      totalEnrolled: userIds.length,
+      modulesCompleted: completed.length,
+      capstonesProduced: capstones,
+      externalCourseworkStarted: certExternal,
+      averageScore: completed.length > 0
+        ? Math.round(completed.reduce((s, m) => s + (m.score ?? 0), 0) / completed.length)
+        : 0,
+    });
+  },
+);
+
+router.get(
+  "/pathways/facilitator/reports/engagement",
+  requireAuth,
+  requireRole("teacher"),
+  async (req: Request, res: Response) => {
+    const cohorts = await prisma.pathwayCohort.findMany({
+      where: { facilitatorId: req.user!.id },
+      include: { enrollments: { select: { userId: true } } },
+    });
+    const userIds = cohorts.flatMap((c) => c.enrollments.map((e) => e.userId));
+    const allMs = await prisma.pathwayMilestone.findMany({ where: { userId: { in: userIds } } });
+
+    // Bucket activity by day for the last 30 days
+    const buckets: Record<string, number> = {};
+    const now = Date.now();
+    for (let i = 29; i >= 0; i--) {
+      const day = new Date(now - i * 86400000).toISOString().slice(0, 10);
+      buckets[day] = 0;
+    }
+    for (const m of allMs) {
+      const ts = (m.completedAt ?? m.createdAt).toISOString().slice(0, 10);
+      if (buckets[ts] !== undefined) buckets[ts] += 1;
+    }
+    const series = Object.entries(buckets).map(([date, count]) => ({ date, count }));
+
+    res.json({
+      totalLearners: userIds.length,
+      activeLast7Days: new Set(
+        allMs
+          .filter((m) => (m.completedAt ?? m.createdAt) >= new Date(Date.now() - 7 * 86400000))
+          .map((m) => m.userId),
+      ).size,
+      activeLast30Days: new Set(
+        allMs
+          .filter((m) => (m.completedAt ?? m.createdAt) >= new Date(Date.now() - 30 * 86400000))
+          .map((m) => m.userId),
+      ).size,
+      dailyActivity: series,
+    });
   },
 );
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -690,7 +690,7 @@ model ClassModuleAssignment {
 model PathwayCohort {
   id            String   @id @default(cuid())
   name          String
-  band          String   // "explorer" | "launch"
+  band          String   // "explorer" | "launch" | "mixed"
   sitePartner   String?
   facilitatorId String
   facilitator   User     @relation(fields: [facilitatorId], references: [id])
@@ -698,11 +698,17 @@ model PathwayCohort {
   endDate       DateTime?
   trackIds      String[] // which tracks are active for this cohort
   joinCode      String   @unique
+  description   String?
+  maxEnrollment Int?     @default(25)
+  status        String   @default("draft") // draft | active | paused | ended | archived
+  notes         Json?    // facilitator notes — array of { text, author, ts }
   createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   enrollments   PathwayEnrollment[]
 
   @@index([facilitatorId])
+  @@index([status])
 }
 
 model PathwayEnrollment {

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -1571,18 +1571,41 @@ async function main() {
   }
   console.log("Seeded Aisha:", aisha.email);
 
-  // Cohort
+  // ── Active cohort: ETO Spring 2026 ──
   const cohort = await prisma.pathwayCohort.upsert({
     where: { joinCode: "ETO2026" },
     create: {
       name: "ETO Spring 2026 — Cyber Cohort",
       band: "launch",
-      sitePartner: "Escape The Odds",
+      sitePartner: "Escape The Odds — South Side",
       facilitatorId: facilitator.id,
       trackIds: ["cyber-launch"],
       joinCode: "ETO2026",
+      status: "active",
+      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+      maxEnrollment: 12,
+      startDate: new Date("2026-03-02"),
+      endDate: new Date("2026-04-13"),
+      notes: [
+        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
+        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
+        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
+      ],
     },
-    update: { facilitatorId: facilitator.id },
+    update: {
+      facilitatorId: facilitator.id,
+      status: "active",
+      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+      maxEnrollment: 12,
+      startDate: new Date("2026-03-02"),
+      endDate: new Date("2026-04-13"),
+      sitePartner: "Escape The Odds — South Side",
+      notes: [
+        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
+        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
+        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
+      ],
+    },
   });
 
   // Enroll Marcus and Aisha
@@ -1616,7 +1639,96 @@ async function main() {
       update: { status: m.status, score: m.score },
     });
   }
-  console.log("Seeded Pathways cohort, enrollments, and milestones.");
+
+  // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
+  const endedCohort = await prisma.pathwayCohort.upsert({
+    where: { joinCode: "ETO2025F" },
+    create: {
+      name: "ETO Fall 2025 — Pilot Cohort",
+      band: "launch",
+      sitePartner: "Escape The Odds — West Side",
+      facilitatorId: facilitator.id,
+      trackIds: ["cyber-launch"],
+      joinCode: "ETO2025F",
+      status: "ended",
+      description: "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
+      maxEnrollment: 8,
+      startDate: new Date("2025-10-06"),
+      endDate: new Date("2025-11-17"),
+      notes: [
+        { text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.", author: "Coach Davis", ts: new Date("2025-11-20").toISOString() },
+      ],
+    },
+    update: { facilitatorId: facilitator.id, status: "ended" },
+  });
+
+  // Fictional graduates of the Fall 2025 pilot
+  const graduates = [
+    { name: "Jasmine", email: "grad-jasmine@brightboost.local", scores: [88, 92, 81, 79, 85, 100, 90] },
+    { name: "DeShawn", email: "grad-deshawn@brightboost.local", scores: [82, 95, 87, 84, 91, 100, 95] },
+    { name: "Reina", email: "grad-reina@brightboost.local", scores: [76, 88, 92, 89, 78, 100, 87] },
+  ];
+  const moduleSlugs = ["cyber-foundations", "digital-safety-sim", "network-basics", "threat-detective", "career-map", "cisco-netacad-link", "capstone-security-plan"];
+  const gradHash = await bcrypt.hash("graduate", 10);
+  for (const g of graduates) {
+    let gu = await prisma.user.findUnique({ where: { email: g.email } });
+    if (!gu) {
+      gu = await prisma.user.create({
+        data: {
+          name: g.name,
+          email: g.email,
+          password: gradHash,
+          role: "student",
+          userType: "pathways",
+          ageBand: "launch",
+          birthYear: 2008,
+        },
+      });
+    }
+    await prisma.pathwayEnrollment.upsert({
+      where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
+      create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
+      update: { status: "completed" },
+    });
+    // Realistic completion milestones (each module completed during the Fall pilot)
+    for (let i = 0; i < moduleSlugs.length; i++) {
+      const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+      await prisma.pathwayMilestone.upsert({
+        where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
+        create: {
+          userId: gu.id,
+          trackSlug: "cyber-launch",
+          moduleSlug: moduleSlugs[i],
+          status: "completed",
+          score: g.scores[i],
+          completedAt: completedDate,
+        },
+        update: { status: "completed", score: g.scores[i], completedAt: completedDate },
+      });
+    }
+  }
+
+  // ── Draft cohort: ETO Summer 2026 — Planning ──
+  await prisma.pathwayCohort.upsert({
+    where: { joinCode: "ETO2026S" },
+    create: {
+      name: "ETO Summer 2026 — Planning",
+      band: "mixed",
+      sitePartner: "Escape The Odds — TBD",
+      facilitatorId: facilitator.id,
+      trackIds: ["cyber-launch"],
+      joinCode: "ETO2026S",
+      status: "draft",
+      description: "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
+      maxEnrollment: 16,
+      startDate: new Date("2026-06-15"),
+      endDate: new Date("2026-07-27"),
+      notes: [],
+    },
+    update: { facilitatorId: facilitator.id, status: "draft" },
+  });
+
+  console.log("Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.");
   } catch (e) {
     console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,9 +57,18 @@ import TracksOverview from "./components/pathways/TracksOverview";
 import TrackDetail from "./components/pathways/TrackDetail";
 import ModulePlayer from "./components/pathways/ModulePlayer";
 import PathwaysProfile from "./components/pathways/PathwaysProfile";
-import FacilitatorDashboard from "./components/pathways/FacilitatorDashboard";
 import PathwaysAbout from "./components/pathways/PathwaysAbout";
 import ProgramOverviewPage from "./components/pathways/facilitator/ProgramOverview";
+import FacilitatorLayout from "./components/pathways/facilitator/FacilitatorLayout";
+import FacilitatorDashboardPage from "./components/pathways/facilitator/pages/Dashboard";
+import CohortsListPage from "./components/pathways/facilitator/pages/CohortsList";
+import CohortNewPage from "./components/pathways/facilitator/pages/CohortNew";
+import CohortDetailPage from "./components/pathways/facilitator/pages/CohortDetail";
+import FacilitatorTracksPage from "./components/pathways/facilitator/pages/Tracks";
+import FacilitatorLearnersPage from "./components/pathways/facilitator/pages/Learners";
+import FacilitatorLearnerDetailPage from "./components/pathways/facilitator/pages/LearnerDetail";
+import FacilitatorReportsPage from "./components/pathways/facilitator/pages/Reports";
+import FacilitatorSettingsPage from "./components/pathways/facilitator/pages/Settings";
 
 // Import styles
 import "./App.css";
@@ -179,8 +188,18 @@ function App() {
                 <Route path="tracks/:trackSlug" element={<TrackDetail />} />
                 <Route path="tracks/:trackSlug/:moduleSlug" element={<ModulePlayer />} />
                 <Route path="profile" element={<PathwaysProfile />} />
-                <Route path="facilitator" element={<FacilitatorDashboard />} />
-                <Route path="facilitator/resources" element={<ProgramOverviewPage />} />
+                <Route path="facilitator" element={<FacilitatorLayout />}>
+                  <Route index element={<FacilitatorDashboardPage />} />
+                  <Route path="cohorts" element={<CohortsListPage />} />
+                  <Route path="cohorts/new" element={<CohortNewPage />} />
+                  <Route path="cohorts/:id" element={<CohortDetailPage />} />
+                  <Route path="tracks" element={<FacilitatorTracksPage />} />
+                  <Route path="learners" element={<FacilitatorLearnersPage />} />
+                  <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
+                  <Route path="reports" element={<FacilitatorReportsPage />} />
+                  <Route path="resources" element={<ProgramOverviewPage />} />
+                  <Route path="settings" element={<FacilitatorSettingsPage />} />
+                </Route>
               </Route>
 
               {/* Legacy Redirects for Flat Routes (if any external links exist) */}

--- a/src/components/pathways/PathwaysAbout.tsx
+++ b/src/components/pathways/PathwaysAbout.tsx
@@ -64,7 +64,8 @@ export default function PathwaysAbout() {
   const fundingItems = t("pathways.about.partners.funding", { returnObjects: true }) as string[];
 
   return (
-    <div className={`${isDark ? "dark" : ""} min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100`}>
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       {/* Top controls — language + theme */}
       <div className="absolute top-4 right-4 z-20 flex items-center gap-3">
         <LanguageToggle variant={isDark ? "dark" : "light"} />
@@ -281,6 +282,7 @@ export default function PathwaysAbout() {
       {/* Footer */}
       <div className="border-t border-slate-200 dark:border-slate-800 py-8 text-center text-xs text-slate-500 dark:text-slate-600">
         {t("pathways.about.footer")}
+      </div>
       </div>
     </div>
   );

--- a/src/components/pathways/PathwaysLayout.tsx
+++ b/src/components/pathways/PathwaysLayout.tsx
@@ -1,10 +1,12 @@
 /**
  * Pathways Layout — mature shell for secondary-age (14-17) users.
  *
- * Theme: toggles a `.dark` class on the Pathways root <div> so Tailwind
- * `dark:` variants apply only inside Pathways. The K-8 surfaces stay
- * unaffected. Preference is persisted under `bb_pathways_theme` so it
- * survives reload.
+ * Theme: toggles a `.dark` class on an OUTER wrapper div so Tailwind's
+ * class strategy can resolve `dark:` variants on the descendants below.
+ * (Tailwind's selector is `.dark .dark\\:foo`, which requires `.dark` on
+ * an ancestor — putting both on the same element doesn't work.) The
+ * wrapper is Pathways-scoped, so K-8 surfaces stay unaffected.
+ * Preference is persisted under `bb_pathways_theme`.
  *
  * i18n: every label is keyed under `pathways.layout.*` and falls back
  * to English via i18n.ts fallbackLng.
@@ -51,9 +53,8 @@ export default function PathwaysLayout() {
   const isFacilitator = user?.role === "teacher";
 
   return (
-    <div
-      className={`${isDark ? "dark" : ""} min-h-screen flex bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors`}
-    >
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen flex bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors">
       {/* Sidebar */}
       <nav className="hidden md:flex flex-col w-56 border-r shrink-0 bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
         <div className="p-4 border-b border-slate-200 dark:border-slate-800">
@@ -131,6 +132,7 @@ export default function PathwaysLayout() {
           )}
         </div>
       </main>
+      </div>
     </div>
   );
 }

--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -1,0 +1,233 @@
+/**
+ * FacilitatorLayout — operational admin shell inside PathwaysLayout.
+ *
+ * Visual identity is intentionally distinct from the student experience:
+ *  - left sidebar nav (vs student bottom nav / colorful cards)
+ *  - role badge in header + cohort context selector
+ *  - data-dense, table-forward content rather than tile-forward
+ *  - neutral palette accents (slate + indigo) instead of track-color fills
+ *
+ * Mounts as a nested route under /pathways/facilitator so PathwaysLayout
+ * still supplies the .dark wrapper and the parent shell.
+ */
+import { useEffect, useState } from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  LayoutDashboard,
+  Users,
+  Compass,
+  GraduationCap,
+  BarChart3,
+  BookOpen,
+  Settings as SettingsIcon,
+  Shield,
+  ChevronDown,
+} from "lucide-react";
+
+const ACTIVE_COHORT_KEY = "bb_facilitator_active_cohort";
+
+interface CohortOption {
+  id: string;
+  name: string;
+  status: string;
+}
+
+export default function FacilitatorLayout() {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const [cohorts, setCohorts] = useState<CohortOption[]>([]);
+  const [activeCohortId, setActiveCohortId] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(ACTIVE_COHORT_KEY);
+    } catch {
+      return null;
+    }
+  });
+  const [cohortMenuOpen, setCohortMenuOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/pathways/cohorts", {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        const arr: CohortOption[] = Array.isArray(data)
+          ? data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))
+          : [];
+        setCohorts(arr);
+        if (!activeCohortId && arr.length > 0) {
+          // Default to the first active cohort
+          const firstActive = arr.find((c) => c.status === "active") ?? arr[0];
+          setActiveCohortId(firstActive.id);
+        }
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    try {
+      if (activeCohortId) localStorage.setItem(ACTIVE_COHORT_KEY, activeCohortId);
+    } catch {
+      /* ignore */
+    }
+  }, [activeCohortId]);
+
+  const activeCohort = cohorts.find((c) => c.id === activeCohortId);
+
+  return (
+    <div className="flex flex-col gap-6 -mt-2">
+      {/* Header bar with role + cohort selector */}
+      <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+        <div className="flex items-center gap-3 text-sm">
+          <span className="font-medium text-slate-900 dark:text-slate-100">
+            {user?.name ?? t("pathways.facilitator.adminTitle")}
+          </span>
+          <span className="text-slate-400 dark:text-slate-600">•</span>
+          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[11px] font-semibold uppercase tracking-wider bg-indigo-100 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300">
+            <Shield className="w-3 h-3" /> {t("pathways.facilitator.roleBadge")}
+          </span>
+        </div>
+
+        {/* Active cohort selector */}
+        {cohorts.length > 0 && (
+          <div className="relative">
+            <button
+              onClick={() => setCohortMenuOpen((o) => !o)}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border bg-white border-slate-200 text-sm text-slate-800 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              <span className="text-slate-500 dark:text-slate-500 text-xs uppercase tracking-wider">
+                {t("pathways.facilitator.activeCohort")}
+              </span>
+              <span className="font-medium">{activeCohort?.name ?? t("pathways.facilitator.selectCohort")}</span>
+              <ChevronDown className={`w-4 h-4 transition-transform ${cohortMenuOpen ? "rotate-180" : ""}`} />
+            </button>
+            {cohortMenuOpen && (
+              <div className="absolute right-0 top-full mt-1 z-30 min-w-[260px] rounded-lg border bg-white border-slate-200 dark:bg-slate-800 dark:border-slate-700 shadow-lg overflow-hidden">
+                {cohorts.map((c) => (
+                  <button
+                    key={c.id}
+                    onClick={() => {
+                      setActiveCohortId(c.id);
+                      setCohortMenuOpen(false);
+                    }}
+                    className={`w-full flex items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                      c.id === activeCohortId
+                        ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300"
+                        : "text-slate-800 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-700/50"
+                    }`}
+                  >
+                    <span>{c.name}</span>
+                    <StatusPill status={c.status} />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-6">
+        {/* Left sidebar nav */}
+        <aside className="hidden lg:block w-56 shrink-0">
+          <nav className="sticky top-6 rounded-xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 p-2 space-y-0.5">
+            <SidebarItem to="/pathways/facilitator" end icon={<LayoutDashboard className="w-4 h-4" />} label={t("pathways.facilitator.nav.dashboard")} />
+            <SidebarItem to="/pathways/facilitator/cohorts" icon={<Users className="w-4 h-4" />} label={t("pathways.facilitator.nav.cohorts")} />
+            <SidebarItem to="/pathways/facilitator/tracks" icon={<Compass className="w-4 h-4" />} label={t("pathways.facilitator.nav.tracks")} />
+            <SidebarItem to="/pathways/facilitator/learners" icon={<GraduationCap className="w-4 h-4" />} label={t("pathways.facilitator.nav.learners")} />
+            <SidebarItem to="/pathways/facilitator/reports" icon={<BarChart3 className="w-4 h-4" />} label={t("pathways.facilitator.nav.reports")} />
+            <SidebarItem to="/pathways/facilitator/resources" icon={<BookOpen className="w-4 h-4" />} label={t("pathways.facilitator.nav.resources")} />
+            <SidebarItem to="/pathways/facilitator/settings" icon={<SettingsIcon className="w-4 h-4" />} label={t("pathways.facilitator.nav.settings")} />
+          </nav>
+        </aside>
+
+        {/* Mobile horizontal nav */}
+        <nav className="lg:hidden -mx-1 px-1 flex gap-1 overflow-x-auto pb-2 border-b border-slate-200 dark:border-slate-800">
+          <MobileSidebarItem to="/pathways/facilitator" end label={t("pathways.facilitator.nav.dashboard")} />
+          <MobileSidebarItem to="/pathways/facilitator/cohorts" label={t("pathways.facilitator.nav.cohorts")} />
+          <MobileSidebarItem to="/pathways/facilitator/tracks" label={t("pathways.facilitator.nav.tracks")} />
+          <MobileSidebarItem to="/pathways/facilitator/learners" label={t("pathways.facilitator.nav.learners")} />
+          <MobileSidebarItem to="/pathways/facilitator/reports" label={t("pathways.facilitator.nav.reports")} />
+          <MobileSidebarItem to="/pathways/facilitator/resources" label={t("pathways.facilitator.nav.resources")} />
+          <MobileSidebarItem to="/pathways/facilitator/settings" label={t("pathways.facilitator.nav.settings")} />
+        </nav>
+
+        {/* Page content */}
+        <div className="flex-1 min-w-0">
+          <Outlet context={{ activeCohortId, cohorts, refreshCohorts: () => {
+            fetch("/api/pathways/cohorts", {
+              headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+            })
+              .then((r) => r.json())
+              .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))
+              .catch(() => {});
+          } }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarItem({
+  to,
+  icon,
+  label,
+  end,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  end?: boolean;
+}) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300"
+            : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700/50"
+        }`
+      }
+    >
+      {icon}
+      <span>{label}</span>
+    </NavLink>
+  );
+}
+
+function MobileSidebarItem({ to, label, end }: { to: string; label: string; end?: boolean }) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `whitespace-nowrap px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300"
+            : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-700/50"
+        }`
+      }
+    >
+      {label}
+    </NavLink>
+  );
+}
+
+export function StatusPill({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    active: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    draft: "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300",
+    paused: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    ended: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300",
+    archived: "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-500",
+  };
+  return (
+    <span className={`text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded ${styles[status] ?? styles.draft}`}>
+      {status}
+    </span>
+  );
+}

--- a/src/components/pathways/facilitator/pages/CohortDetail.tsx
+++ b/src/components/pathways/facilitator/pages/CohortDetail.tsx
@@ -1,0 +1,813 @@
+/**
+ * Cohort Detail page — tabbed interface for a single cohort.
+ *
+ * Tabs:
+ *   - Overview: stats, dates, join code, active tracks
+ *   - Roster: enrolled learners, add/remove, progress
+ *   - Modules: assigned modules + completion per module
+ *   - Calendar: session schedule + due dates (placeholder for now)
+ *   - Notes: cohort-wide facilitator notes
+ *   - Settings: edit metadata, lifecycle actions, regenerate code
+ */
+import { useEffect, useState, useCallback } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
+import {
+  ArrowLeft,
+  Copy,
+  CheckCheck,
+  RefreshCw,
+  Play,
+  Pause,
+  CircleSlash,
+  Archive,
+  Trash2,
+  StickyNote,
+  Plus,
+  Download,
+  Users,
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+} from "lucide-react";
+import Card, { CardBody, CardHeader, StatTile } from "../shared/Card";
+import { StatusPill } from "../FacilitatorLayout";
+
+type TabKey = "overview" | "roster" | "modules" | "calendar" | "notes" | "settings";
+
+interface Cohort {
+  id: string;
+  name: string;
+  band: string;
+  sitePartner: string | null;
+  facilitatorId: string;
+  joinCode: string;
+  status: string;
+  description: string | null;
+  maxEnrollment: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  trackIds: string[];
+  notes: Array<{ text: string; author: string; ts: string }> | null;
+  createdAt: string;
+  updatedAt: string;
+  enrollments: Array<{
+    id: string;
+    userId: string;
+    enrolledAt: string;
+    status: string;
+    user: { id: string; name: string | null; email: string | null; ageBand: string | null };
+  }>;
+}
+
+interface CohortProgress {
+  enrolledCount: number;
+  learners: Array<{
+    id: string;
+    name: string | null;
+    ageBand: string | null;
+    milestones: Array<{ moduleSlug: string; status: string; score: number | null; completedAt: string | null }>;
+    completedCount: number;
+    totalModules: number;
+    lastActive: string | null;
+  }>;
+}
+
+export default function CohortDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const [cohort, setCohort] = useState<Cohort | null>(null);
+  const [progress, setProgress] = useState<CohortProgress | null>(null);
+  const [tab, setTab] = useState<TabKey>("overview");
+  const [loading, setLoading] = useState(true);
+
+  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+
+  const loadCohort = useCallback(async () => {
+    if (!id) return;
+    try {
+      const [c, p] = await Promise.all([
+        fetch(`/api/pathways/cohorts/${id}`, { headers: auth }).then((r) => r.json()),
+        fetch(`/api/pathways/facilitator/cohort/${id}/progress`, { headers: auth }).then((r) => r.json()),
+      ]);
+      setCohort(c);
+      setProgress(p);
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  useEffect(() => {
+    loadCohort();
+    // Hash routing for deep-link to roster
+    const h = window.location.hash.slice(1);
+    if (["overview", "roster", "modules", "calendar", "notes", "settings"].includes(h)) {
+      setTab(h as TabKey);
+    }
+  }, [loadCohort]);
+
+  if (loading) {
+    return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+  }
+  if (!cohort) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-slate-600 dark:text-slate-400">{t("pathways.facilitator.detail.notFound")}</p>
+        <button
+          onClick={() => navigate("/pathways/facilitator/cohorts")}
+          className="mt-3 text-sm text-indigo-700 dark:text-indigo-400 hover:underline"
+        >
+          {t("pathways.facilitator.create.backToCohorts")}
+        </button>
+      </div>
+    );
+  }
+
+  const tabs: { key: TabKey; label: string }[] = [
+    { key: "overview", label: t("pathways.facilitator.detail.tabs.overview") },
+    { key: "roster", label: t("pathways.facilitator.detail.tabs.roster") },
+    { key: "modules", label: t("pathways.facilitator.detail.tabs.modules") },
+    { key: "calendar", label: t("pathways.facilitator.detail.tabs.calendar") },
+    { key: "notes", label: t("pathways.facilitator.detail.tabs.notes") },
+    { key: "settings", label: t("pathways.facilitator.detail.tabs.settings") },
+  ];
+
+  return (
+    <div className="space-y-5">
+      <button
+        onClick={() => navigate("/pathways/facilitator/cohorts")}
+        className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        <ArrowLeft className="w-4 h-4" /> {t("pathways.facilitator.create.backToCohorts")}
+      </button>
+
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{cohort.name}</h1>
+            <StatusPill status={cohort.status} />
+          </div>
+          {cohort.sitePartner && (
+            <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">{cohort.sitePartner}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700 overflow-x-auto -mx-1 px-1">
+        {tabs.map((tt) => {
+          const active = tab === tt.key;
+          return (
+            <button
+              key={tt.key}
+              onClick={() => {
+                setTab(tt.key);
+                window.location.hash = tt.key;
+              }}
+              className={`px-3 sm:px-4 py-2 rounded-t-lg text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
+                active
+                  ? "text-indigo-700 border-indigo-600 bg-indigo-50 dark:text-indigo-300 dark:border-indigo-500 dark:bg-indigo-600/10"
+                  : "text-slate-600 border-transparent hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800/50"
+              }`}
+            >
+              {tt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "overview" && <OverviewTab cohort={cohort} progress={progress} />}
+      {tab === "roster" && <RosterTab cohort={cohort} progress={progress} onReload={loadCohort} />}
+      {tab === "modules" && <ModulesTab cohort={cohort} progress={progress} />}
+      {tab === "calendar" && <CalendarTab cohort={cohort} />}
+      {tab === "notes" && <NotesTab cohort={cohort} onReload={loadCohort} />}
+      {tab === "settings" && <SettingsTab cohort={cohort} onReload={loadCohort} />}
+    </div>
+  );
+}
+
+// ─── Overview Tab ───────────────────────────────────────────────────────
+
+function OverviewTab({ cohort, progress }: { cohort: Cohort; progress: CohortProgress | null }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const totalCompletion = progress
+    ? progress.learners.reduce((sum, l) => sum + l.completedCount, 0)
+    : 0;
+  const possibleCompletion = progress ? progress.learners.length * 7 : 0;
+  const pct = possibleCompletion > 0 ? Math.round((totalCompletion / possibleCompletion) * 100) : 0;
+
+  const copy = () => {
+    navigator.clipboard?.writeText(cohort.joinCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <StatTile
+          label={t("pathways.facilitator.detail.overview.enrolled")}
+          value={`${cohort.enrollments.length}${cohort.maxEnrollment ? ` / ${cohort.maxEnrollment}` : ""}`}
+          icon={<Users className="w-4 h-4" />}
+        />
+        <StatTile
+          label={t("pathways.facilitator.detail.overview.completion")}
+          value={`${pct}%`}
+          icon={<CheckCircle2 className="w-4 h-4" />}
+        />
+        <StatTile
+          label={t("pathways.facilitator.detail.overview.startDate")}
+          value={cohort.startDate ? new Date(cohort.startDate).toLocaleDateString() : "—"}
+          icon={<Clock className="w-4 h-4" />}
+        />
+        <StatTile
+          label={t("pathways.facilitator.detail.overview.endDate")}
+          value={cohort.endDate ? new Date(cohort.endDate).toLocaleDateString() : "—"}
+          icon={<Clock className="w-4 h-4" />}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.detail.overview.joinCodeTitle")}
+          </h3>
+        </CardHeader>
+        <CardBody>
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/20 dark:border-indigo-800/30 max-w-md">
+            <code className="font-mono text-2xl font-bold text-indigo-700 dark:text-indigo-300 tracking-wider">
+              {cohort.joinCode}
+            </code>
+            <button
+              onClick={copy}
+              className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white border border-indigo-200 text-indigo-700 dark:bg-indigo-900/30 dark:border-indigo-700/50 dark:text-indigo-300 text-xs font-medium hover:bg-indigo-50 dark:hover:bg-indigo-800/30"
+            >
+              {copied ? <CheckCheck className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+              {copied ? t("pathways.facilitator.detail.overview.copied") : t("pathways.common.copy")}
+            </button>
+          </div>
+          <p className="text-xs text-slate-600 dark:text-slate-400 mt-2">
+            {t("pathways.facilitator.detail.overview.joinCodeHint")}
+          </p>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.detail.overview.activeTracksTitle")}
+          </h3>
+        </CardHeader>
+        <CardBody>
+          <div className="space-y-2">
+            {cohort.trackIds.map((slug) => {
+              const track = PATHWAY_TRACKS.find((tr) => tr.slug === slug);
+              return (
+                <div
+                  key={slug}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-700/50"
+                >
+                  <div
+                    className="w-2 h-8 rounded-full"
+                    style={{ backgroundColor: track?.color ?? "#64748b" }}
+                  />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {t(`pathways.tracks.items.${slug}.name`, track?.name ?? slug)}
+                    </p>
+                    <p className="text-xs text-slate-600 dark:text-slate-400">
+                      {track?.modules.length ?? 0} {t("pathways.tracks.modulesCount", { count: track?.modules.length ?? 0 })}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardBody>
+      </Card>
+
+      {cohort.description && (
+        <Card>
+          <CardHeader>
+            <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+              {t("pathways.facilitator.detail.overview.descriptionTitle")}
+            </h3>
+          </CardHeader>
+          <CardBody>
+            <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-line">
+              {cohort.description}
+            </p>
+          </CardBody>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ─── Roster Tab ─────────────────────────────────────────────────────────
+
+function RosterTab({
+  cohort,
+  progress,
+  onReload,
+}: {
+  cohort: Cohort;
+  progress: CohortProgress | null;
+  onReload: () => void;
+}) {
+  const { t } = useTranslation();
+  const [addEmail, setAddEmail] = useState("");
+  const [addError, setAddError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+
+  const addLearner = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setAddError(null);
+    if (!addEmail.trim()) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/pathways/facilitator/cohorts/${cohort.id}/learners`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...auth },
+        body: JSON.stringify({ email: addEmail.trim() }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(d.error || "Failed to add learner");
+      }
+      setAddEmail("");
+      onReload();
+    } catch (err: unknown) {
+      setAddError(err instanceof Error ? err.message : "Failed to add learner");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const removeLearner = async (userId: string, name: string | null) => {
+    if (!window.confirm(t("pathways.facilitator.detail.roster.confirmRemove", { name: name ?? "this learner" }))) return;
+    await fetch(`/api/pathways/facilitator/cohorts/${cohort.id}/learners/${userId}`, {
+      method: "DELETE",
+      headers: auth,
+    });
+    onReload();
+  };
+
+  const exportCsv = () => {
+    window.open(
+      `/api/pathways/facilitator/cohorts/${cohort.id}/export?token=${localStorage.getItem("token") ?? ""}`,
+      "_blank",
+    );
+    // Note: query-string auth is a fallback for the download attribute. For full security,
+    // a one-time signed download URL would be better. For demo purposes the Authorization
+    // header would normally be used, but window.open can't carry headers. Leaving as-is
+    // and treating CSV export as a same-session convenience.
+  };
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={addLearner} className="flex flex-wrap gap-2 items-start">
+        <div className="flex-1 min-w-[200px]">
+          <input
+            type="email"
+            value={addEmail}
+            onChange={(e) => setAddEmail(e.target.value)}
+            placeholder={t("pathways.facilitator.detail.roster.addEmailPlaceholder") as string}
+            className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-sm text-slate-900 placeholder-slate-400 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          {addError && <p className="text-xs text-red-700 dark:text-red-400 mt-1">{addError}</p>}
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-400 text-white text-sm font-medium"
+        >
+          <Plus className="w-4 h-4" /> {t("pathways.facilitator.detail.roster.addLearner")}
+        </button>
+        <button
+          type="button"
+          onClick={exportCsv}
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700 text-sm font-medium"
+        >
+          <Download className="w-4 h-4" /> {t("pathways.common.exportCsv")}
+        </button>
+      </form>
+
+      {cohort.enrollments.length === 0 ? (
+        <Card>
+          <div className="px-5 py-12 text-center text-sm text-slate-600 dark:text-slate-400">
+            {t("pathways.facilitator.detail.roster.empty")}
+          </div>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-800/80 text-left text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400">
+              <tr>
+                <th className="px-5 py-3">{t("pathways.facilitator.detail.roster.col.name")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.detail.roster.col.completed")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.detail.roster.col.lastActive")}</th>
+                <th className="px-5 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700/50">
+              {cohort.enrollments.map((e) => {
+                const lp = progress?.learners.find((l) => l.id === e.user.id);
+                return (
+                  <tr key={e.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                    <td className="px-5 py-3">
+                      <Link
+                        to={`/pathways/facilitator/learners/${e.user.id}`}
+                        className="font-medium text-slate-900 dark:text-slate-100 hover:text-indigo-700 dark:hover:text-indigo-300"
+                      >
+                        {e.user.name ?? e.user.email}
+                      </Link>
+                      <p className="text-xs text-slate-600 dark:text-slate-500">{e.user.email}</p>
+                    </td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-slate-300">
+                      {lp?.completedCount ?? 0}<span className="text-slate-500">/7</span>
+                    </td>
+                    <td className="px-5 py-3 text-xs text-slate-600 dark:text-slate-500">
+                      {lp?.lastActive ? new Date(lp.lastActive).toLocaleDateString() : "—"}
+                    </td>
+                    <td className="px-5 py-3 text-right">
+                      <button
+                        onClick={() => removeLearner(e.user.id, e.user.name)}
+                        aria-label={t("pathways.facilitator.detail.roster.removeLearner") as string}
+                        className="p-1.5 rounded text-slate-500 hover:text-red-700 hover:bg-red-50 dark:hover:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ─── Modules Tab ────────────────────────────────────────────────────────
+
+const CYBER_MODULE_SLUGS = [
+  "cyber-foundations",
+  "digital-safety-sim",
+  "network-basics",
+  "threat-detective",
+  "career-map",
+  "cisco-netacad-link",
+  "capstone-security-plan",
+];
+
+function ModulesTab({ cohort, progress }: { cohort: Cohort; progress: CohortProgress | null }) {
+  const { t } = useTranslation();
+  const enrolled = cohort.enrollments.length;
+
+  return (
+    <Card className="overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 dark:bg-slate-800/80 text-left text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400">
+          <tr>
+            <th className="px-5 py-3">{t("pathways.facilitator.detail.modules.col.module")}</th>
+            <th className="px-5 py-3">{t("pathways.facilitator.detail.modules.col.completed")}</th>
+            <th className="px-5 py-3">{t("pathways.facilitator.detail.modules.col.inProgress")}</th>
+            <th className="px-5 py-3">{t("pathways.facilitator.detail.modules.col.avgScore")}</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 dark:divide-slate-700/50">
+          {CYBER_MODULE_SLUGS.map((slug, i) => {
+            let completed = 0;
+            let inProgress = 0;
+            let scoreSum = 0;
+            let scoreCount = 0;
+            for (const l of progress?.learners ?? []) {
+              const m = l.milestones.find((ms) => ms.moduleSlug === slug);
+              if (m?.status === "completed") {
+                completed++;
+                if (m.score !== null) {
+                  scoreSum += m.score;
+                  scoreCount++;
+                }
+              } else if (m?.status === "in_progress") {
+                inProgress++;
+              }
+            }
+            const avgScore = scoreCount > 0 ? Math.round(scoreSum / scoreCount) : null;
+            const completionPct = enrolled > 0 ? Math.round((completed / enrolled) * 100) : 0;
+            return (
+              <tr key={slug}>
+                <td className="px-5 py-3">
+                  <div className="flex items-center gap-3">
+                    <span className="w-6 h-6 rounded-full bg-slate-100 dark:bg-slate-700 text-xs font-bold text-slate-700 dark:text-slate-300 flex items-center justify-center">
+                      {i + 1}
+                    </span>
+                    <span className="font-medium text-slate-900 dark:text-slate-100">
+                      {t(`pathways.tracks.modules.${slug}.name`, slug)}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-5 py-3">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="text-slate-900 dark:text-slate-100 font-medium">{completed}/{enrolled}</span>
+                    <span className="text-xs text-slate-500">({completionPct}%)</span>
+                  </div>
+                </td>
+                <td className="px-5 py-3 text-slate-700 dark:text-slate-300">{inProgress}</td>
+                <td className="px-5 py-3 text-slate-700 dark:text-slate-300">
+                  {avgScore !== null ? `${avgScore}%` : "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Card>
+  );
+}
+
+// ─── Calendar Tab (placeholder) ─────────────────────────────────────────
+
+function CalendarTab({ cohort }: { cohort: Cohort }) {
+  const { t } = useTranslation();
+  const start = cohort.startDate ? new Date(cohort.startDate) : null;
+  const end = cohort.endDate ? new Date(cohort.endDate) : null;
+
+  const sessions: { week: number; date: Date; focus: string }[] = [];
+  if (start && end) {
+    const focuses = [
+      "Cyber Foundations",
+      "Digital Safety Sim",
+      "Network Basics",
+      "Threat Detective",
+      "Career Map + Cisco",
+      "Capstone Showcase",
+    ];
+    for (let i = 0; i < 6; i++) {
+      const d = new Date(start);
+      d.setDate(d.getDate() + i * 7);
+      if (d <= end) {
+        sessions.push({ week: i + 1, date: d, focus: focuses[i] });
+      }
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+          {t("pathways.facilitator.detail.calendar.title")}
+        </h3>
+        <p className="text-xs text-slate-600 dark:text-slate-500 mt-1">
+          {t("pathways.facilitator.detail.calendar.hint")}
+        </p>
+      </CardHeader>
+      <CardBody>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            {t("pathways.facilitator.detail.calendar.empty")}
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {sessions.map((s) => (
+              <li key={s.week} className="flex items-center gap-4 p-3 rounded-lg bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-700/50">
+                <div className="w-12 text-center">
+                  <p className="text-[10px] uppercase tracking-wider text-slate-500">{t("pathways.facilitator.detail.calendar.week")}</p>
+                  <p className="text-xl font-bold text-slate-900 dark:text-slate-100">{s.week}</p>
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-slate-900 dark:text-slate-100">{s.focus}</p>
+                  <p className="text-xs text-slate-600 dark:text-slate-500 mt-0.5">
+                    {s.date.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+// ─── Notes Tab ─────────────────────────────────────────────────────────
+
+function NotesTab({ cohort, onReload }: { cohort: Cohort; onReload: () => void }) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const notes = cohort.notes ?? [];
+
+  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+
+  const add = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim()) return;
+    setSubmitting(true);
+    try {
+      await fetch(`/api/pathways/facilitator/cohorts/${cohort.id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...auth },
+        body: JSON.stringify({ text: draft.trim() }),
+      });
+      setDraft("");
+      onReload();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardBody>
+          <form onSubmit={add} className="space-y-2">
+            <label className="text-xs font-medium uppercase tracking-wider text-slate-600 dark:text-slate-400">
+              {t("pathways.facilitator.detail.notes.addNew")}
+            </label>
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={3}
+              placeholder={t("pathways.facilitator.detail.notes.placeholder") as string}
+              className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-sm text-slate-900 placeholder-slate-400 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+            />
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={submitting || !draft.trim()}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-400 text-white text-sm font-medium"
+              >
+                <StickyNote className="w-3.5 h-3.5" /> {t("pathways.facilitator.detail.notes.save")}
+              </button>
+            </div>
+          </form>
+        </CardBody>
+      </Card>
+
+      {notes.length === 0 ? (
+        <Card>
+          <div className="px-5 py-12 text-center text-sm text-slate-600 dark:text-slate-400">
+            {t("pathways.facilitator.detail.notes.empty")}
+          </div>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {[...notes].reverse().map((n, i) => (
+            <Card key={i}>
+              <CardBody className="space-y-1">
+                <p className="text-sm text-slate-800 dark:text-slate-200 whitespace-pre-line">{n.text}</p>
+                <p className="text-[11px] text-slate-500">
+                  {n.author} · {new Date(n.ts).toLocaleString()}
+                </p>
+              </CardBody>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Settings Tab ──────────────────────────────────────────────────────
+
+function SettingsTab({ cohort, onReload }: { cohort: Cohort; onReload: () => void }) {
+  const { t } = useTranslation();
+  const [busy, setBusy] = useState<string | null>(null);
+  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+
+  const action = async (path: string, key: string, confirmMsg?: string) => {
+    if (confirmMsg && !window.confirm(confirmMsg)) return;
+    setBusy(key);
+    try {
+      await fetch(`/api/pathways/facilitator/cohorts/${cohort.id}/${path}`, {
+        method: "POST",
+        headers: auth,
+      });
+      onReload();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const lifecycleButtons: { path: string; key: string; label: string; icon: React.ReactNode; visible: boolean; danger?: boolean }[] = [
+    {
+      path: "start",
+      key: "start",
+      label: t("pathways.facilitator.detail.settings.start"),
+      icon: <Play className="w-3.5 h-3.5" />,
+      visible: cohort.status === "draft" || cohort.status === "paused",
+    },
+    {
+      path: "pause",
+      key: "pause",
+      label: t("pathways.facilitator.detail.settings.pause"),
+      icon: <Pause className="w-3.5 h-3.5" />,
+      visible: cohort.status === "active",
+    },
+    {
+      path: "end",
+      key: "end",
+      label: t("pathways.facilitator.detail.settings.end"),
+      icon: <CircleSlash className="w-3.5 h-3.5" />,
+      visible: cohort.status === "active" || cohort.status === "paused",
+    },
+    {
+      path: "archive",
+      key: "archive",
+      label: t("pathways.facilitator.detail.settings.archive"),
+      icon: <Archive className="w-3.5 h-3.5" />,
+      visible: cohort.status === "ended" || cohort.status === "draft",
+      danger: true,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.detail.settings.lifecycleTitle")}
+          </h3>
+          <p className="text-xs text-slate-600 dark:text-slate-500 mt-1">
+            {t("pathways.facilitator.detail.settings.lifecycleHint")}
+          </p>
+        </CardHeader>
+        <CardBody>
+          <div className="flex flex-wrap gap-2">
+            {lifecycleButtons.filter((b) => b.visible).map((b) => (
+              <button
+                key={b.key}
+                onClick={() => action(b.path, b.key, b.danger ? (t("pathways.facilitator.detail.settings.confirmArchive") as string) : undefined)}
+                disabled={busy === b.key}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  b.danger
+                    ? "border bg-white border-red-200 text-red-700 hover:bg-red-50 dark:bg-slate-800 dark:border-red-800/30 dark:text-red-400 dark:hover:bg-red-900/20"
+                    : "bg-indigo-600 hover:bg-indigo-700 text-white"
+                }`}
+              >
+                {b.icon} {b.label}
+              </button>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.detail.settings.joinCodeTitle")}
+          </h3>
+          <p className="text-xs text-slate-600 dark:text-slate-500 mt-1">
+            {t("pathways.facilitator.detail.settings.joinCodeHint")}
+          </p>
+        </CardHeader>
+        <CardBody>
+          <div className="flex items-center gap-3">
+            <code className="font-mono text-lg font-bold text-slate-800 dark:text-slate-200 tracking-wider">
+              {cohort.joinCode}
+            </code>
+            <button
+              onClick={() => action("regenerate-code", "regen", t("pathways.facilitator.detail.settings.confirmRegen") as string)}
+              disabled={busy === "regen"}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-sm text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700"
+            >
+              <RefreshCw className={`w-3.5 h-3.5 ${busy === "regen" ? "animate-spin" : ""}`} />
+              {t("pathways.facilitator.detail.settings.regenerateCode")}
+            </button>
+          </div>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+            <AlertCircle className="w-4 h-4" />
+            <h3 className="font-semibold">{t("pathways.facilitator.detail.settings.dataTitle")}</h3>
+          </div>
+        </CardHeader>
+        <CardBody>
+          <p className="text-sm text-slate-700 dark:text-slate-400">
+            {t("pathways.facilitator.detail.settings.dataInfo", {
+              id: cohort.id.slice(0, 8),
+              created: new Date(cohort.createdAt).toLocaleDateString(),
+            })}
+          </p>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/CohortNew.tsx
+++ b/src/components/pathways/facilitator/pages/CohortNew.tsx
@@ -1,0 +1,271 @@
+/**
+ * Create Cohort page — facilitator builds a new cohort.
+ *
+ * On submit: POST /api/pathways/cohorts → redirect to detail page.
+ * Created cohorts are "draft" status by default; facilitator promotes
+ * to "active" from the detail page.
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
+import { ArrowLeft } from "lucide-react";
+import Card, { CardBody } from "../shared/Card";
+
+const ALL_TRACKS = PATHWAY_TRACKS.filter((t) => t.status === "active");
+
+export default function CohortNew() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [sitePartner, setSitePartner] = useState("");
+  const [band, setBand] = useState<"explorer" | "launch" | "mixed">("launch");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [trackIds, setTrackIds] = useState<string[]>(["cyber-launch"]);
+  const [maxEnrollment, setMaxEnrollment] = useState(25);
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggleTrack = (slug: string) => {
+    setTrackIds((prev) => (prev.includes(slug) ? prev.filter((t) => t !== slug) : [...prev, slug]));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError(t("pathways.facilitator.create.errorNameRequired"));
+      return;
+    }
+    if (trackIds.length === 0) {
+      setError(t("pathways.facilitator.create.errorTrackRequired"));
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = {
+        name: name.trim(),
+        band,
+        trackIds,
+        maxEnrollment,
+      };
+      if (sitePartner.trim()) body.sitePartner = sitePartner.trim();
+      if (description.trim()) body.description = description.trim();
+      if (startDate) body.startDate = new Date(startDate).toISOString();
+      if (endDate) body.endDate = new Date(endDate).toISOString();
+
+      const res = await fetch("/api/pathways/cohorts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to create cohort");
+      }
+      const created = await res.json();
+      navigate(`/pathways/facilitator/cohorts/${created.id}`);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to create cohort");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <button
+        onClick={() => navigate("/pathways/facilitator/cohorts")}
+        className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        <ArrowLeft className="w-4 h-4" /> {t("pathways.facilitator.create.backToCohorts")}
+      </button>
+
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.facilitator.create.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.facilitator.create.subtitle")}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <Card>
+          <CardBody className="space-y-5">
+            <Field label={t("pathways.facilitator.create.fieldName")} required>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t("pathways.facilitator.create.namePlaceholder") as string}
+                required
+                maxLength={200}
+                className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 placeholder-slate-400 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </Field>
+
+            <Field label={t("pathways.facilitator.create.fieldSite")}>
+              <input
+                type="text"
+                value={sitePartner}
+                onChange={(e) => setSitePartner(e.target.value)}
+                placeholder={t("pathways.facilitator.create.sitePlaceholder") as string}
+                maxLength={200}
+                className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 placeholder-slate-400 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </Field>
+
+            <Field label={t("pathways.facilitator.create.fieldBand")} required>
+              <div className="flex flex-wrap gap-2">
+                {(["explorer", "launch", "mixed"] as const).map((b) => (
+                  <button
+                    type="button"
+                    key={b}
+                    onClick={() => setBand(b)}
+                    className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border ${
+                      band === b
+                        ? "bg-indigo-600 border-indigo-600 text-white"
+                        : "bg-white border-slate-200 text-slate-800 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700"
+                    }`}
+                  >
+                    {t(`pathways.facilitator.band.${b}`)}
+                  </button>
+                ))}
+              </div>
+            </Field>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <Field label={t("pathways.facilitator.create.fieldStartDate")}>
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </Field>
+              <Field label={t("pathways.facilitator.create.fieldEndDate")}>
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </Field>
+            </div>
+
+            <Field label={t("pathways.facilitator.create.fieldTracks")} required>
+              <div className="space-y-2">
+                {ALL_TRACKS.map((track) => (
+                  <label
+                    key={track.slug}
+                    className="flex items-center gap-3 p-2.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 dark:bg-slate-900/50 dark:border-slate-700 dark:hover:bg-slate-800/50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={trackIds.includes(track.slug)}
+                      onChange={() => toggleTrack(track.slug)}
+                      className="w-4 h-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                        {t(`pathways.tracks.items.${track.slug}.name`, track.name)}
+                      </p>
+                      <p className="text-xs text-slate-600 dark:text-slate-400 truncate">
+                        {t(`pathways.tracks.items.${track.slug}.tagline`, track.tagline)}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+                {PATHWAY_TRACKS.filter((t) => t.status === "coming_soon").map((track) => (
+                  <div
+                    key={track.slug}
+                    className="flex items-center gap-3 p-2.5 rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/30 opacity-60"
+                  >
+                    <input type="checkbox" disabled className="w-4 h-4" />
+                    <div className="flex-1">
+                      <p className="text-sm font-medium text-slate-700 dark:text-slate-400">
+                        {t(`pathways.tracks.items.${track.slug}.name`, track.name)}
+                      </p>
+                      <p className="text-xs text-slate-500">{t("pathways.common.comingSoon")}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Field>
+
+            <Field label={t("pathways.facilitator.create.fieldMaxEnrollment")}>
+              <input
+                type="number"
+                value={maxEnrollment}
+                onChange={(e) => setMaxEnrollment(parseInt(e.target.value, 10) || 25)}
+                min={1}
+                max={500}
+                className="w-32 px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </Field>
+
+            <Field label={t("pathways.facilitator.create.fieldDescription")}>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                maxLength={2000}
+                placeholder={t("pathways.facilitator.create.descriptionPlaceholder") as string}
+                className="w-full px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 placeholder-slate-400 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+              />
+            </Field>
+
+            {error && (
+              <div className="p-3 rounded-lg bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-800/30 text-sm text-red-700 dark:text-red-300">
+                {error}
+              </div>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => navigate("/pathways/facilitator/cohorts")}
+                className="px-4 py-2 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-sm font-medium text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                {t("pathways.facilitator.create.cancel")}
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-400 text-white text-sm font-medium transition-colors"
+              >
+                {submitting ? t("pathways.common.loading") : t("pathways.facilitator.create.createCohort")}
+              </button>
+            </div>
+          </CardBody>
+        </Card>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-800 dark:text-slate-200 mb-1.5">
+        {label}
+        {required && <span className="text-red-600 dark:text-red-400 ml-1">*</span>}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/CohortsList.tsx
+++ b/src/components/pathways/facilitator/pages/CohortsList.tsx
@@ -1,0 +1,182 @@
+/**
+ * Cohorts list — full list of facilitator's cohorts with filter/search.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Plus, Search, Users } from "lucide-react";
+import Card from "../shared/Card";
+import { StatusPill } from "../FacilitatorLayout";
+
+interface Cohort {
+  id: string;
+  name: string;
+  band: string;
+  sitePartner: string | null;
+  status: string;
+  startDate: string | null;
+  endDate: string | null;
+  updatedAt: string;
+  _count?: { enrollments: number };
+}
+
+const STATUS_OPTIONS = ["all", "draft", "active", "paused", "ended", "archived"];
+const BAND_OPTIONS = ["all", "explorer", "launch", "mixed"];
+
+export default function CohortsList() {
+  const { t } = useTranslation();
+  const [cohorts, setCohorts] = useState<Cohort[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [bandFilter, setBandFilter] = useState("all");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetch("/api/pathways/cohorts", {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+    })
+      .then((r) => r.json())
+      .then((data) => setCohorts(Array.isArray(data) ? data : []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = useMemo(() => {
+    return cohorts.filter((c) => {
+      if (statusFilter !== "all" && c.status !== statusFilter) return false;
+      if (bandFilter !== "all" && c.band !== bandFilter) return false;
+      if (search) {
+        const q = search.toLowerCase();
+        const hay = `${c.name} ${c.sitePartner ?? ""}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [cohorts, statusFilter, bandFilter, search]);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {t("pathways.facilitator.cohorts.title")}
+          </h1>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+            {t("pathways.facilitator.cohorts.subtitle")}
+          </p>
+        </div>
+        <Link
+          to="/pathways/facilitator/cohorts/new"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+        >
+          <Plus className="w-4 h-4" /> {t("pathways.facilitator.cohorts.newCohort")}
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <div className="relative">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+          <input
+            type="text"
+            placeholder={t("pathways.facilitator.cohorts.searchPlaceholder")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 pr-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="px-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          aria-label={t("pathways.facilitator.cohorts.filterStatus")}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {s === "all" ? t("pathways.facilitator.cohorts.filterStatusAll") : t(`pathways.facilitator.status.${s}`, s)}
+            </option>
+          ))}
+        </select>
+        <select
+          value={bandFilter}
+          onChange={(e) => setBandFilter(e.target.value)}
+          className="px-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+          aria-label={t("pathways.facilitator.cohorts.filterBand")}
+        >
+          {BAND_OPTIONS.map((b) => (
+            <option key={b} value={b}>
+              {b === "all" ? t("pathways.facilitator.cohorts.filterBandAll") : t(`pathways.facilitator.band.${b}`, b)}
+            </option>
+          ))}
+        </select>
+        <span className="text-xs text-slate-500 dark:text-slate-500 ml-auto">
+          {t("pathways.facilitator.cohorts.resultCount", { count: filtered.length })}
+        </span>
+      </div>
+
+      {loading ? (
+        <Card>
+          <div className="px-5 py-12 text-center text-slate-600 dark:text-slate-400">
+            {t("pathways.common.loading")}
+          </div>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <div className="px-5 py-12 text-center">
+            <Users className="w-10 h-10 text-slate-400 dark:text-slate-600 mx-auto mb-3" />
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {cohorts.length === 0
+                ? t("pathways.facilitator.cohorts.emptyAll")
+                : t("pathways.facilitator.cohorts.emptyFiltered")}
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-800/80">
+                <tr className="text-left text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400">
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.name")}</th>
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.site")}</th>
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.band")}</th>
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.status")}</th>
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.enrolled")}</th>
+                  <th className="px-5 py-3">{t("pathways.facilitator.cohorts.col.dates")}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 dark:divide-slate-700/50">
+                {filtered.map((c) => (
+                  <tr
+                    key={c.id}
+                    className="hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+                  >
+                    <td className="px-5 py-3">
+                      <Link
+                        to={`/pathways/facilitator/cohorts/${c.id}`}
+                        className="font-medium text-slate-900 dark:text-slate-100 hover:text-indigo-700 dark:hover:text-indigo-300"
+                      >
+                        {c.name}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-slate-400">{c.sitePartner ?? "—"}</td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-slate-400 capitalize">{c.band}</td>
+                    <td className="px-5 py-3"><StatusPill status={c.status} /></td>
+                    <td className="px-5 py-3 text-slate-700 dark:text-slate-300 font-medium">
+                      {c._count?.enrollments ?? 0}
+                    </td>
+                    <td className="px-5 py-3 text-xs text-slate-600 dark:text-slate-500">
+                      {c.startDate ? new Date(c.startDate).toLocaleDateString() : "—"}
+                      {" → "}
+                      {c.endDate ? new Date(c.endDate).toLocaleDateString() : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -1,0 +1,373 @@
+/**
+ * Dashboard — operational landing page at /pathways/facilitator.
+ *
+ * The questions this page answers, top to bottom:
+ *   1. Which of my cohorts are active and how are they doing?
+ *   2. What happened across all cohorts this week?
+ *   3. What do I need to do right now?
+ *
+ * Data sources:
+ *   GET /api/pathways/cohorts
+ *   GET /api/pathways/facilitator/reports/weekly
+ *   GET /api/pathways/facilitator/reports/outcomes
+ */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import {
+  Users,
+  CalendarDays,
+  PlayCircle,
+  Download,
+  AlertTriangle,
+  ChevronRight,
+  CheckCircle2,
+  Copy,
+  CheckCheck,
+  Plus,
+  Sparkles,
+} from "lucide-react";
+import Card, { CardBody, CardHeader, StatTile } from "../shared/Card";
+import { StatusPill } from "../FacilitatorLayout";
+
+interface Cohort {
+  id: string;
+  name: string;
+  status: string;
+  sitePartner: string | null;
+  joinCode: string;
+  startDate: string | null;
+  endDate: string | null;
+  maxEnrollment: number | null;
+  trackIds: string[];
+  _count?: { enrollments: number };
+}
+
+interface WeeklyReport {
+  modulesCompleted: number;
+  newEnrollments: number;
+  inactiveLearners: { id: string; name: string | null }[];
+  capstonesInProgress: number;
+  recentActivity: Array<{
+    id: string;
+    moduleSlug: string;
+    trackSlug: string;
+    status: string;
+    score: number | null;
+    completedAt: string | null;
+    createdAt: string;
+    user?: { name: string | null };
+  }>;
+}
+
+export default function Dashboard() {
+  const { t } = useTranslation();
+  const [cohorts, setCohorts] = useState<Cohort[]>([]);
+  const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+
+  const headers = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/pathways/cohorts", { headers }).then((r) => r.json()),
+      fetch("/api/pathways/facilitator/reports/weekly", { headers }).then((r) => r.json()),
+    ])
+      .then(([c, w]) => {
+        setCohorts(Array.isArray(c) ? c : []);
+        setWeekly(w);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const activeCohorts = cohorts.filter((c) => c.status === "active");
+
+  const copyCode = (code: string) => {
+    navigator.clipboard
+      ?.writeText(code)
+      .then(() => {
+        setCopiedCode(code);
+        setTimeout(() => setCopiedCode(null), 2000);
+      })
+      .catch(() => {});
+  };
+
+  const daysRemaining = (endDate: string | null): number | null => {
+    if (!endDate) return null;
+    const diff = new Date(endDate).getTime() - Date.now();
+    return Math.max(0, Math.ceil(diff / 86400000));
+  };
+
+  if (loading) {
+    return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Empty state */}
+      {cohorts.length === 0 && (
+        <Card className="text-center py-16">
+          <CardBody>
+            <Users className="w-12 h-12 text-slate-400 dark:text-slate-600 mx-auto mb-4" />
+            <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">{t("pathways.facilitator.empty.title")}</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400 mt-2 max-w-md mx-auto">
+              {t("pathways.facilitator.empty.subtitle")}
+            </p>
+            <Link
+              to="/pathways/facilitator/cohorts/new"
+              className="inline-flex items-center gap-2 mt-6 px-5 py-2.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+            >
+              <Plus className="w-4 h-4" /> {t("pathways.facilitator.empty.cta")}
+            </Link>
+          </CardBody>
+        </Card>
+      )}
+
+      {/* Active cohorts */}
+      {activeCohorts.length > 0 && (
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {t("pathways.facilitator.dashboard.activeCohortsTitle")}
+            </h2>
+            <Link
+              to="/pathways/facilitator/cohorts"
+              className="text-sm text-indigo-700 dark:text-indigo-400 hover:underline"
+            >
+              {t("pathways.facilitator.dashboard.viewAllCohorts")}
+            </Link>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {activeCohorts.map((c) => {
+              const remaining = daysRemaining(c.endDate);
+              return (
+                <Card key={c.id}>
+                  <CardBody className="space-y-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-slate-900 dark:text-slate-100 truncate">{c.name}</p>
+                        {c.sitePartner && (
+                          <p className="text-xs text-slate-600 dark:text-slate-400 truncate mt-0.5">
+                            {c.sitePartner}
+                          </p>
+                        )}
+                      </div>
+                      <StatusPill status={c.status} />
+                    </div>
+
+                    <div className="flex items-center gap-2 p-2 rounded-lg bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/20 dark:border-indigo-800/30">
+                      <span className="text-[10px] uppercase tracking-wider text-indigo-700 dark:text-indigo-300 font-semibold">
+                        {t("pathways.facilitator.dashboard.joinCode")}
+                      </span>
+                      <code className="font-mono text-sm font-bold text-indigo-800 dark:text-indigo-300 flex-1">
+                        {c.joinCode}
+                      </code>
+                      <button
+                        onClick={() => copyCode(c.joinCode)}
+                        aria-label={t("pathways.common.copy")}
+                        className="p-1 rounded hover:bg-indigo-100 dark:hover:bg-indigo-800/40 text-indigo-700 dark:text-indigo-300"
+                      >
+                        {copiedCode === c.joinCode ? (
+                          <CheckCheck className="w-3.5 h-3.5" />
+                        ) : (
+                          <Copy className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 text-xs">
+                      <div>
+                        <p className="text-slate-500 dark:text-slate-500 uppercase tracking-wider text-[10px]">
+                          {t("pathways.facilitator.dashboard.enrolled")}
+                        </p>
+                        <p className="font-bold text-slate-900 dark:text-slate-100 text-lg">
+                          {c._count?.enrollments ?? 0}
+                          {c.maxEnrollment && (
+                            <span className="text-slate-500 font-normal text-sm"> / {c.maxEnrollment}</span>
+                          )}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-slate-500 dark:text-slate-500 uppercase tracking-wider text-[10px]">
+                          {t("pathways.facilitator.dashboard.daysRemaining")}
+                        </p>
+                        <p className="font-bold text-slate-900 dark:text-slate-100 text-lg">
+                          {remaining ?? "—"}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex gap-2 pt-2">
+                      <Link
+                        to={`/pathways/facilitator/cohorts/${c.id}`}
+                        className="flex-1 text-center px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-medium transition-colors"
+                      >
+                        {t("pathways.facilitator.dashboard.openCohort")}
+                      </Link>
+                      <Link
+                        to={`/pathways/facilitator/cohorts/${c.id}#roster`}
+                        className="flex-1 text-center px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700 text-xs font-medium transition-colors"
+                      >
+                        {t("pathways.facilitator.dashboard.viewRoster")}
+                      </Link>
+                    </div>
+                  </CardBody>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* This week at a glance */}
+      {weekly && (
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">
+            {t("pathways.facilitator.dashboard.thisWeekTitle")}
+          </h2>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+            <StatTile
+              label={t("pathways.facilitator.dashboard.modulesCompleted")}
+              value={weekly.modulesCompleted}
+              icon={<CheckCircle2 className="w-4 h-4" />}
+            />
+            <StatTile
+              label={t("pathways.facilitator.dashboard.newEnrollments")}
+              value={weekly.newEnrollments}
+              icon={<Users className="w-4 h-4" />}
+            />
+            <StatTile
+              label={t("pathways.facilitator.dashboard.needsFollowUp")}
+              value={weekly.inactiveLearners.length}
+              hint={
+                weekly.inactiveLearners.length > 0
+                  ? weekly.inactiveLearners
+                      .slice(0, 3)
+                      .map((l) => l.name)
+                      .join(", ")
+                  : undefined
+              }
+              icon={<AlertTriangle className="w-4 h-4" />}
+              accentClass={weekly.inactiveLearners.length > 0 ? "border-amber-300 dark:border-amber-800/30" : ""}
+            />
+            <StatTile
+              label={t("pathways.facilitator.dashboard.capstonesInProgress")}
+              value={weekly.capstonesInProgress}
+              icon={<Sparkles className="w-4 h-4" />}
+            />
+          </div>
+        </section>
+      )}
+
+      {/* Quick actions */}
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">
+          {t("pathways.facilitator.dashboard.quickActionsTitle")}
+        </h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Link
+            to="/pathways/facilitator/cohorts/new"
+            className="flex items-center gap-3 p-4 rounded-xl border bg-white border-slate-200 hover:bg-slate-50 hover:border-indigo-300 dark:bg-slate-800/50 dark:border-slate-700 dark:hover:bg-slate-800 dark:hover:border-indigo-700 transition-colors"
+          >
+            <div className="w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-600/20 text-indigo-700 dark:text-indigo-300 flex items-center justify-center">
+              <Plus className="w-5 h-5" />
+            </div>
+            <div>
+              <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">
+                {t("pathways.facilitator.dashboard.actionCreateCohort")}
+              </p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">
+                {t("pathways.facilitator.dashboard.actionCreateCohortSub")}
+              </p>
+            </div>
+          </Link>
+          <Link
+            to="/pathways/facilitator/cohorts"
+            className="flex items-center gap-3 p-4 rounded-xl border bg-white border-slate-200 hover:bg-slate-50 hover:border-indigo-300 dark:bg-slate-800/50 dark:border-slate-700 dark:hover:bg-slate-800 dark:hover:border-indigo-700 transition-colors"
+          >
+            <div className="w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-600/20 text-indigo-700 dark:text-indigo-300 flex items-center justify-center">
+              <Users className="w-5 h-5" />
+            </div>
+            <div>
+              <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">
+                {t("pathways.facilitator.dashboard.actionAddLearner")}
+              </p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">
+                {t("pathways.facilitator.dashboard.actionAddLearnerSub")}
+              </p>
+            </div>
+          </Link>
+          <Link
+            to="/pathways/facilitator/reports"
+            className="flex items-center gap-3 p-4 rounded-xl border bg-white border-slate-200 hover:bg-slate-50 hover:border-indigo-300 dark:bg-slate-800/50 dark:border-slate-700 dark:hover:bg-slate-800 dark:hover:border-indigo-700 transition-colors"
+          >
+            <div className="w-10 h-10 rounded-lg bg-indigo-100 dark:bg-indigo-600/20 text-indigo-700 dark:text-indigo-300 flex items-center justify-center">
+              <Download className="w-5 h-5" />
+            </div>
+            <div>
+              <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">
+                {t("pathways.facilitator.dashboard.actionWeeklyReport")}
+              </p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">
+                {t("pathways.facilitator.dashboard.actionWeeklyReportSub")}
+              </p>
+            </div>
+          </Link>
+        </div>
+      </section>
+
+      {/* Recent activity feed */}
+      {weekly && weekly.recentActivity.length > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">
+            {t("pathways.facilitator.dashboard.recentActivityTitle")}
+          </h2>
+          <Card>
+            <ul className="divide-y divide-slate-200 dark:divide-slate-700/50">
+              {weekly.recentActivity.slice(0, 10).map((m) => (
+                <li key={m.id} className="flex items-center gap-3 px-5 py-3">
+                  {m.status === "completed" ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0" />
+                  ) : (
+                    <PlayCircle className="w-4 h-4 text-indigo-600 dark:text-indigo-400 shrink-0" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-slate-800 dark:text-slate-200">
+                      <span className="font-medium">{m.user?.name ?? t("pathways.facilitator.dashboard.aLearner")}</span>{" "}
+                      <span className="text-slate-600 dark:text-slate-400">
+                        {m.status === "completed"
+                          ? t("pathways.facilitator.dashboard.completedModule")
+                          : t("pathways.facilitator.dashboard.startedModule")}{" "}
+                      </span>
+                      <span className="text-slate-800 dark:text-slate-200">
+                        {m.moduleSlug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                      </span>
+                      {m.score !== null && (
+                        <span className="text-slate-500 dark:text-slate-500"> · {m.score}%</span>
+                      )}
+                    </p>
+                    <p className="text-[10px] text-slate-500 mt-0.5">
+                      {new Date(m.completedAt ?? m.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <CalendarDays className="w-3.5 h-3.5 text-slate-400 dark:text-slate-600" />
+                </li>
+              ))}
+            </ul>
+            <CardHeader className="border-t border-b-0 border-slate-200 dark:border-slate-700">
+              <Link
+                to="/pathways/facilitator/reports"
+                className="inline-flex items-center gap-1 text-sm text-indigo-700 dark:text-indigo-400 hover:underline"
+              >
+                {t("pathways.facilitator.dashboard.viewFullReport")} <ChevronRight className="w-3.5 h-3.5" />
+              </Link>
+            </CardHeader>
+          </Card>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/LearnerDetail.tsx
+++ b/src/components/pathways/facilitator/pages/LearnerDetail.tsx
@@ -1,0 +1,192 @@
+/**
+ * Learner detail — full progress, enrollments, and milestones for one learner.
+ */
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, CheckCircle2, Clock, XCircle } from "lucide-react";
+import Card, { CardBody, CardHeader } from "../shared/Card";
+import { StatusPill } from "../FacilitatorLayout";
+
+interface LearnerDetailData {
+  user: { id: string; name: string | null; email: string | null; ageBand: string | null; birthYear: number | null };
+  enrollments: Array<{
+    id: string;
+    enrolledAt: string;
+    status: string;
+    cohort: { id: string; name: string; status: string };
+  }>;
+  milestones: Array<{ moduleSlug: string; trackSlug: string; status: string; score: number | null; completedAt: string | null; createdAt: string }>;
+}
+
+export default function LearnerDetail() {
+  const { userId } = useParams();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const [data, setData] = useState<LearnerDetailData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`/api/pathways/facilitator/learners/${userId}`, {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+    })
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  if (loading) return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+  if (!data) return (
+    <div className="text-center py-20">
+      <p className="text-slate-600 dark:text-slate-400">{t("pathways.facilitator.learnerDetail.notFound")}</p>
+      <button
+        onClick={() => navigate("/pathways/facilitator/learners")}
+        className="mt-3 text-sm text-indigo-700 dark:text-indigo-400 hover:underline"
+      >
+        {t("pathways.facilitator.learnerDetail.backToLearners")}
+      </button>
+    </div>
+  );
+
+  const completed = data.milestones.filter((m) => m.status === "completed");
+  const avgScore = completed.length > 0
+    ? Math.round(completed.reduce((s, m) => s + (m.score ?? 0), 0) / completed.length)
+    : 0;
+
+  return (
+    <div className="space-y-5">
+      <button
+        onClick={() => navigate("/pathways/facilitator/learners")}
+        className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        <ArrowLeft className="w-4 h-4" /> {t("pathways.facilitator.learnerDetail.backToLearners")}
+      </button>
+
+      <Card>
+        <CardBody>
+          <div className="flex items-center gap-4">
+            <div className="w-16 h-16 rounded-full bg-indigo-100 dark:bg-indigo-600/20 text-indigo-700 dark:text-indigo-300 flex items-center justify-center text-2xl font-bold">
+              {(data.user.name ?? "?")[0]?.toUpperCase()}
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">{data.user.name ?? t("pathways.profile.learner")}</h1>
+              <p className="text-sm text-slate-600 dark:text-slate-400">{data.user.email}</p>
+              <p className="text-xs text-slate-500 dark:text-slate-500 mt-0.5 capitalize">
+                {t("pathways.facilitator.learnerDetail.band")}: {data.user.ageBand ?? "—"}
+              </p>
+            </div>
+          </div>
+        </CardBody>
+      </Card>
+
+      <div className="grid sm:grid-cols-3 gap-3">
+        <SimpleStat
+          label={t("pathways.facilitator.learnerDetail.modulesCompleted")}
+          value={completed.length}
+          icon={<CheckCircle2 className="w-4 h-4 text-emerald-700 dark:text-emerald-400" />}
+        />
+        <SimpleStat
+          label={t("pathways.facilitator.learnerDetail.inProgress")}
+          value={data.milestones.filter((m) => m.status === "in_progress").length}
+          icon={<Clock className="w-4 h-4 text-indigo-700 dark:text-indigo-400" />}
+        />
+        <SimpleStat
+          label={t("pathways.facilitator.learnerDetail.avgScore")}
+          value={`${avgScore}%`}
+          icon={<CheckCircle2 className="w-4 h-4 text-amber-700 dark:text-amber-400" />}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.learnerDetail.cohorts")}
+          </h3>
+        </CardHeader>
+        <CardBody>
+          <ul className="space-y-2">
+            {data.enrollments.map((e) => (
+              <li key={e.id} className="flex items-center justify-between gap-3 p-2.5 rounded-lg border bg-slate-50 border-slate-200 dark:bg-slate-900/50 dark:border-slate-700/50">
+                <Link
+                  to={`/pathways/facilitator/cohorts/${e.cohort.id}`}
+                  className="text-sm font-medium text-slate-900 dark:text-slate-100 hover:text-indigo-700 dark:hover:text-indigo-300"
+                >
+                  {e.cohort.name}
+                </Link>
+                <div className="flex items-center gap-2">
+                  <StatusPill status={e.cohort.status} />
+                  <span className="text-xs text-slate-600 dark:text-slate-500">
+                    {t("pathways.facilitator.learnerDetail.enrolledOn", { date: new Date(e.enrolledAt).toLocaleDateString() })}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.learnerDetail.milestones")}
+          </h3>
+        </CardHeader>
+        <CardBody>
+          {data.milestones.length === 0 ? (
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {t("pathways.facilitator.learnerDetail.noMilestones")}
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {data.milestones.map((m, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-3 p-2 rounded text-sm"
+                >
+                  {m.status === "completed" ? (
+                    <CheckCircle2 className="w-4 h-4 text-emerald-700 dark:text-emerald-400 shrink-0" />
+                  ) : m.status === "in_progress" ? (
+                    <Clock className="w-4 h-4 text-indigo-700 dark:text-indigo-400 shrink-0" />
+                  ) : (
+                    <XCircle className="w-4 h-4 text-slate-400 dark:text-slate-600 shrink-0" />
+                  )}
+                  <span className="flex-1 text-slate-800 dark:text-slate-300">
+                    {t(`pathways.tracks.modules.${m.moduleSlug}.name`, m.moduleSlug)}
+                  </span>
+                  <span className="text-xs text-slate-600 dark:text-slate-500">
+                    {m.score !== null ? `${m.score}%` : ""}
+                  </span>
+                  <span className="text-xs text-slate-500 w-24 text-right">
+                    {m.completedAt ? new Date(m.completedAt).toLocaleDateString() : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+function SimpleStat({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | number;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 p-4">
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-medium">{label}</p>
+        {icon}
+      </div>
+      <p className="text-2xl font-bold text-slate-900 dark:text-white">{value}</p>
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/Learners.tsx
+++ b/src/components/pathways/facilitator/pages/Learners.tsx
@@ -1,0 +1,189 @@
+/**
+ * Learners — cross-cohort master roster with search/filter.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Search, Users } from "lucide-react";
+import Card from "../shared/Card";
+
+interface Learner {
+  id: string;
+  name: string | null;
+  email: string | null;
+  ageBand: string | null;
+  cohorts: { id: string; name: string; status: string }[];
+  completedCount: number;
+  totalModules: number;
+  lastActive: string | null;
+  status: string;
+}
+
+export default function Learners() {
+  const { t } = useTranslation();
+  const [learners, setLearners] = useState<Learner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [bandFilter, setBandFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [cohortFilter, setCohortFilter] = useState("all");
+
+  useEffect(() => {
+    fetch("/api/pathways/facilitator/learners", {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+    })
+      .then((r) => r.json())
+      .then((data) => setLearners(Array.isArray(data) ? data : []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const allCohorts = useMemo(() => {
+    const seen = new Map<string, { id: string; name: string }>();
+    for (const l of learners) for (const c of l.cohorts) seen.set(c.id, { id: c.id, name: c.name });
+    return Array.from(seen.values());
+  }, [learners]);
+
+  const filtered = useMemo(() => {
+    return learners.filter((l) => {
+      if (bandFilter !== "all" && l.ageBand !== bandFilter) return false;
+      if (statusFilter !== "all" && l.status !== statusFilter) return false;
+      if (cohortFilter !== "all" && !l.cohorts.some((c) => c.id === cohortFilter)) return false;
+      if (search) {
+        const q = search.toLowerCase();
+        const hay = `${l.name ?? ""} ${l.email ?? ""}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [learners, search, bandFilter, statusFilter, cohortFilter]);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.facilitator.learners.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.facilitator.learners.subtitle")}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <div className="relative">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+          <input
+            type="text"
+            placeholder={t("pathways.facilitator.learners.searchPlaceholder") as string}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 pr-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <select
+          value={cohortFilter}
+          onChange={(e) => setCohortFilter(e.target.value)}
+          className="px-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+        >
+          <option value="all">{t("pathways.facilitator.learners.filterCohortAll")}</option>
+          {allCohorts.map((c) => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+        <select
+          value={bandFilter}
+          onChange={(e) => setBandFilter(e.target.value)}
+          className="px-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+        >
+          <option value="all">{t("pathways.facilitator.cohorts.filterBandAll")}</option>
+          <option value="explorer">{t("pathways.facilitator.band.explorer")}</option>
+          <option value="launch">{t("pathways.facilitator.band.launch")}</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="px-3 py-1.5 text-sm rounded-lg border bg-white border-slate-200 text-slate-800 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200"
+        >
+          <option value="all">{t("pathways.facilitator.learners.filterStatusAll")}</option>
+          <option value="active">{t("pathways.facilitator.learners.statusActive")}</option>
+          <option value="completed">{t("pathways.facilitator.learners.statusCompleted")}</option>
+        </select>
+        <span className="text-xs text-slate-500 ml-auto">
+          {t("pathways.facilitator.learners.resultCount", { count: filtered.length })}
+        </span>
+      </div>
+
+      {loading ? (
+        <Card>
+          <div className="px-5 py-12 text-center text-slate-600 dark:text-slate-400">
+            {t("pathways.common.loading")}
+          </div>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <div className="px-5 py-12 text-center">
+            <Users className="w-10 h-10 text-slate-400 dark:text-slate-600 mx-auto mb-3" />
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {learners.length === 0
+                ? t("pathways.facilitator.learners.emptyAll")
+                : t("pathways.facilitator.learners.emptyFiltered")}
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-800/80 text-left text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400">
+              <tr>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.name")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.cohorts")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.band")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.completion")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.lastActive")}</th>
+                <th className="px-5 py-3">{t("pathways.facilitator.learners.col.status")}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-700/50">
+              {filtered.map((l) => (
+                <tr key={l.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                  <td className="px-5 py-3">
+                    <Link
+                      to={`/pathways/facilitator/learners/${l.id}`}
+                      className="font-medium text-slate-900 dark:text-slate-100 hover:text-indigo-700 dark:hover:text-indigo-300"
+                    >
+                      {l.name ?? l.email}
+                    </Link>
+                    <p className="text-xs text-slate-600 dark:text-slate-500">{l.email}</p>
+                  </td>
+                  <td className="px-5 py-3 text-xs text-slate-700 dark:text-slate-400">
+                    {l.cohorts.map((c) => c.name).join(", ")}
+                  </td>
+                  <td className="px-5 py-3 text-slate-700 dark:text-slate-400 capitalize">{l.ageBand ?? "—"}</td>
+                  <td className="px-5 py-3 text-slate-900 dark:text-slate-100 font-medium">
+                    {l.completedCount}<span className="text-slate-500 font-normal">/{l.totalModules || 7}</span>
+                  </td>
+                  <td className="px-5 py-3 text-xs text-slate-600 dark:text-slate-500">
+                    {l.lastActive ? new Date(l.lastActive).toLocaleDateString() : "—"}
+                  </td>
+                  <td className="px-5 py-3 text-xs">
+                    <span
+                      className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wider ${
+                        l.status === "active"
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                          : l.status === "completed"
+                            ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                            : "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-400"
+                      }`}
+                    >
+                      {l.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/pages/Reports.tsx
+++ b/src/components/pathways/facilitator/pages/Reports.tsx
@@ -1,0 +1,342 @@
+/**
+ * Reports — funder/partner-ready reporting interface.
+ * Four pre-built report types + a stats dashboard. CSV export available.
+ */
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Activity,
+  BookOpen,
+  Award,
+  TrendingUp,
+  Download,
+  Users,
+  CheckCircle2,
+  Sparkles,
+  GraduationCap,
+} from "lucide-react";
+import Card, { CardBody, CardHeader, StatTile } from "../shared/Card";
+
+type ReportKey = "weekly" | "outcomes" | "engagement" | "cohort";
+
+interface WeeklyReport {
+  windowDays: number;
+  modulesCompleted: number;
+  newEnrollments: number;
+  inactiveLearners: { id: string; name: string | null }[];
+  capstonesInProgress: number;
+  recentActivity: Array<{ moduleSlug: string; user?: { name: string | null }; score: number | null; completedAt: string | null; createdAt: string }>;
+}
+
+interface OutcomesReport {
+  totalCohorts: number;
+  activeCohorts: number;
+  endedCohorts: number;
+  totalEnrolled: number;
+  modulesCompleted: number;
+  capstonesProduced: number;
+  externalCourseworkStarted: number;
+  averageScore: number;
+}
+
+interface EngagementReport {
+  totalLearners: number;
+  activeLast7Days: number;
+  activeLast30Days: number;
+  dailyActivity: { date: string; count: number }[];
+}
+
+export default function Reports() {
+  const { t } = useTranslation();
+  const [active, setActive] = useState<ReportKey>("weekly");
+  const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
+  const [outcomes, setOutcomes] = useState<OutcomesReport | null>(null);
+  const [engagement, setEngagement] = useState<EngagementReport | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+    Promise.all([
+      fetch("/api/pathways/facilitator/reports/weekly", { headers: auth }).then((r) => r.json()),
+      fetch("/api/pathways/facilitator/reports/outcomes", { headers: auth }).then((r) => r.json()),
+      fetch("/api/pathways/facilitator/reports/engagement", { headers: auth }).then((r) => r.json()),
+    ])
+      .then(([w, o, e]) => {
+        setWeekly(w);
+        setOutcomes(o);
+        setEngagement(e);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const reports: { key: ReportKey; label: string; icon: React.ReactNode; description: string }[] = [
+    {
+      key: "weekly",
+      label: t("pathways.facilitator.reports.types.weekly.label"),
+      icon: <Activity className="w-4 h-4" />,
+      description: t("pathways.facilitator.reports.types.weekly.description"),
+    },
+    {
+      key: "outcomes",
+      label: t("pathways.facilitator.reports.types.outcomes.label"),
+      icon: <Award className="w-4 h-4" />,
+      description: t("pathways.facilitator.reports.types.outcomes.description"),
+    },
+    {
+      key: "engagement",
+      label: t("pathways.facilitator.reports.types.engagement.label"),
+      icon: <TrendingUp className="w-4 h-4" />,
+      description: t("pathways.facilitator.reports.types.engagement.description"),
+    },
+    {
+      key: "cohort",
+      label: t("pathways.facilitator.reports.types.cohort.label"),
+      icon: <BookOpen className="w-4 h-4" />,
+      description: t("pathways.facilitator.reports.types.cohort.description"),
+    },
+  ];
+
+  const exportWeekly = () => {
+    if (!weekly) return;
+    const rows = [
+      ["Window", `${weekly.windowDays} days`],
+      ["Modules Completed", weekly.modulesCompleted.toString()],
+      ["New Enrollments", weekly.newEnrollments.toString()],
+      ["Inactive Learners", weekly.inactiveLearners.map((l) => l.name).join("; ")],
+      ["Capstones In Progress", weekly.capstonesInProgress.toString()],
+    ];
+    downloadCsv("weekly_activity_report.csv", rows);
+  };
+
+  const exportOutcomes = () => {
+    if (!outcomes) return;
+    const rows = Object.entries(outcomes).map(([k, v]) => [k, String(v)]);
+    downloadCsv("outcomes_report.csv", rows);
+  };
+
+  if (loading) {
+    return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.facilitator.reports.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.facilitator.reports.subtitle")}
+        </p>
+      </div>
+
+      {/* Stats summary across all reports */}
+      {outcomes && (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <StatTile
+            label={t("pathways.facilitator.reports.summary.totalLearners")}
+            value={outcomes.totalEnrolled}
+            icon={<Users className="w-4 h-4" />}
+          />
+          <StatTile
+            label={t("pathways.facilitator.reports.summary.modulesCompleted")}
+            value={outcomes.modulesCompleted}
+            icon={<CheckCircle2 className="w-4 h-4" />}
+          />
+          <StatTile
+            label={t("pathways.facilitator.reports.summary.capstones")}
+            value={outcomes.capstonesProduced}
+            icon={<Sparkles className="w-4 h-4" />}
+          />
+          <StatTile
+            label={t("pathways.facilitator.reports.summary.avgScore")}
+            value={`${outcomes.averageScore}%`}
+            icon={<GraduationCap className="w-4 h-4" />}
+          />
+        </div>
+      )}
+
+      {/* Report type selector */}
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {reports.map((r) => {
+          const isActive = active === r.key;
+          return (
+            <button
+              key={r.key}
+              onClick={() => setActive(r.key)}
+              className={`text-left p-4 rounded-xl border transition-colors ${
+                isActive
+                  ? "border-indigo-600 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-600/10"
+                  : "border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:bg-slate-800"
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span className={isActive ? "text-indigo-700 dark:text-indigo-300" : "text-slate-600 dark:text-slate-400"}>
+                  {r.icon}
+                </span>
+                <p className={`text-sm font-semibold ${isActive ? "text-indigo-800 dark:text-indigo-200" : "text-slate-900 dark:text-slate-100"}`}>
+                  {r.label}
+                </p>
+              </div>
+              <p className="text-xs text-slate-600 dark:text-slate-400">{r.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Selected report body */}
+      {active === "weekly" && weekly && <WeeklyView w={weekly} onExport={exportWeekly} />}
+      {active === "outcomes" && outcomes && <OutcomesView o={outcomes} onExport={exportOutcomes} />}
+      {active === "engagement" && engagement && <EngagementView e={engagement} />}
+      {active === "cohort" && <CohortReportNote />}
+    </div>
+  );
+}
+
+function WeeklyView({ w, onExport }: { w: WeeklyReport; onExport: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+            {t("pathways.facilitator.reports.types.weekly.label")}
+          </h3>
+          <p className="text-xs text-slate-600 dark:text-slate-400">
+            {t("pathways.facilitator.reports.windowDays", { days: w.windowDays })}
+          </p>
+        </div>
+        <button
+          onClick={onExport}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700 text-xs font-medium"
+        >
+          <Download className="w-3.5 h-3.5" /> {t("pathways.common.exportCsv")}
+        </button>
+      </CardHeader>
+      <CardBody className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <KV label={t("pathways.facilitator.dashboard.modulesCompleted")} value={w.modulesCompleted} />
+          <KV label={t("pathways.facilitator.dashboard.newEnrollments")} value={w.newEnrollments} />
+          <KV label={t("pathways.facilitator.dashboard.needsFollowUp")} value={w.inactiveLearners.length} />
+          <KV label={t("pathways.facilitator.dashboard.capstonesInProgress")} value={w.capstonesInProgress} />
+        </div>
+        {w.inactiveLearners.length > 0 && (
+          <div>
+            <p className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-medium mb-1">
+              {t("pathways.facilitator.reports.inactiveList")}
+            </p>
+            <ul className="text-sm text-slate-700 dark:text-slate-300 space-y-1">
+              {w.inactiveLearners.slice(0, 10).map((l) => (
+                <li key={l.id}>· {l.name ?? l.id.slice(0, 8)}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+function OutcomesView({ o, onExport }: { o: OutcomesReport; onExport: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+          {t("pathways.facilitator.reports.types.outcomes.label")}
+        </h3>
+        <button
+          onClick={onExport}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700 text-xs font-medium"
+        >
+          <Download className="w-3.5 h-3.5" /> {t("pathways.common.exportCsv")}
+        </button>
+      </CardHeader>
+      <CardBody>
+        <div className="grid sm:grid-cols-2 gap-3">
+          <KV label={t("pathways.facilitator.reports.outcomes.totalCohorts")} value={o.totalCohorts} />
+          <KV label={t("pathways.facilitator.reports.outcomes.activeCohorts")} value={o.activeCohorts} />
+          <KV label={t("pathways.facilitator.reports.outcomes.endedCohorts")} value={o.endedCohorts} />
+          <KV label={t("pathways.facilitator.reports.outcomes.totalEnrolled")} value={o.totalEnrolled} />
+          <KV label={t("pathways.facilitator.reports.outcomes.modulesCompleted")} value={o.modulesCompleted} />
+          <KV label={t("pathways.facilitator.reports.outcomes.capstones")} value={o.capstonesProduced} />
+          <KV label={t("pathways.facilitator.reports.outcomes.cisco")} value={o.externalCourseworkStarted} />
+          <KV label={t("pathways.facilitator.reports.outcomes.avgScore")} value={`${o.averageScore}%`} />
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function EngagementView({ e }: { e: EngagementReport }) {
+  const { t } = useTranslation();
+  const max = Math.max(1, ...e.dailyActivity.map((d) => d.count));
+  return (
+    <Card>
+      <CardHeader>
+        <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+          {t("pathways.facilitator.reports.types.engagement.label")}
+        </h3>
+      </CardHeader>
+      <CardBody className="space-y-4">
+        <div className="grid sm:grid-cols-3 gap-3">
+          <KV label={t("pathways.facilitator.reports.engagement.totalLearners")} value={e.totalLearners} />
+          <KV label={t("pathways.facilitator.reports.engagement.active7")} value={e.activeLast7Days} />
+          <KV label={t("pathways.facilitator.reports.engagement.active30")} value={e.activeLast30Days} />
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-medium mb-2">
+            {t("pathways.facilitator.reports.engagement.dailyActivity")}
+          </p>
+          <div className="flex items-end gap-px h-24">
+            {e.dailyActivity.map((d) => (
+              <div
+                key={d.date}
+                className="flex-1 bg-indigo-200 dark:bg-indigo-600/40 rounded-t hover:bg-indigo-400 dark:hover:bg-indigo-500 transition-colors"
+                style={{ height: `${(d.count / max) * 100}%` }}
+                title={`${d.date}: ${d.count}`}
+              />
+            ))}
+          </div>
+          <div className="flex justify-between text-[10px] text-slate-500 mt-1">
+            <span>{e.dailyActivity[0]?.date}</span>
+            <span>{e.dailyActivity[e.dailyActivity.length - 1]?.date}</span>
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+function CohortReportNote() {
+  const { t } = useTranslation();
+  return (
+    <Card>
+      <CardBody>
+        <p className="text-sm text-slate-700 dark:text-slate-400">
+          {t("pathways.facilitator.reports.cohortReportHint")}
+        </p>
+      </CardBody>
+    </Card>
+  );
+}
+
+function KV({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="p-3 rounded-lg bg-slate-50 border border-slate-200 dark:bg-slate-900/50 dark:border-slate-700/50">
+      <p className="text-[10px] uppercase tracking-wider text-slate-600 dark:text-slate-400 font-medium">{label}</p>
+      <p className="text-xl font-bold text-slate-900 dark:text-slate-100 mt-0.5">{value}</p>
+    </div>
+  );
+}
+
+function downloadCsv(filename: string, rows: string[][]) {
+  const csv = rows.map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(",")).join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/components/pathways/facilitator/pages/Settings.tsx
+++ b/src/components/pathways/facilitator/pages/Settings.tsx
@@ -1,0 +1,199 @@
+/**
+ * Settings page — facilitator-wide preferences. Persisted to localStorage
+ * for now; will move to a Prisma `FacilitatorPrefs` model once we know
+ * which prefs matter to partners in production.
+ */
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Save, Bell, ClipboardList } from "lucide-react";
+import Card, { CardBody, CardHeader } from "../shared/Card";
+
+const PREFS_KEY = "bb_facilitator_prefs";
+
+interface Prefs {
+  defaultBand: "explorer" | "launch" | "mixed";
+  defaultMaxEnrollment: number;
+  notifyOnNewEnrollment: boolean;
+  notifyOnInactiveLearner: boolean;
+  notifyOnCohortStatusChange: boolean;
+}
+
+const DEFAULTS: Prefs = {
+  defaultBand: "launch",
+  defaultMaxEnrollment: 16,
+  notifyOnNewEnrollment: true,
+  notifyOnInactiveLearner: true,
+  notifyOnCohortStatusChange: false,
+};
+
+function readPrefs(): Prefs {
+  try {
+    const raw = localStorage.getItem(PREFS_KEY);
+    if (!raw) return DEFAULTS;
+    return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export default function Settings() {
+  const { t } = useTranslation();
+  const [prefs, setPrefs] = useState<Prefs>(() => readPrefs());
+  const [saved, setSaved] = useState(false);
+
+  const update = <K extends keyof Prefs>(key: K, value: Prefs[K]) => {
+    setPrefs((p) => ({ ...p, [key]: value }));
+  };
+
+  const save = () => {
+    try {
+      localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  useEffect(() => {
+    setSaved(false);
+  }, [prefs]);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          {t("pathways.facilitator.settings.title")}
+        </h1>
+        <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+          {t("pathways.facilitator.settings.subtitle")}
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <ClipboardList className="w-4 h-4 text-indigo-700 dark:text-indigo-400" />
+            <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+              {t("pathways.facilitator.settings.cohortDefaultsTitle")}
+            </h3>
+          </div>
+          <p className="text-xs text-slate-600 dark:text-slate-500 mt-1">
+            {t("pathways.facilitator.settings.cohortDefaultsHint")}
+          </p>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-800 dark:text-slate-200 mb-1.5">
+              {t("pathways.facilitator.settings.defaultBand")}
+            </label>
+            <div className="flex gap-2">
+              {(["explorer", "launch", "mixed"] as const).map((b) => (
+                <button
+                  key={b}
+                  onClick={() => update("defaultBand", b)}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border ${
+                    prefs.defaultBand === b
+                      ? "bg-indigo-600 border-indigo-600 text-white"
+                      : "bg-white border-slate-200 text-slate-800 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700"
+                  }`}
+                >
+                  {t(`pathways.facilitator.band.${b}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-800 dark:text-slate-200 mb-1.5">
+              {t("pathways.facilitator.settings.defaultMaxEnrollment")}
+            </label>
+            <input
+              type="number"
+              value={prefs.defaultMaxEnrollment}
+              onChange={(e) => update("defaultMaxEnrollment", parseInt(e.target.value, 10) || 16)}
+              min={1}
+              max={500}
+              className="w-32 px-3 py-2 rounded-lg border bg-white border-slate-200 text-slate-900 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bell className="w-4 h-4 text-indigo-700 dark:text-indigo-400" />
+            <h3 className="font-semibold text-slate-900 dark:text-slate-200">
+              {t("pathways.facilitator.settings.notificationsTitle")}
+            </h3>
+          </div>
+          <p className="text-xs text-slate-600 dark:text-slate-500 mt-1">
+            {t("pathways.facilitator.settings.notificationsHint")}
+          </p>
+        </CardHeader>
+        <CardBody className="space-y-3">
+          <Toggle
+            label={t("pathways.facilitator.settings.notifyNewEnrollment")}
+            description={t("pathways.facilitator.settings.notifyNewEnrollmentHint")}
+            checked={prefs.notifyOnNewEnrollment}
+            onChange={(v) => update("notifyOnNewEnrollment", v)}
+          />
+          <Toggle
+            label={t("pathways.facilitator.settings.notifyInactive")}
+            description={t("pathways.facilitator.settings.notifyInactiveHint")}
+            checked={prefs.notifyOnInactiveLearner}
+            onChange={(v) => update("notifyOnInactiveLearner", v)}
+          />
+          <Toggle
+            label={t("pathways.facilitator.settings.notifyStatusChange")}
+            description={t("pathways.facilitator.settings.notifyStatusChangeHint")}
+            checked={prefs.notifyOnCohortStatusChange}
+            onChange={(v) => update("notifyOnCohortStatusChange", v)}
+          />
+        </CardBody>
+      </Card>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={save}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
+        >
+          <Save className="w-4 h-4" /> {t("pathways.facilitator.settings.savePreferences")}
+        </button>
+        {saved && (
+          <span className="text-xs text-emerald-700 dark:text-emerald-400">
+            {t("pathways.facilitator.settings.saved")}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-start gap-3 cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 w-4 h-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+      />
+      <div>
+        <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{label}</p>
+        <p className="text-xs text-slate-600 dark:text-slate-400 mt-0.5">{description}</p>
+      </div>
+    </label>
+  );
+}

--- a/src/components/pathways/facilitator/pages/Tracks.tsx
+++ b/src/components/pathways/facilitator/pages/Tracks.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tracks page — catalog of available tracks with per-track stats and
+ * a "Request a Custom Track" stub for the Q3 2026 roadmap item.
+ */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { PATHWAY_TRACKS } from "@/constants/pathwayTracks";
+import { Shield, Rocket, DollarSign, Cpu, Film, Lock, ExternalLink, Sparkles, X } from "lucide-react";
+import Card, { CardBody } from "../shared/Card";
+import { StatusPill } from "../FacilitatorLayout";
+
+const ICONS: Record<string, React.ReactNode> = {
+  Shield: <Shield className="w-6 h-6" />,
+  Rocket: <Rocket className="w-6 h-6" />,
+  DollarSign: <DollarSign className="w-6 h-6" />,
+  Cpu: <Cpu className="w-6 h-6" />,
+  Film: <Film className="w-6 h-6" />,
+};
+
+interface TrackUsage {
+  cohorts: { id: string; name: string; status: string }[];
+  learnerCount: number;
+  completionCount: number;
+}
+
+export default function Tracks() {
+  const { t } = useTranslation();
+  const [usage, setUsage] = useState<Record<string, TrackUsage>>({});
+  const [requestOpen, setRequestOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/pathways/facilitator/tracks", {
+      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+    })
+      .then((r) => r.json())
+      .then((data) => setUsage(data || {}))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+            {t("pathways.facilitator.tracks.title")}
+          </h1>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
+            {t("pathways.facilitator.tracks.subtitle")}
+          </p>
+        </div>
+        <button
+          onClick={() => setRequestOpen(true)}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700 text-sm font-medium"
+        >
+          <Sparkles className="w-4 h-4" /> {t("pathways.facilitator.tracks.requestCustom")}
+        </button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {PATHWAY_TRACKS.map((track) => {
+          const u = usage[track.slug];
+          const isActive = track.status === "active";
+          return (
+            <Card key={track.slug}>
+              <CardBody className="space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div
+                    className="w-12 h-12 rounded-lg flex items-center justify-center"
+                    style={{ backgroundColor: track.color + "20", color: track.color }}
+                  >
+                    {ICONS[track.icon]}
+                  </div>
+                  {!isActive && (
+                    <span className="flex items-center gap-1 text-[10px] font-medium text-slate-600 dark:text-slate-500 bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded-full">
+                      <Lock className="w-3 h-3" /> {t("pathways.common.comingSoon")}
+                    </span>
+                  )}
+                </div>
+                <div>
+                  <h3 className="font-semibold text-slate-900 dark:text-slate-100">
+                    {t(`pathways.tracks.items.${track.slug}.name`, track.name)}
+                  </h3>
+                  <p className="text-xs text-slate-600 dark:text-slate-400">
+                    {t(`pathways.tracks.items.${track.slug}.tagline`, track.tagline)}
+                  </p>
+                </div>
+                <p className="text-xs text-slate-700 dark:text-slate-500">
+                  {track.modules.length} {t("pathways.facilitator.tracks.modules")}
+                </p>
+
+                {isActive && (
+                  <>
+                    <div className="grid grid-cols-3 gap-2 text-xs">
+                      <Stat label={t("pathways.facilitator.tracks.cohorts")} value={u?.cohorts.length ?? 0} />
+                      <Stat label={t("pathways.facilitator.tracks.learners")} value={u?.learnerCount ?? 0} />
+                      <Stat label={t("pathways.facilitator.tracks.completions")} value={u?.completionCount ?? 0} />
+                    </div>
+                    {u && u.cohorts.length > 0 && (
+                      <div className="text-xs text-slate-600 dark:text-slate-500">
+                        <p className="font-medium mb-1">{t("pathways.facilitator.tracks.usedBy")}</p>
+                        <ul className="space-y-0.5">
+                          {u.cohorts.map((c) => (
+                            <li key={c.id} className="flex items-center justify-between gap-2">
+                              <Link
+                                to={`/pathways/facilitator/cohorts/${c.id}`}
+                                className="truncate hover:text-indigo-700 dark:hover:text-indigo-300"
+                              >
+                                {c.name}
+                              </Link>
+                              <StatusPill status={c.status} />
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    <Link
+                      to={`/pathways/tracks/${track.slug}`}
+                      className="inline-flex items-center gap-1.5 mt-1 text-sm text-indigo-700 dark:text-indigo-400 hover:underline"
+                    >
+                      {t("pathways.facilitator.tracks.preview")} <ExternalLink className="w-3.5 h-3.5" />
+                    </Link>
+                  </>
+                )}
+              </CardBody>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Custom track request modal */}
+      {requestOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+          onClick={() => setRequestOpen(false)}
+          role="dialog"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 p-6 shadow-xl"
+          >
+            <div className="flex items-start justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Sparkles className="w-5 h-5 text-indigo-700 dark:text-indigo-300" />
+                <h3 className="font-bold text-lg text-slate-900 dark:text-slate-100">
+                  {t("pathways.facilitator.tracks.customTitle")}
+                </h3>
+              </div>
+              <button
+                onClick={() => setRequestOpen(false)}
+                aria-label="Close"
+                className="text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <span className="inline-block text-[11px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-600/20 dark:text-indigo-300 mb-3">
+              {t("pathways.facilitator.tracks.customRoadmap")}
+            </span>
+            <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+              {t("pathways.facilitator.tracks.customBody")}
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setRequestOpen(false)}
+                className="px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 text-sm text-slate-700 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-700"
+              >
+                {t("pathways.facilitator.create.cancel")}
+              </button>
+              <a
+                href="mailto:nwalker@brightbotsint.com?subject=Pathways%20Custom%20Track%20Request"
+                className="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
+              >
+                {t("pathways.facilitator.tracks.contactUs")}
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg bg-slate-50 dark:bg-slate-900/50 px-2 py-1.5 text-center">
+      <p className="text-[10px] uppercase tracking-wider text-slate-600 dark:text-slate-500">{label}</p>
+      <p className="text-sm font-bold text-slate-900 dark:text-slate-100">{value}</p>
+    </div>
+  );
+}

--- a/src/components/pathways/facilitator/shared/Card.tsx
+++ b/src/components/pathways/facilitator/shared/Card.tsx
@@ -1,0 +1,55 @@
+/**
+ * Shared light/dark-aware card used across the facilitator admin pages.
+ */
+import type { ReactNode } from "react";
+
+export default function Card({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 shadow-sm ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={`px-5 py-4 border-b border-slate-200 dark:border-slate-700 ${className}`}>{children}</div>
+  );
+}
+
+export function CardBody({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return <div className={`p-5 ${className}`}>{children}</div>;
+}
+
+export function StatTile({
+  label,
+  value,
+  hint,
+  icon,
+  accentClass,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+  icon?: ReactNode;
+  accentClass?: string;
+}) {
+  return (
+    <div className={`rounded-xl border bg-white border-slate-200 dark:bg-slate-800/50 dark:border-slate-700 p-4 ${accentClass ?? ""}`}>
+      <div className="flex items-center justify-between">
+        <p className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-medium">{label}</p>
+        {icon && <span className="text-slate-400 dark:text-slate-500">{icon}</span>}
+      </div>
+      <p className="text-2xl font-bold text-slate-900 dark:text-white mt-1">{value}</p>
+      {hint && <p className="text-xs text-slate-500 mt-0.5">{hint}</p>}
+    </div>
+  );
+}

--- a/src/locales/en/pathways.json
+++ b/src/locales/en/pathways.json
@@ -20,7 +20,8 @@
       "startQuiz": "Start Quiz",
       "nextQuestion": "Next Question",
       "logInOrJoin": "Log In or Join",
-      "requestPilot": "Request a Pilot"
+      "requestPilot": "Request a Pilot",
+      "copy": "Copy"
     },
     "layout": {
       "eyebrow": "Bright Boost",
@@ -206,9 +207,283 @@
       },
       "band": {
         "explorer": "Explorer (14–15)",
-        "launch": "Launch (16–17)"
+        "launch": "Launch (16–17)",
+        "mixed": "Mixed bands"
       },
-      "resourcesTitle": "Program overview, session guide, printables"
+      "resourcesTitle": "Program overview, session guide, printables",
+      "adminTitle": "Facilitator Admin",
+      "roleBadge": "Facilitator",
+      "activeCohort": "Active",
+      "selectCohort": "Select a cohort",
+      "empty": {
+        "title": "No Cohorts Yet",
+        "subtitle": "Get started by creating your first cohort. You'll generate a join code and start enrolling learners right away.",
+        "cta": "Create Your First Cohort"
+      },
+      "nav": {
+        "dashboard": "Dashboard",
+        "cohorts": "Cohorts",
+        "tracks": "Tracks",
+        "learners": "Learners",
+        "reports": "Reports",
+        "resources": "Resources",
+        "settings": "Settings"
+      },
+      "dashboard": {
+        "activeCohortsTitle": "Active Cohorts",
+        "viewAllCohorts": "View all cohorts →",
+        "thisWeekTitle": "This Week at a Glance",
+        "quickActionsTitle": "Quick Actions",
+        "recentActivityTitle": "Recent Activity",
+        "viewFullReport": "View full report",
+        "joinCode": "Code",
+        "enrolled": "Enrolled",
+        "daysRemaining": "Days Left",
+        "openCohort": "Open Cohort",
+        "viewRoster": "View Roster",
+        "modulesCompleted": "Modules Completed",
+        "newEnrollments": "New Enrollments",
+        "needsFollowUp": "Needs Follow-Up",
+        "capstonesInProgress": "Capstones In Progress",
+        "actionCreateCohort": "Create New Cohort",
+        "actionCreateCohortSub": "Set up a new program with a fresh join code",
+        "actionAddLearner": "Add Learner",
+        "actionAddLearnerSub": "Enroll a learner into an existing cohort",
+        "actionWeeklyReport": "Export This Week's Report",
+        "actionWeeklyReportSub": "Download a CSV summary for partners",
+        "completedModule": "completed",
+        "startedModule": "started",
+        "aLearner": "A learner"
+      },
+      "cohorts": {
+        "title": "Cohorts",
+        "subtitle": "Every cohort you own, across sites and seasons.",
+        "newCohort": "New Cohort",
+        "searchPlaceholder": "Search by name or site…",
+        "filterStatus": "Filter by status",
+        "filterStatusAll": "All statuses",
+        "filterBand": "Filter by band",
+        "filterBandAll": "All bands",
+        "resultCount": "{{count}} shown",
+        "emptyAll": "You haven't created any cohorts yet.",
+        "emptyFiltered": "No cohorts match the current filters.",
+        "col": {
+          "name": "Name",
+          "site": "Site Partner",
+          "band": "Band",
+          "status": "Status",
+          "enrolled": "Enrolled",
+          "dates": "Dates"
+        }
+      },
+      "status_": {
+        "draft": "Draft",
+        "active": "Active",
+        "paused": "Paused",
+        "ended": "Ended",
+        "archived": "Archived"
+      },
+      "create": {
+        "backToCohorts": "Back to Cohorts",
+        "title": "Create a New Cohort",
+        "subtitle": "Set up the basics. You can fine-tune everything from the cohort detail page after.",
+        "fieldName": "Cohort Name",
+        "namePlaceholder": "e.g., \"ETO Fall 2026 — Cyber Cohort\"",
+        "fieldSite": "Site Partner",
+        "sitePlaceholder": "e.g., \"Escape The Odds — South Side\"",
+        "fieldBand": "Age Band",
+        "fieldStartDate": "Start Date",
+        "fieldEndDate": "End Date",
+        "fieldTracks": "Active Tracks",
+        "fieldMaxEnrollment": "Maximum Enrollment",
+        "fieldDescription": "Cohort Description (optional)",
+        "descriptionPlaceholder": "Context for facilitator notes…",
+        "cancel": "Cancel",
+        "createCohort": "Create Cohort",
+        "errorNameRequired": "Cohort name is required.",
+        "errorTrackRequired": "Select at least one track."
+      },
+      "detail": {
+        "notFound": "Cohort not found.",
+        "tabs": {
+          "overview": "Overview",
+          "roster": "Roster",
+          "modules": "Modules",
+          "calendar": "Calendar",
+          "notes": "Notes",
+          "settings": "Settings"
+        },
+        "overview": {
+          "enrolled": "Enrolled",
+          "completion": "Completion",
+          "startDate": "Start Date",
+          "endDate": "End Date",
+          "joinCodeTitle": "Join Code",
+          "joinCodeHint": "Learners use this code to enroll themselves. Treat it like a temporary password — regenerate if it's been shared too widely.",
+          "copied": "Copied!",
+          "activeTracksTitle": "Active Tracks",
+          "descriptionTitle": "About this Cohort"
+        },
+        "roster": {
+          "addEmailPlaceholder": "learner@email.com",
+          "addLearner": "Add Learner",
+          "empty": "No learners enrolled yet. Share the join code or add by email above.",
+          "removeLearner": "Remove learner",
+          "confirmRemove": "Remove {{name}} from this cohort? Their progress will remain in the database but they will no longer appear on this roster.",
+          "col": {
+            "name": "Learner",
+            "completed": "Modules",
+            "lastActive": "Last Active"
+          }
+        },
+        "modules": {
+          "col": {
+            "module": "Module",
+            "completed": "Completed",
+            "inProgress": "In Progress",
+            "avgScore": "Avg Score"
+          }
+        },
+        "calendar": {
+          "title": "Session Schedule",
+          "hint": "Generated from cohort start date assuming weekly sessions. Override per-session in a future release.",
+          "empty": "Set a start and end date on the cohort to see a generated session calendar.",
+          "week": "Week"
+        },
+        "notes": {
+          "addNew": "Add a new note",
+          "placeholder": "What did you observe in today's session? Plans for next week?",
+          "save": "Save note",
+          "empty": "No notes yet. Use this space to track patterns, plans, and observations across sessions."
+        },
+        "settings": {
+          "lifecycleTitle": "Cohort Lifecycle",
+          "lifecycleHint": "Move the cohort between draft → active → paused → ended → archived.",
+          "start": "Start Cohort",
+          "pause": "Pause",
+          "end": "End Program",
+          "archive": "Archive",
+          "confirmArchive": "Archive this cohort? It will be hidden from default views but data is preserved.",
+          "joinCodeTitle": "Join Code Management",
+          "joinCodeHint": "If the current code has been shared too widely or is compromised, regenerate it. Existing enrolled learners are unaffected.",
+          "regenerateCode": "Regenerate Code",
+          "confirmRegen": "Generate a new join code? The current code will stop working immediately.",
+          "dataTitle": "Cohort Data",
+          "dataInfo": "ID: {{id}} • Created: {{created}}"
+        }
+      },
+      "tracks": {
+        "title": "Tracks",
+        "subtitle": "Catalog of available learning tracks. Active tracks can be assigned to cohorts.",
+        "requestCustom": "Request a Custom Track",
+        "modules": "modules",
+        "cohorts": "Cohorts",
+        "learners": "Learners",
+        "completions": "Completions",
+        "usedBy": "Used by:",
+        "preview": "Preview as Learner",
+        "customTitle": "Custom Track Builder",
+        "customRoadmap": "Coming Q3 2026",
+        "customBody": "Soon you'll be able to build custom tracks tailored to your site's needs. In the meantime, contact us to discuss adding content to the Pathways catalog.",
+        "contactUs": "Contact Us"
+      },
+      "learners": {
+        "title": "Learners",
+        "subtitle": "Every learner across every cohort you manage.",
+        "searchPlaceholder": "Search by name or email…",
+        "filterCohortAll": "All cohorts",
+        "filterStatusAll": "All statuses",
+        "statusActive": "Active",
+        "statusCompleted": "Completed",
+        "resultCount": "{{count}} learners shown",
+        "emptyAll": "No learners enrolled in any of your cohorts yet.",
+        "emptyFiltered": "No learners match the current filters.",
+        "col": {
+          "name": "Learner",
+          "cohorts": "Cohort(s)",
+          "band": "Band",
+          "completion": "Completion",
+          "lastActive": "Last Active",
+          "status": "Status"
+        }
+      },
+      "learnerDetail": {
+        "notFound": "Learner not found in your cohorts.",
+        "backToLearners": "Back to All Learners",
+        "band": "Band",
+        "modulesCompleted": "Modules Completed",
+        "inProgress": "In Progress",
+        "avgScore": "Average Score",
+        "cohorts": "Cohort Enrollments",
+        "enrolledOn": "Enrolled {{date}}",
+        "milestones": "Module Progress",
+        "noMilestones": "No module activity yet."
+      },
+      "reports": {
+        "title": "Reports",
+        "subtitle": "Funder-ready summaries. Pick a template and export.",
+        "windowDays": "Last {{days}} days",
+        "inactiveList": "Learners with no activity in this window:",
+        "cohortReportHint": "Per-cohort completion reports are surfaced from each cohort's detail page. Open a cohort → Overview to see its full report. (Cross-cohort outcome rollups live in the Outcomes report.)",
+        "types": {
+          "weekly": {
+            "label": "Weekly Activity",
+            "description": "What happened across all cohorts in the past 7 days."
+          },
+          "outcomes": {
+            "label": "Outcomes",
+            "description": "Aggregated outcomes for funder reporting."
+          },
+          "engagement": {
+            "label": "Engagement",
+            "description": "Login and activity patterns over the last 30 days."
+          },
+          "cohort": {
+            "label": "Cohort Completion",
+            "description": "End-of-program summary for a specific cohort."
+          }
+        },
+        "summary": {
+          "totalLearners": "Total Learners",
+          "modulesCompleted": "Modules Completed",
+          "capstones": "Capstones Produced",
+          "avgScore": "Avg Score"
+        },
+        "outcomes": {
+          "totalCohorts": "Total Cohorts",
+          "activeCohorts": "Active Cohorts",
+          "endedCohorts": "Ended Cohorts",
+          "totalEnrolled": "Total Enrolled",
+          "modulesCompleted": "Modules Completed",
+          "capstones": "Capstones Produced",
+          "cisco": "Cisco NetAcad Started",
+          "avgScore": "Average Score"
+        },
+        "engagement": {
+          "totalLearners": "Total Learners",
+          "active7": "Active in Last 7 Days",
+          "active30": "Active in Last 30 Days",
+          "dailyActivity": "Daily Activity (Last 30 Days)"
+        }
+      },
+      "settings": {
+        "title": "Settings",
+        "subtitle": "Defaults and preferences for how you run cohorts.",
+        "cohortDefaultsTitle": "Cohort Defaults",
+        "cohortDefaultsHint": "Used to prefill the Create Cohort form. You can always override per-cohort.",
+        "defaultBand": "Default Age Band",
+        "defaultMaxEnrollment": "Default Max Enrollment",
+        "notificationsTitle": "Notifications",
+        "notificationsHint": "Choose which events surface in the dashboard. Email/SMS notifications coming later.",
+        "notifyNewEnrollment": "New enrollment",
+        "notifyNewEnrollmentHint": "Highlight when a learner joins one of your cohorts.",
+        "notifyInactive": "Inactive learner",
+        "notifyInactiveHint": "Flag learners who haven't logged in for 5+ days.",
+        "notifyStatusChange": "Cohort status change",
+        "notifyStatusChangeHint": "Notify on draft → active → paused → ended transitions.",
+        "savePreferences": "Save Preferences",
+        "saved": "Saved."
+      }
     },
     "modules": {
       "foundations": {

--- a/src/locales/es/pathways.json
+++ b/src/locales/es/pathways.json
@@ -20,7 +20,8 @@
       "startQuiz": "Comenzar Quiz",
       "nextQuestion": "Siguiente Pregunta",
       "logInOrJoin": "Inicia Sesión o Únete",
-      "requestPilot": "Solicitar un Piloto"
+      "requestPilot": "Solicitar un Piloto",
+      "copy": "Copiar"
     },
     "layout": {
       "eyebrow": "Bright Boost",
@@ -206,9 +207,276 @@
       },
       "band": {
         "explorer": "Explorador (14–15)",
-        "launch": "Lanzamiento (16–17)"
+        "launch": "Lanzamiento (16–17)",
+        "mixed": "Niveles mixtos"
       },
-      "resourcesTitle": "Resumen del programa, guía de sesiones, imprimibles"
+      "resourcesTitle": "Resumen del programa, guía de sesiones, imprimibles",
+      "adminTitle": "Administración del Facilitador",
+      "roleBadge": "Facilitador",
+      "activeCohort": "Activo",
+      "selectCohort": "Selecciona un grupo",
+      "empty": {
+        "title": "Aún no hay grupos",
+        "subtitle": "Empieza creando tu primer grupo. Generarás un código de acceso y podrás empezar a inscribir estudiantes de inmediato.",
+        "cta": "Crear Tu Primer Grupo"
+      },
+      "nav": {
+        "dashboard": "Panel",
+        "cohorts": "Grupos",
+        "tracks": "Rutas",
+        "learners": "Estudiantes",
+        "reports": "Reportes",
+        "resources": "Recursos",
+        "settings": "Ajustes"
+      },
+      "dashboard": {
+        "activeCohortsTitle": "Grupos Activos",
+        "viewAllCohorts": "Ver todos los grupos →",
+        "thisWeekTitle": "Esta Semana en un Vistazo",
+        "quickActionsTitle": "Acciones Rápidas",
+        "recentActivityTitle": "Actividad Reciente",
+        "viewFullReport": "Ver reporte completo",
+        "joinCode": "Código",
+        "enrolled": "Inscritos",
+        "daysRemaining": "Días Restantes",
+        "openCohort": "Abrir Grupo",
+        "viewRoster": "Ver Lista",
+        "modulesCompleted": "Módulos Completados",
+        "newEnrollments": "Nuevas Inscripciones",
+        "needsFollowUp": "Requiere Seguimiento",
+        "capstonesInProgress": "Proyectos Finales en Progreso",
+        "actionCreateCohort": "Crear Nuevo Grupo",
+        "actionCreateCohortSub": "Configura un nuevo programa con código de acceso nuevo",
+        "actionAddLearner": "Añadir Estudiante",
+        "actionAddLearnerSub": "Inscribe a un estudiante en un grupo existente",
+        "actionWeeklyReport": "Exportar Reporte Semanal",
+        "actionWeeklyReportSub": "Descarga un CSV resumen para socios",
+        "completedModule": "completó",
+        "startedModule": "empezó",
+        "aLearner": "Un estudiante"
+      },
+      "cohorts": {
+        "title": "Grupos",
+        "subtitle": "Cada grupo que diriges, a través de sitios y temporadas.",
+        "newCohort": "Nuevo Grupo",
+        "searchPlaceholder": "Buscar por nombre o sitio…",
+        "filterStatus": "Filtrar por estado",
+        "filterStatusAll": "Todos los estados",
+        "filterBand": "Filtrar por nivel",
+        "filterBandAll": "Todos los niveles",
+        "resultCount": "{{count}} mostrados",
+        "emptyAll": "Aún no has creado ningún grupo.",
+        "emptyFiltered": "Ningún grupo coincide con los filtros actuales.",
+        "col": {
+          "name": "Nombre",
+          "site": "Aliado",
+          "band": "Nivel",
+          "status": "Estado",
+          "enrolled": "Inscritos",
+          "dates": "Fechas"
+        }
+      },
+      "create": {
+        "backToCohorts": "Volver a Grupos",
+        "title": "Crear un Nuevo Grupo",
+        "subtitle": "Configura lo básico. Puedes ajustar todo lo demás desde la página del grupo después.",
+        "fieldName": "Nombre del Grupo",
+        "namePlaceholder": "ej., \"ETO Otoño 2026 — Cyber Cohort\"",
+        "fieldSite": "Organización Aliada",
+        "sitePlaceholder": "ej., \"Escape The Odds — South Side\"",
+        "fieldBand": "Rango de Edad",
+        "fieldStartDate": "Fecha de Inicio",
+        "fieldEndDate": "Fecha de Fin",
+        "fieldTracks": "Rutas Activas",
+        "fieldMaxEnrollment": "Inscripción Máxima",
+        "fieldDescription": "Descripción del Grupo (opcional)",
+        "descriptionPlaceholder": "Contexto para las notas del facilitador…",
+        "cancel": "Cancelar",
+        "createCohort": "Crear Grupo",
+        "errorNameRequired": "El nombre del grupo es requerido.",
+        "errorTrackRequired": "Selecciona al menos una ruta."
+      },
+      "detail": {
+        "notFound": "Grupo no encontrado.",
+        "tabs": {
+          "overview": "Resumen",
+          "roster": "Lista",
+          "modules": "Módulos",
+          "calendar": "Calendario",
+          "notes": "Notas",
+          "settings": "Ajustes"
+        },
+        "overview": {
+          "enrolled": "Inscritos",
+          "completion": "Completado",
+          "startDate": "Inicio",
+          "endDate": "Fin",
+          "joinCodeTitle": "Código de Acceso",
+          "joinCodeHint": "Los estudiantes usan este código para inscribirse. Trátalo como una contraseña temporal — regéneralo si se comparte demasiado.",
+          "copied": "¡Copiado!",
+          "activeTracksTitle": "Rutas Activas",
+          "descriptionTitle": "Acerca de este Grupo"
+        },
+        "roster": {
+          "addEmailPlaceholder": "estudiante@correo.com",
+          "addLearner": "Añadir Estudiante",
+          "empty": "Aún no hay estudiantes inscritos. Comparte el código o añade por correo arriba.",
+          "removeLearner": "Eliminar estudiante",
+          "confirmRemove": "¿Eliminar a {{name}} de este grupo? Su progreso permanecerá en la base de datos pero ya no aparecerá en esta lista.",
+          "col": {
+            "name": "Estudiante",
+            "completed": "Módulos",
+            "lastActive": "Última Actividad"
+          }
+        },
+        "modules": {
+          "col": {
+            "module": "Módulo",
+            "completed": "Completados",
+            "inProgress": "En Progreso",
+            "avgScore": "Puntaje Promedio"
+          }
+        },
+        "calendar": {
+          "title": "Horario de Sesiones",
+          "hint": "Generado a partir de la fecha de inicio asumiendo sesiones semanales. Sobrescritura por sesión en una versión futura.",
+          "empty": "Establece fecha de inicio y fin del grupo para ver un calendario de sesiones generado.",
+          "week": "Semana"
+        },
+        "notes": {
+          "addNew": "Añadir una nota",
+          "placeholder": "¿Qué observaste en la sesión de hoy? ¿Planes para la próxima semana?",
+          "save": "Guardar nota",
+          "empty": "Aún no hay notas. Usa este espacio para rastrear patrones, planes y observaciones entre sesiones."
+        },
+        "settings": {
+          "lifecycleTitle": "Ciclo de Vida del Grupo",
+          "lifecycleHint": "Mueve el grupo entre borrador → activo → pausado → terminado → archivado.",
+          "start": "Iniciar Grupo",
+          "pause": "Pausar",
+          "end": "Terminar Programa",
+          "archive": "Archivar",
+          "confirmArchive": "¿Archivar este grupo? Se ocultará de las vistas predeterminadas pero los datos se conservan.",
+          "joinCodeTitle": "Gestión del Código de Acceso",
+          "joinCodeHint": "Si el código actual se ha compartido demasiado o está comprometido, regenéralo. Los estudiantes ya inscritos no se ven afectados.",
+          "regenerateCode": "Regenerar Código",
+          "confirmRegen": "¿Generar un nuevo código? El código actual dejará de funcionar inmediatamente.",
+          "dataTitle": "Datos del Grupo",
+          "dataInfo": "ID: {{id}} • Creado: {{created}}"
+        }
+      },
+      "tracks": {
+        "title": "Rutas",
+        "subtitle": "Catálogo de rutas de aprendizaje disponibles. Las rutas activas pueden asignarse a grupos.",
+        "requestCustom": "Solicitar una Ruta Personalizada",
+        "modules": "módulos",
+        "cohorts": "Grupos",
+        "learners": "Estudiantes",
+        "completions": "Completados",
+        "usedBy": "Usado por:",
+        "preview": "Vista Previa como Estudiante",
+        "customTitle": "Constructor de Rutas Personalizadas",
+        "customRoadmap": "Próximamente Q3 2026",
+        "customBody": "Pronto podrás construir rutas personalizadas adaptadas a las necesidades de tu sitio. Mientras tanto, contáctanos para discutir agregar contenido al catálogo de Pathways.",
+        "contactUs": "Contáctanos"
+      },
+      "learners": {
+        "title": "Estudiantes",
+        "subtitle": "Cada estudiante a través de cada grupo que administras.",
+        "searchPlaceholder": "Buscar por nombre o correo…",
+        "filterCohortAll": "Todos los grupos",
+        "filterStatusAll": "Todos los estados",
+        "statusActive": "Activo",
+        "statusCompleted": "Completado",
+        "resultCount": "{{count}} estudiantes mostrados",
+        "emptyAll": "Aún no hay estudiantes inscritos en ninguno de tus grupos.",
+        "emptyFiltered": "Ningún estudiante coincide con los filtros actuales.",
+        "col": {
+          "name": "Estudiante",
+          "cohorts": "Grupo(s)",
+          "band": "Nivel",
+          "completion": "Completado",
+          "lastActive": "Última Actividad",
+          "status": "Estado"
+        }
+      },
+      "learnerDetail": {
+        "notFound": "Estudiante no encontrado en tus grupos.",
+        "backToLearners": "Volver a Todos los Estudiantes",
+        "band": "Nivel",
+        "modulesCompleted": "Módulos Completados",
+        "inProgress": "En Progreso",
+        "avgScore": "Puntaje Promedio",
+        "cohorts": "Inscripciones en Grupos",
+        "enrolledOn": "Inscrito {{date}}",
+        "milestones": "Progreso de Módulos",
+        "noMilestones": "Aún no hay actividad en módulos."
+      },
+      "reports": {
+        "title": "Reportes",
+        "subtitle": "Resúmenes listos para financiadores. Elige una plantilla y exporta.",
+        "windowDays": "Últimos {{days}} días",
+        "inactiveList": "Estudiantes sin actividad en esta ventana:",
+        "cohortReportHint": "Los reportes de finalización por grupo aparecen desde la página de detalle de cada grupo. Abre un grupo → Resumen para ver su reporte completo.",
+        "types": {
+          "weekly": {
+            "label": "Actividad Semanal",
+            "description": "Qué ocurrió en todos los grupos en los últimos 7 días."
+          },
+          "outcomes": {
+            "label": "Resultados",
+            "description": "Resultados agregados para reportes a financiadores."
+          },
+          "engagement": {
+            "label": "Participación",
+            "description": "Patrones de acceso y actividad en los últimos 30 días."
+          },
+          "cohort": {
+            "label": "Finalización de Grupo",
+            "description": "Resumen de fin de programa para un grupo específico."
+          }
+        },
+        "summary": {
+          "totalLearners": "Total Estudiantes",
+          "modulesCompleted": "Módulos Completados",
+          "capstones": "Proyectos Producidos",
+          "avgScore": "Puntaje Promedio"
+        },
+        "outcomes": {
+          "totalCohorts": "Total Grupos",
+          "activeCohorts": "Grupos Activos",
+          "endedCohorts": "Grupos Terminados",
+          "totalEnrolled": "Total Inscritos",
+          "modulesCompleted": "Módulos Completados",
+          "capstones": "Proyectos Producidos",
+          "cisco": "Cisco NetAcad Iniciado",
+          "avgScore": "Puntaje Promedio"
+        },
+        "engagement": {
+          "totalLearners": "Total Estudiantes",
+          "active7": "Activos en los Últimos 7 Días",
+          "active30": "Activos en los Últimos 30 Días",
+          "dailyActivity": "Actividad Diaria (Últimos 30 Días)"
+        }
+      },
+      "settings": {
+        "title": "Ajustes",
+        "subtitle": "Valores predeterminados y preferencias para cómo manejas los grupos.",
+        "cohortDefaultsTitle": "Predeterminados del Grupo",
+        "cohortDefaultsHint": "Usado para prellenar el formulario de Crear Grupo. Siempre puedes sobrescribir por grupo.",
+        "defaultBand": "Nivel Predeterminado",
+        "defaultMaxEnrollment": "Inscripción Máxima Predeterminada",
+        "notificationsTitle": "Notificaciones",
+        "notificationsHint": "Elige qué eventos aparecen en el panel. Notificaciones por correo/SMS más adelante.",
+        "notifyNewEnrollment": "Nueva inscripción",
+        "notifyNewEnrollmentHint": "Resalta cuando un estudiante se une a uno de tus grupos.",
+        "notifyInactive": "Estudiante inactivo",
+        "notifyInactiveHint": "Marca estudiantes que no han accedido en 5+ días.",
+        "notifyStatusChange": "Cambio de estado del grupo",
+        "notifyStatusChangeHint": "Notifica en transiciones borrador → activo → pausado → terminado.",
+        "savePreferences": "Guardar Preferencias",
+        "saved": "Guardado."
+      }
     },
     "modules": {
       "foundations": {


### PR DESCRIPTION
## Summary

Rebuilds the facilitator side of Pathways as a real admin tool. The previous single-page \`/pathways/facilitator\` was effectively a student-style roster view; this PR turns it into a sidebar-led operational interface so Aaron's site coordinators can actually run a program with it.

**Stacked on top of #579** (dark mode wrapper fix). Merge #579 first, or merge them together.

## What's new

### Information architecture
Sidebar nav with 7 sections:

| Route | Purpose |
|---|---|
| /pathways/facilitator | Operational landing — active cohorts, this-week stats, quick actions, recent activity |
| /pathways/facilitator/cohorts | Cohort list with status/band/site filters + search |
| /pathways/facilitator/cohorts/new | Create cohort form (name, site, band, dates, tracks, max enrollment, description) |
| /pathways/facilitator/cohorts/:id | Cohort detail with 6 tabs: Overview / Roster / Modules / Calendar / Notes / Settings |
| /pathways/facilitator/tracks | Track catalog with per-track usage stats + "Request a Custom Track" stub (Q3 2026 roadmap) |
| /pathways/facilitator/learners | Cross-cohort master roster with search, cohort filter, band filter, status filter |
| /pathways/facilitator/learners/:userId | Per-learner detail with enrollments and milestones |
| /pathways/facilitator/reports | 4 report templates (Weekly / Outcomes / Engagement / Cohort Completion) + CSV export |
| /pathways/facilitator/resources | (existing) Resources playbook from PR #576 |
| /pathways/facilitator/settings | Cohort defaults + notification prefs (localStorage for now) |

### Schema changes (additive, backwards-compatible)

\`PathwayCohort\` model gains:
- \`status\` — draft / active / paused / ended / archived (default: draft)
- \`description\`, \`maxEnrollment\`, \`notes\` (Json), \`updatedAt\`
- New \`@@index([status])\`

Synced to both \`prisma/schema.prisma\` and \`backend/prisma/schema.prisma\`. Existing rows are backfilled by Prisma's default-value behavior (status = "draft" for any null rows; seed updates the existing ETO cohort to "active").

### New API endpoints (16, all teacher-gated)

Lifecycle, roster, notes, exports — see commit body for the full list. The existing \`POST /pathways/cohorts\` was extended to accept description, maxEnrollment, and the new "mixed" band value.

### Seed updates — gives Coach Davis a populated demo

- **ETO Spring 2026 — Cyber Cohort** (active) — Marcus + Aisha, 3 pre-populated facilitator notes, real dates
- **ETO Fall 2025 — Pilot Cohort** (ended) — 3 fictional graduates (Jasmine, DeShawn, Reina) with completed milestones across all 7 modules, scores in the 76-100 range. **This makes the Outcomes report render meaningful numbers.**
- **ETO Summer 2026 — Planning** (draft) — empty, demonstrates create-cohort workflow

### Visual distinction from student side

- Sidebar nav (student uses bottom nav)
- Data-dense tables over tile/card layouts
- Neutral slate + indigo palette (no track-color full fills)
- "Facilitator" role badge in header
- Active cohort selector in header (persists per facilitator via localStorage)

### i18n
~200 new keys per locale, fully translated EN + ES. VI/ZH-CN fall back via the existing \`fallbackLng: "en"\`. No raw keys ever appear.

### Dark mode
All new components use the \`dark:\` wrapper pattern from #579. No new dark-mode bugs.

## Stubbed (with clear roadmap)

- **Custom Track Builder** — clicking "Request a Custom Track" opens a modal with a "Coming Q3 2026" badge and a contact-us mailto. Signals roadmap without overpromising.
- **Calendar tab** — generates a 6-week schedule from cohort start date. Per-session edits/assignments are a follow-up.
- **Settings** — persists to localStorage. A \`FacilitatorPrefs\` model is the follow-up.
- **Legacy file** — \`FacilitatorDashboard.tsx\` is no longer routed but kept in the codebase for safety. Safe to delete in a cleanup PR.

## Verification

- [x] \`tsc --noEmit\`: 0 new errors. The 6 pre-existing \`ControlInstructions\` errors from PR #567 are unchanged.
- [x] \`eslint src/components/pathways/facilitator/ src/App.tsx\`: clean.
- [x] All new JSON locale files validate as parseable JSON.
- [x] Backend \`tsc --noEmit\`: clean.

## Test plan (as facilitator@test.com / pathway123)

- [ ] Land on /pathways/facilitator — see 1 active cohort card + this-week stats + recent activity
- [ ] Header shows "Coach Davis · Facilitator · ETO Spring 2026 — Cyber Cohort ▾"
- [ ] Click cohort selector — see 3 cohorts (active / ended / draft) with status pills
- [ ] Navigate to Cohorts — see all 3 with filters
- [ ] Click ETO Spring 2026 — tabbed detail page, all 6 tabs functional
- [ ] Overview tab — see join code with copy button, 2 stat tiles, active track list, description
- [ ] Roster tab — see Marcus + Aisha, can attempt add-learner-by-email, CSV export downloads
- [ ] Modules tab — per-module completion stats
- [ ] Calendar tab — 6-week schedule rendered from start date
- [ ] Notes tab — 3 pre-populated notes visible, can add new
- [ ] Settings tab — lifecycle buttons (Pause/End), regenerate code with confirm
- [ ] Click Create New Cohort — form works, creates draft, lands on detail
- [ ] Tracks — 5 tracks; Cyber Launch shows usage stats; "Request Custom Track" modal opens
- [ ] Learners — 5 (Marcus, Aisha, + 3 graduates); search + filter work
- [ ] Reports — Weekly/Outcomes/Engagement render with seeded data, CSV export works
- [ ] Settings — toggle prefs, Save shows "Saved." confirmation
- [ ] Toggle to light mode — all pages readable, contrast good
- [ ] Toggle to ES — all UI chrome in Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code)