### PR TITLE
fix: facilitator dashboard — JWT key, layout, missing migration

### DIFF
--- a/backend/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
+++ b/backend/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
@@ -1,0 +1,12 @@
+-- PathwayCohort lifecycle fields introduced in PR #580. The schema files were
+-- updated but no migration was generated, leaving production missing the
+-- columns the new facilitator queries select on. Idempotent so it is safe to
+-- re-run on any environment where some columns may already exist.
+
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "description" TEXT;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "maxEnrollment" INTEGER DEFAULT 25;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "notes" JSONB;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS "PathwayCohort_status_idx" ON "PathwayCohort"("status");

--- a/backend/src/routes/slack-test.ts
+++ b/backend/src/routes/slack-test.ts
@@ -1,0 +1,93 @@
+/**
+ * TEMPORARY VERIFICATION ENDPOINT — remove after Slack confirmed working.
+ *
+ * Two endpoints:
+ *   POST /api/slack-test/ping     — short ping to #deployments
+ *   POST /api/slack-test/welcome  — full welcome message to #general
+ *
+ * Both are intentionally unauthenticated for ease of curl-from-anywhere
+ * verification. This file must be deleted (and its import removed from
+ * server.ts) once the webhook is confirmed working.
+ *
+ * Note on Slack's `channel` field: modern incoming-webhook URLs are tied
+ * to a single channel at creation time, and the JSON `channel` field is
+ * ignored by Slack — so both endpoints below land in whichever channel
+ * the webhook was provisioned for, regardless of the target we pass.
+ * Verify in that channel first; if you need messages in a different
+ * channel, create a second webhook for it.
+ */
+import { Router } from "express";
+import { notifySlack } from "../utils/slack";
+
+const router = Router();
+
+router.post("/api/slack-test/ping", async (_req, res) => {
+  try {
+    await notifySlack(
+      "#deployments",
+      "✅ Slack webhook verification ping from Bright Boost backend",
+    );
+    res.json({ status: "sent", target: "#deployments" });
+  } catch (err) {
+    res.status(500).json({ status: "failed", error: String(err) });
+  }
+});
+
+router.post("/api/slack-test/welcome", async (_req, res) => {
+  const welcomeMessage = `🎉 *Welcome to Bright Bots, Summer 2026 cohort!*
+
+Today's the day. Really excited to have all six of you on board.
+
+Quick orientation for Week 1:
+
+*Today (Monday)*
+• 9:00 AM CT — All-hands kickoff Zoom (check your calendar)
+• Morning: intros, program overview, pod assignments
+• Afternoon: pod breakouts, dev environment setup, first commits
+
+*Your pods*
+
+🛠️ *Build Pod* (lead: Alice)
+• Alice Lin — Technical Frontend/Backend
+• Jack Goetzmann — Gamification & Game Experience
+• Olivia Jiang — Interactive Game Developer
+
+🎨 *Experience Pod* (lead: Catarina)
+• Catarina Lucas Herrera — UI/UX & Gamification
+• Viet Tran — UI/UX Design
+• Ronak Sharma — UX/UI & Website Experience
+
+*Key channels*
+• \`#general\` — team-wide announcements (here)
+• \`#build-pod\` / \`#experience-pod\` — your pod home base
+• \`#standup\` — daily async check-ins
+• \`#help\` — stuck? ask here before spinning your wheels
+• \`#wins\` — celebrate shipped features and test results
+• \`#prompt-log\` — share Claude Code prompts and learnings
+• \`#deployments\` / \`#experiments\` — automated feeds
+
+*Program norms*
+• Ask early, ask often. Help is faster than struggle.
+• Log significant Claude Code prompts in the \`prompts/\` directory.
+• PRs over direct pushes — \`CONTRIBUTING.md\` has the workflow.
+• Every change ships with data. A/B tests aren't optional.
+
+This week:
+• Mon: kickoff + dev environment
+• Tue–Wed: app audit + first PRs
+• Thu: Claude Code training
+• Fri: weekly review + pre-work audits presented
+
+Drop a 👋 in this channel when you're online today. Let's build something real this summer.
+
+— Nathaniel`;
+
+  try {
+    await notifySlack("#general", welcomeMessage);
+    res.json({ status: "sent", target: "#general" });
+  } catch (err) {
+    res.status(500).json({ status: "failed", error: String(err) });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -28,6 +28,8 @@ import feedbackRouter from "./routes/feedback";
 import benchmarkRouter from "./routes/benchmarks";
 import homeAccessRouter from "./routes/homeAccess";
 import experimentsRouter from "./routes/experiments";
+// TEMPORARY — remove after Slack webhook verification is confirmed working.
+import slackTestRouter from "./routes/slack-test";
 import { devRoleShim, authenticateToken } from "./utils/auth";
 import { preventHpp, nocache } from "./utils/security";
 import { notifySlack } from "./utils/slack";
@@ -176,6 +178,8 @@ app.use(express.json({ limit: "50kb" }));
 // Public routes (Auth + Class Login) - Mount before auth middleware to ensure access
 app.use("/api", authRouter);
 app.use("/api", classLoginRouter);
+// TEMPORARY — Slack webhook verification. Remove after confirming.
+app.use(slackTestRouter);
 
 // Public route for Task Ranker integration
 app.use("/context", contextRouter);

--- a/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
+++ b/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
@@ -1,0 +1,12 @@
+-- PathwayCohort lifecycle fields introduced in PR #580. The schema files were
+-- updated but no migration was generated, leaving production missing the
+-- columns the new facilitator queries select on. Idempotent so it is safe to
+-- re-run on any environment where some columns may already exist.
+
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "description" TEXT;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "maxEnrollment" INTEGER DEFAULT 25;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "notes" JSONB;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS "PathwayCohort_status_idx" ON "PathwayCohort"("status");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,25 +181,31 @@ function App() {
               {/* Pathways: public landing page */}
               <Route path="/pathways/about" element={<PathwaysAbout />} />
 
-              {/* Pathways: authenticated routes */}
+              {/* Pathways: student authenticated routes */}
               <Route path="/pathways" element={<ProtectedRoute><PathwaysLayout /></ProtectedRoute>}>
                 <Route index element={<PathwaysHome />} />
                 <Route path="tracks" element={<TracksOverview />} />
                 <Route path="tracks/:trackSlug" element={<TrackDetail />} />
                 <Route path="tracks/:trackSlug/:moduleSlug" element={<ModulePlayer />} />
                 <Route path="profile" element={<PathwaysProfile />} />
-                <Route path="facilitator" element={<FacilitatorLayout />}>
-                  <Route index element={<FacilitatorDashboardPage />} />
-                  <Route path="cohorts" element={<CohortsListPage />} />
-                  <Route path="cohorts/new" element={<CohortNewPage />} />
-                  <Route path="cohorts/:id" element={<CohortDetailPage />} />
-                  <Route path="tracks" element={<FacilitatorTracksPage />} />
-                  <Route path="learners" element={<FacilitatorLearnersPage />} />
-                  <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
-                  <Route path="reports" element={<FacilitatorReportsPage />} />
-                  <Route path="resources" element={<ProgramOverviewPage />} />
-                  <Route path="settings" element={<FacilitatorSettingsPage />} />
-                </Route>
+              </Route>
+
+              {/* Pathways: facilitator routes — sibling of /pathways, owns its own
+                  layout shell so the student sidebar doesn't render on top. */}
+              <Route
+                path="/pathways/facilitator"
+                element={<ProtectedRoute requiredRole="teacher"><FacilitatorLayout /></ProtectedRoute>}
+              >
+                <Route index element={<FacilitatorDashboardPage />} />
+                <Route path="cohorts" element={<CohortsListPage />} />
+                <Route path="cohorts/new" element={<CohortNewPage />} />
+                <Route path="cohorts/:id" element={<CohortDetailPage />} />
+                <Route path="tracks" element={<FacilitatorTracksPage />} />
+                <Route path="learners" element={<FacilitatorLearnersPage />} />
+                <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
+                <Route path="reports" element={<FacilitatorReportsPage />} />
+                <Route path="resources" element={<ProgramOverviewPage />} />
+                <Route path="settings" element={<FacilitatorSettingsPage />} />
               </Route>
 
               {/* Legacy Redirects for Flat Routes (if any external links exist) */}

--- a/src/components/pathways/FacilitatorDashboard.tsx
+++ b/src/components/pathways/FacilitatorDashboard.tsx
@@ -95,7 +95,7 @@ export default function FacilitatorDashboard() {
     });
   };
 
-  const headers = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   useEffect(() => {
     fetch("/api/pathways/cohorts", { headers })

--- a/src/components/pathways/ModulePlayer.tsx
+++ b/src/components/pathways/ModulePlayer.tsx
@@ -24,7 +24,7 @@ export default function ModulePlayer() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
+          Authorization: `Bearer ${localStorage.getItem("bb_access_token")}`,
         },
         body: JSON.stringify({ trackSlug, moduleSlug, status: "in_progress" }),
       }).catch(() => {});
@@ -38,7 +38,7 @@ export default function ModulePlayer() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
+            Authorization: `Bearer ${localStorage.getItem("bb_access_token")}`,
           },
           body: JSON.stringify({ trackSlug, moduleSlug, status: "completed", score }),
         });

--- a/src/components/pathways/PathwaysHome.tsx
+++ b/src/components/pathways/PathwaysHome.tsx
@@ -16,7 +16,7 @@ export default function PathwaysHome() {
 
   useEffect(() => {
     fetch("/api/pathways/student/home", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then(setHomeData)

--- a/src/components/pathways/PathwaysProfile.tsx
+++ b/src/components/pathways/PathwaysProfile.tsx
@@ -13,7 +13,7 @@ export default function PathwaysProfile() {
 
   useEffect(() => {
     fetch("/api/pathways/student/milestones", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => setMilestones(Array.isArray(data) ? data : []))

--- a/src/components/pathways/TrackDetail.tsx
+++ b/src/components/pathways/TrackDetail.tsx
@@ -35,7 +35,7 @@ export default function TrackDetail() {
 
   useEffect(() => {
     fetch("/api/pathways/student/milestones", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) =>
@@ -135,7 +135,7 @@ export default function TrackDetail() {
                     method: "POST",
                     headers: {
                       "Content-Type": "application/json",
-                      Authorization: `Bearer ${localStorage.getItem("token")}`,
+                      Authorization: `Bearer ${localStorage.getItem("bb_access_token")}`,
                     },
                     body: JSON.stringify({
                       trackSlug: track.slug,

--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -49,7 +49,7 @@ export default function FacilitatorLayout() {
 
   useEffect(() => {
     fetch("/api/pathways/cohorts", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => {
@@ -158,7 +158,7 @@ export default function FacilitatorLayout() {
         <div className="flex-1 min-w-0">
           <Outlet context={{ activeCohortId, cohorts, refreshCohorts: () => {
             fetch("/api/pathways/cohorts", {
-              headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+              headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
             })
               .then((r) => r.json())
               .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))

--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -1,5 +1,5 @@
 /**
- * FacilitatorLayout — operational admin shell inside PathwaysLayout.
+ * FacilitatorLayout — operational admin shell, standalone.
  *
  * Visual identity is intentionally distinct from the student experience:
  *  - left sidebar nav (vs student bottom nav / colorful cards)
@@ -7,13 +7,17 @@
  *  - data-dense, table-forward content rather than tile-forward
  *  - neutral palette accents (slate + indigo) instead of track-color fills
  *
- * Mounts as a nested route under /pathways/facilitator so PathwaysLayout
- * still supplies the .dark wrapper and the parent shell.
+ * Mounted at /pathways/facilitator as a SIBLING of /pathways, not a child,
+ * so the student PathwaysLayout sidebar doesn't render on top. Provides its
+ * own `.dark` wrapper, brand header, theme toggle, language toggle, and
+ * sign-out — reading the same `bb_pathways_theme` localStorage key as
+ * PathwaysLayout so a facilitator's preference is shared across both sides.
  */
 import { useEffect, useState } from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
+import LanguageToggle from "@/components/LanguageToggle";
 import {
   LayoutDashboard,
   Users,
@@ -24,9 +28,22 @@ import {
   Settings as SettingsIcon,
   Shield,
   ChevronDown,
+  LogOut,
+  Moon,
+  Sun,
 } from "lucide-react";
 
 const ACTIVE_COHORT_KEY = "bb_facilitator_active_cohort";
+const THEME_KEY = "bb_pathways_theme";
+
+function readStoredTheme(): "dark" | "light" {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
 
 interface CohortOption {
   id: string;
@@ -36,7 +53,10 @@ interface CohortOption {
 
 export default function FacilitatorLayout() {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
+  const isDark = theme === "dark";
   const [cohorts, setCohorts] = useState<CohortOption[]>([]);
   const [activeCohortId, setActiveCohortId] = useState<string | null>(() => {
     try {
@@ -46,6 +66,19 @@ export default function FacilitatorLayout() {
     }
   });
   const [cohortMenuOpen, setCohortMenuOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      /* localStorage unavailable — preference will not persist */
+    }
+  }, [theme]);
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
 
   useEffect(() => {
     fetch("/api/pathways/cohorts", {
@@ -78,7 +111,37 @@ export default function FacilitatorLayout() {
   const activeCohort = cohorts.find((c) => c.id === activeCohortId);
 
   return (
-    <div className="flex flex-col gap-6 -mt-2">
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors">
+        {/* Brand + global chrome (theme/language/logout) */}
+        <div className="flex items-center justify-between px-4 md:px-8 py-3 border-b bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-slate-500 font-medium">
+              {t("pathways.layout.eyebrow")}
+            </p>
+            <p className="text-lg font-bold bg-gradient-to-r from-indigo-600 to-cyan-600 dark:from-indigo-400 dark:to-cyan-400 bg-clip-text text-transparent">
+              {t("pathways.layout.brand")}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <LanguageToggle variant={isDark ? "dark" : "light"} />
+            <button
+              onClick={() => setTheme(isDark ? "light" : "dark")}
+              className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
+              aria-label={isDark ? t("pathways.common.lightMode") : t("pathways.common.darkMode")}
+            >
+              {isDark ? <Sun className="w-4 h-4 text-slate-300" /> : <Moon className="w-4 h-4 text-slate-700" />}
+            </button>
+            <button
+              onClick={handleLogout}
+              className="flex items-center gap-1.5 px-2 py-1 rounded text-xs text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <LogOut className="w-3 h-3" /> {t("pathways.common.signOut")}
+            </button>
+          </div>
+        </div>
+
+        <div className="p-4 md:p-8 max-w-7xl mx-auto flex flex-col gap-6">
       {/* Header bar with role + cohort selector */}
       <div className="flex flex-wrap items-center justify-between gap-3 px-1">
         <div className="flex items-center gap-3 text-sm">
@@ -164,6 +227,8 @@ export default function FacilitatorLayout() {
               .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))
               .catch(() => {});
           } }} />
+        </div>
+      </div>
         </div>
       </div>
     </div>

--- a/src/components/pathways/facilitator/pages/CohortDetail.tsx
+++ b/src/components/pathways/facilitator/pages/CohortDetail.tsx
@@ -83,7 +83,7 @@ export default function CohortDetail() {
   const [tab, setTab] = useState<TabKey>("overview");
   const [loading, setLoading] = useState(true);
 
-  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const auth = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   const loadCohort = useCallback(async () => {
     if (!id) return;
@@ -329,7 +329,7 @@ function RosterTab({
   const [addError, setAddError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const auth = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   const addLearner = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -366,7 +366,7 @@ function RosterTab({
 
   const exportCsv = () => {
     window.open(
-      `/api/pathways/facilitator/cohorts/${cohort.id}/export?token=${localStorage.getItem("token") ?? ""}`,
+      `/api/pathways/facilitator/cohorts/${cohort.id}/export?token=${localStorage.getItem("bb_access_token") ?? ""}`,
       "_blank",
     );
     // Note: query-string auth is a fallback for the download attribute. For full security,
@@ -611,7 +611,7 @@ function NotesTab({ cohort, onReload }: { cohort: Cohort; onReload: () => void }
   const [submitting, setSubmitting] = useState(false);
   const notes = cohort.notes ?? [];
 
-  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const auth = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   const add = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -687,7 +687,7 @@ function NotesTab({ cohort, onReload }: { cohort: Cohort; onReload: () => void }
 function SettingsTab({ cohort, onReload }: { cohort: Cohort; onReload: () => void }) {
   const { t } = useTranslation();
   const [busy, setBusy] = useState<string | null>(null);
-  const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const auth = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   const action = async (path: string, key: string, confirmMsg?: string) => {
     if (confirmMsg && !window.confirm(confirmMsg)) return;

--- a/src/components/pathways/facilitator/pages/CohortNew.tsx
+++ b/src/components/pathways/facilitator/pages/CohortNew.tsx
@@ -60,7 +60,7 @@ export default function CohortNew() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
+          Authorization: `Bearer ${localStorage.getItem("bb_access_token")}`,
         },
         body: JSON.stringify(body),
       });

--- a/src/components/pathways/facilitator/pages/CohortsList.tsx
+++ b/src/components/pathways/facilitator/pages/CohortsList.tsx
@@ -33,7 +33,7 @@ export default function CohortsList() {
 
   useEffect(() => {
     fetch("/api/pathways/cohorts", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => setCohorts(Array.isArray(data) ? data : []))

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -67,7 +67,7 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
-  const headers = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+  const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   useEffect(() => {
     Promise.all([
@@ -76,7 +76,14 @@ export default function Dashboard() {
     ])
       .then(([c, w]) => {
         setCohorts(Array.isArray(c) ? c : []);
-        setWeekly(w);
+        // Guard against error responses (e.g. 401/403/500) being passed in as `weekly`.
+        // The view code below dereferences `weekly.inactiveLearners` / `weekly.recentActivity`,
+        // so we only accept payloads that actually look like a WeeklyReport.
+        if (w && typeof w === "object" && Array.isArray(w.inactiveLearners) && Array.isArray(w.recentActivity)) {
+          setWeekly(w as WeeklyReport);
+        } else {
+          setWeekly(null);
+        }
       })
       .catch(() => {})
       .finally(() => setLoading(false));

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -65,28 +65,57 @@ export default function Dashboard() {
   const [cohorts, setCohorts] = useState<Cohort[]>([]);
   const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
   const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   useEffect(() => {
+    // Hard 10s ceiling per request so a hung backend or missing migration
+    // surfaces as an error UI instead of an indefinite "Loading…" state.
+    const ac = new AbortController();
+    const timeout = setTimeout(() => ac.abort(), 10000);
+
+    const safeFetch = async (url: string) => {
+      const r = await fetch(url, { headers, signal: ac.signal });
+      const body = await r.json().catch(() => null);
+      if (!r.ok) {
+        throw new Error(
+          (body && (body.error || body.message)) || `${r.status} ${r.statusText}`,
+        );
+      }
+      return body;
+    };
+
     Promise.all([
-      fetch("/api/pathways/cohorts", { headers }).then((r) => r.json()),
-      fetch("/api/pathways/facilitator/reports/weekly", { headers }).then((r) => r.json()),
+      safeFetch("/api/pathways/cohorts"),
+      safeFetch("/api/pathways/facilitator/reports/weekly"),
     ])
       .then(([c, w]) => {
         setCohorts(Array.isArray(c) ? c : []);
-        // Guard against error responses (e.g. 401/403/500) being passed in as `weekly`.
-        // The view code below dereferences `weekly.inactiveLearners` / `weekly.recentActivity`,
-        // so we only accept payloads that actually look like a WeeklyReport.
+        // Guard against error responses being passed in as `weekly`. The view
+        // dereferences `weekly.inactiveLearners` / `weekly.recentActivity`, so
+        // we only accept payloads that actually look like a WeeklyReport.
         if (w && typeof w === "object" && Array.isArray(w.inactiveLearners) && Array.isArray(w.recentActivity)) {
           setWeekly(w as WeeklyReport);
         } else {
           setWeekly(null);
         }
+        setLoadError(null);
       })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+      .catch((err) => {
+        const msg = err?.name === "AbortError" ? "timeout" : err?.message || "fetch failed";
+        setLoadError(msg);
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        setLoading(false);
+      });
+
+    return () => {
+      clearTimeout(timeout);
+      ac.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -114,8 +143,31 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-8">
+      {/* Load error — keep the rest of the page rendering so navigation still works. */}
+      {loadError && (
+        <Card className="border-amber-300 dark:border-amber-800/40">
+          <CardBody className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm">
+                Couldn't load cohort data
+              </p>
+              <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">
+                {loadError}
+              </p>
+            </div>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-xs px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              Retry
+            </button>
+          </CardBody>
+        </Card>
+      )}
+
       {/* Empty state */}
-      {cohorts.length === 0 && (
+      {!loadError && cohorts.length === 0 && (
         <Card className="text-center py-16">
           <CardBody>
             <Users className="w-12 h-12 text-slate-400 dark:text-slate-600 mx-auto mb-4" />

--- a/src/components/pathways/facilitator/pages/LearnerDetail.tsx
+++ b/src/components/pathways/facilitator/pages/LearnerDetail.tsx
@@ -29,7 +29,7 @@ export default function LearnerDetail() {
   useEffect(() => {
     if (!userId) return;
     fetch(`/api/pathways/facilitator/learners/${userId}`, {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then(setData)

--- a/src/components/pathways/facilitator/pages/Learners.tsx
+++ b/src/components/pathways/facilitator/pages/Learners.tsx
@@ -30,7 +30,7 @@ export default function Learners() {
 
   useEffect(() => {
     fetch("/api/pathways/facilitator/learners", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => setLearners(Array.isArray(data) ? data : []))

--- a/src/components/pathways/facilitator/pages/Reports.tsx
+++ b/src/components/pathways/facilitator/pages/Reports.tsx
@@ -55,7 +55,7 @@ export default function Reports() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const auth = { Authorization: `Bearer ${localStorage.getItem("token")}` };
+    const auth = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
     Promise.all([
       fetch("/api/pathways/facilitator/reports/weekly", { headers: auth }).then((r) => r.json()),
       fetch("/api/pathways/facilitator/reports/outcomes", { headers: auth }).then((r) => r.json()),

--- a/src/components/pathways/facilitator/pages/Tracks.tsx
+++ b/src/components/pathways/facilitator/pages/Tracks.tsx
@@ -31,7 +31,7 @@ export default function Tracks() {
 
   useEffect(() => {
     fetch("/api/pathways/facilitator/tracks", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => setUsage(data || {}))


### PR DESCRIPTION
## Summary

Three fixes for the `/pathways/facilitator` regression introduced by #580, plus the pre-existing Slack webhook verify commit that already lived on this branch.

- **JWT key mismatch** (`e0d600f`) — every Pathways/facilitator component read the token from `localStorage.getItem("token")`, but AuthContext stores it under `bb_access_token`. Every facilitator API call went out as `Bearer null`, the backend returned 403, and the new Dashboard then crashed on `weekly.inactiveLearners.length`. Fixed across 14 files / 21 occurrences. Also fixes silently-broken milestone tracking in the student-side `ModulePlayer`/`PathwaysHome`/`TrackDetail`/`PathwaysProfile`.
- **Duplicate sidebar + missing migration + hanging load** (`185addd`)
  - `/pathways/facilitator` was nested inside `/pathways`, so `PathwaysLayout` rendered its sidebar AND `FacilitatorLayout` rendered its sidebar. Moved to a sibling top-level route; made `FacilitatorLayout` self-contained (dark wrapper, brand bar, theme/language toggle, sign-out — all reading the same `bb_pathways_theme` key so preference persists across surfaces).
  - PR #580 added `status` / `description` / `maxEnrollment` / `notes` / `updatedAt` + `@@index([status])` to `PathwayCohort` in both schema files but never generated a migration — production queries throw on every facilitator endpoint. Added `20260514_add_pathway_cohort_lifecycle` in both prisma trees (idempotent: `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`). `backend/scripts/predeploy.sh` will pick it up automatically.
  - Hardened Dashboard against a slow/failing API: 10s AbortController ceiling, non-2xx parsing, error Card with Retry button instead of perpetual "Loading…".

Also includes `2f0c223` — temporary Slack webhook verification endpoint (the original purpose of this branch).

## Test plan

- [ ] Railway deploy completes (predeploy applies `20260514_add_pathway_cohort_lifecycle`)
- [ ] Log in as `facilitator@test.com` / `pathway123` → land on `/pathways/facilitator`
- [ ] ONE sidebar visible (facilitator nav: Dashboard / Cohorts / Tracks / Learners / Reports / Resources / Settings)
- [ ] Active cohort cards render (ETO Spring 2026 — Cyber Cohort)
- [ ] Drill into a cohort, then a learner (Marcus / Aisha)
- [ ] No console errors, no 500s in Network tab
- [ ] Dark/light toggle works; sign-out works
- [ ] Marcus/Aisha student login still routes to `/pathways` and renders
- [ ] K-8 login still works (teacher@school.com, student@test.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)