### PR TITLE
fix: facilitator dashboard layout, missing PathwayCohort migration, dashboard error handling

### DIFF
--- a/backend/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
+++ b/backend/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
@@ -1,0 +1,12 @@
+-- PathwayCohort lifecycle fields introduced in PR #580. The schema files were
+-- updated but no migration was generated, leaving production missing the
+-- columns the new facilitator queries select on. Idempotent so it is safe to
+-- re-run on any environment where some columns may already exist.
+
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "description" TEXT;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "maxEnrollment" INTEGER DEFAULT 25;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "notes" JSONB;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS "PathwayCohort_status_idx" ON "PathwayCohort"("status");

--- a/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
+++ b/prisma/migrations/20260514_add_pathway_cohort_lifecycle/migration.sql
@@ -1,0 +1,12 @@
+-- PathwayCohort lifecycle fields introduced in PR #580. The schema files were
+-- updated but no migration was generated, leaving production missing the
+-- columns the new facilitator queries select on. Idempotent so it is safe to
+-- re-run on any environment where some columns may already exist.
+
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'draft';
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "description" TEXT;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "maxEnrollment" INTEGER DEFAULT 25;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "notes" JSONB;
+ALTER TABLE "PathwayCohort" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS "PathwayCohort_status_idx" ON "PathwayCohort"("status");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,25 +181,31 @@ function App() {
               {/* Pathways: public landing page */}
               <Route path="/pathways/about" element={<PathwaysAbout />} />
 
-              {/* Pathways: authenticated routes */}
+              {/* Pathways: student authenticated routes */}
               <Route path="/pathways" element={<ProtectedRoute><PathwaysLayout /></ProtectedRoute>}>
                 <Route index element={<PathwaysHome />} />
                 <Route path="tracks" element={<TracksOverview />} />
                 <Route path="tracks/:trackSlug" element={<TrackDetail />} />
                 <Route path="tracks/:trackSlug/:moduleSlug" element={<ModulePlayer />} />
                 <Route path="profile" element={<PathwaysProfile />} />
-                <Route path="facilitator" element={<FacilitatorLayout />}>
-                  <Route index element={<FacilitatorDashboardPage />} />
-                  <Route path="cohorts" element={<CohortsListPage />} />
-                  <Route path="cohorts/new" element={<CohortNewPage />} />
-                  <Route path="cohorts/:id" element={<CohortDetailPage />} />
-                  <Route path="tracks" element={<FacilitatorTracksPage />} />
-                  <Route path="learners" element={<FacilitatorLearnersPage />} />
-                  <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
-                  <Route path="reports" element={<FacilitatorReportsPage />} />
-                  <Route path="resources" element={<ProgramOverviewPage />} />
-                  <Route path="settings" element={<FacilitatorSettingsPage />} />
-                </Route>
+              </Route>
+
+              {/* Pathways: facilitator routes — sibling of /pathways, owns its own
+                  layout shell so the student sidebar doesn't render on top. */}
+              <Route
+                path="/pathways/facilitator"
+                element={<ProtectedRoute requiredRole="teacher"><FacilitatorLayout /></ProtectedRoute>}
+              >
+                <Route index element={<FacilitatorDashboardPage />} />
+                <Route path="cohorts" element={<CohortsListPage />} />
+                <Route path="cohorts/new" element={<CohortNewPage />} />
+                <Route path="cohorts/:id" element={<CohortDetailPage />} />
+                <Route path="tracks" element={<FacilitatorTracksPage />} />
+                <Route path="learners" element={<FacilitatorLearnersPage />} />
+                <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
+                <Route path="reports" element={<FacilitatorReportsPage />} />
+                <Route path="resources" element={<ProgramOverviewPage />} />
+                <Route path="settings" element={<FacilitatorSettingsPage />} />
               </Route>
 
               {/* Legacy Redirects for Flat Routes (if any external links exist) */}

--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -1,5 +1,5 @@
 /**
- * FacilitatorLayout — operational admin shell inside PathwaysLayout.
+ * FacilitatorLayout — operational admin shell, standalone.
  *
  * Visual identity is intentionally distinct from the student experience:
  *  - left sidebar nav (vs student bottom nav / colorful cards)
@@ -7,13 +7,17 @@
  *  - data-dense, table-forward content rather than tile-forward
  *  - neutral palette accents (slate + indigo) instead of track-color fills
  *
- * Mounts as a nested route under /pathways/facilitator so PathwaysLayout
- * still supplies the .dark wrapper and the parent shell.
+ * Mounted at /pathways/facilitator as a SIBLING of /pathways, not a child,
+ * so the student PathwaysLayout sidebar doesn't render on top. Provides its
+ * own `.dark` wrapper, brand header, theme toggle, language toggle, and
+ * sign-out — reading the same `bb_pathways_theme` localStorage key as
+ * PathwaysLayout so a facilitator's preference is shared across both sides.
  */
 import { useEffect, useState } from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
+import LanguageToggle from "@/components/LanguageToggle";
 import {
   LayoutDashboard,
   Users,
@@ -24,9 +28,22 @@ import {
   Settings as SettingsIcon,
   Shield,
   ChevronDown,
+  LogOut,
+  Moon,
+  Sun,
 } from "lucide-react";
 
 const ACTIVE_COHORT_KEY = "bb_facilitator_active_cohort";
+const THEME_KEY = "bb_pathways_theme";
+
+function readStoredTheme(): "dark" | "light" {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
 
 interface CohortOption {
   id: string;
@@ -36,7 +53,10 @@ interface CohortOption {
 
 export default function FacilitatorLayout() {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
+  const isDark = theme === "dark";
   const [cohorts, setCohorts] = useState<CohortOption[]>([]);
   const [activeCohortId, setActiveCohortId] = useState<string | null>(() => {
     try {
@@ -46,6 +66,19 @@ export default function FacilitatorLayout() {
     }
   });
   const [cohortMenuOpen, setCohortMenuOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      /* localStorage unavailable — preference will not persist */
+    }
+  }, [theme]);
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
 
   useEffect(() => {
     fetch("/api/pathways/cohorts", {
@@ -78,7 +111,37 @@ export default function FacilitatorLayout() {
   const activeCohort = cohorts.find((c) => c.id === activeCohortId);
 
   return (
-    <div className="flex flex-col gap-6 -mt-2">
+    <div className={isDark ? "dark" : ""}>
+      <div className="min-h-screen bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100 transition-colors">
+        {/* Brand + global chrome (theme/language/logout) */}
+        <div className="flex items-center justify-between px-4 md:px-8 py-3 border-b bg-slate-50 border-slate-200 dark:bg-slate-900 dark:border-slate-800">
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-slate-500 font-medium">
+              {t("pathways.layout.eyebrow")}
+            </p>
+            <p className="text-lg font-bold bg-gradient-to-r from-indigo-600 to-cyan-600 dark:from-indigo-400 dark:to-cyan-400 bg-clip-text text-transparent">
+              {t("pathways.layout.brand")}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <LanguageToggle variant={isDark ? "dark" : "light"} />
+            <button
+              onClick={() => setTheme(isDark ? "light" : "dark")}
+              className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
+              aria-label={isDark ? t("pathways.common.lightMode") : t("pathways.common.darkMode")}
+            >
+              {isDark ? <Sun className="w-4 h-4 text-slate-300" /> : <Moon className="w-4 h-4 text-slate-700" />}
+            </button>
+            <button
+              onClick={handleLogout}
+              className="flex items-center gap-1.5 px-2 py-1 rounded text-xs text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <LogOut className="w-3 h-3" /> {t("pathways.common.signOut")}
+            </button>
+          </div>
+        </div>
+
+        <div className="p-4 md:p-8 max-w-7xl mx-auto flex flex-col gap-6">
       {/* Header bar with role + cohort selector */}
       <div className="flex flex-wrap items-center justify-between gap-3 px-1">
         <div className="flex items-center gap-3 text-sm">
@@ -164,6 +227,8 @@ export default function FacilitatorLayout() {
               .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))
               .catch(() => {});
           } }} />
+        </div>
+      </div>
         </div>
       </div>
     </div>

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -65,28 +65,57 @@ export default function Dashboard() {
   const [cohorts, setCohorts] = useState<Cohort[]>([]);
   const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
   const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
   useEffect(() => {
+    // Hard 10s ceiling per request so a hung backend or missing migration
+    // surfaces as an error UI instead of an indefinite "Loading…" state.
+    const ac = new AbortController();
+    const timeout = setTimeout(() => ac.abort(), 10000);
+
+    const safeFetch = async (url: string) => {
+      const r = await fetch(url, { headers, signal: ac.signal });
+      const body = await r.json().catch(() => null);
+      if (!r.ok) {
+        throw new Error(
+          (body && (body.error || body.message)) || `${r.status} ${r.statusText}`,
+        );
+      }
+      return body;
+    };
+
     Promise.all([
-      fetch("/api/pathways/cohorts", { headers }).then((r) => r.json()),
-      fetch("/api/pathways/facilitator/reports/weekly", { headers }).then((r) => r.json()),
+      safeFetch("/api/pathways/cohorts"),
+      safeFetch("/api/pathways/facilitator/reports/weekly"),
     ])
       .then(([c, w]) => {
         setCohorts(Array.isArray(c) ? c : []);
-        // Guard against error responses (e.g. 401/403/500) being passed in as `weekly`.
-        // The view code below dereferences `weekly.inactiveLearners` / `weekly.recentActivity`,
-        // so we only accept payloads that actually look like a WeeklyReport.
+        // Guard against error responses being passed in as `weekly`. The view
+        // dereferences `weekly.inactiveLearners` / `weekly.recentActivity`, so
+        // we only accept payloads that actually look like a WeeklyReport.
         if (w && typeof w === "object" && Array.isArray(w.inactiveLearners) && Array.isArray(w.recentActivity)) {
           setWeekly(w as WeeklyReport);
         } else {
           setWeekly(null);
         }
+        setLoadError(null);
       })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+      .catch((err) => {
+        const msg = err?.name === "AbortError" ? "timeout" : err?.message || "fetch failed";
+        setLoadError(msg);
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        setLoading(false);
+      });
+
+    return () => {
+      clearTimeout(timeout);
+      ac.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -114,8 +143,31 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-8">
+      {/* Load error — keep the rest of the page rendering so navigation still works. */}
+      {loadError && (
+        <Card className="border-amber-300 dark:border-amber-800/40">
+          <CardBody className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm">
+                Couldn't load cohort data
+              </p>
+              <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">
+                {loadError}
+              </p>
+            </div>
+            <button
+              onClick={() => window.location.reload()}
+              className="text-xs px-3 py-1.5 rounded-lg border bg-white border-slate-200 hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              Retry
+            </button>
+          </CardBody>
+        </Card>
+      )}
+
       {/* Empty state */}
-      {cohorts.length === 0 && (
+      {!loadError && cohorts.length === 0 && (
         <Card className="text-center py-16">
           <CardBody>
             <Users className="w-12 h-12 text-slate-400 dark:text-slate-600 mx-auto mb-4" />


### PR DESCRIPTION
## Summary

Three coupled fixes for the `/pathways/facilitator` regression introduced by #580. (The auth-token fix that was the first half of the work landed in #581; this picks up the remaining issues.)

- **Duplicate sidebar.** `/pathways/facilitator` was nested inside `/pathways`, so `PathwaysLayout` rendered its sidebar AND `FacilitatorLayout` rendered its sidebar. Moved to a sibling top-level route. `FacilitatorLayout` is now a standalone shell with its own `.dark` wrapper, brand bar, theme toggle, language toggle, and sign-out — sharing the `bb_pathways_theme` localStorage key with `PathwaysLayout` so a facilitator's theme preference persists across surfaces.
- **Missing migration.** #580 added `status` / `description` / `maxEnrollment` / `notes` / `updatedAt` + `@@index([status])` to `PathwayCohort` in both schema files but never generated a migration. Production runs `prisma.pathwayCohort.findMany(...)` against columns that don't exist. Added `20260514_add_pathway_cohort_lifecycle` to both prisma trees, idempotent (`ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`). `backend/scripts/predeploy.sh` will apply it on the next Railway deploy.
- **Dashboard resilience.** Even with the migration in place, a slow or 5xx response shouldn't strand the page on "Loading…". Added a 10-second `AbortController` ceiling on the two facilitator fetches, non-2xx error parsing, and an Error card with a Retry button.

## Test plan

- [ ] Railway deploy completes (predeploy applies `20260514_add_pathway_cohort_lifecycle`)
- [ ] Log in as `facilitator@test.com` / `pathway123` → land on `/pathways/facilitator`
- [ ] ONE sidebar visible (facilitator nav: Dashboard / Cohorts / Tracks / Learners / Reports / Resources / Settings)
- [ ] Active cohort cards render (ETO Spring 2026 — Cyber Cohort)
- [ ] Drill into a cohort, then a learner (Marcus / Aisha)
- [ ] No console errors, no 500s in Network tab
- [ ] Dark/light toggle works; sign-out works
- [ ] Marcus/Aisha student login still routes to `/pathways` with one (student) sidebar
- [ ] K-8 login still works (`teacher@school.com`, `student@test.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)