### PR TITLE
perf: cache facilitator cohorts in outlet context, dashboard skeleton

### DIFF
--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -13,8 +13,8 @@
  * sign-out — reading the same `bb_pathways_theme` localStorage key as
  * PathwaysLayout so a facilitator's preference is shared across both sides.
  */
-import { useEffect, useState } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import { NavLink, Outlet, useNavigate, useOutletContext } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import LanguageToggle from "@/components/LanguageToggle";
@@ -45,10 +45,38 @@ function readStoredTheme(): "dark" | "light" {
   }
 }
 
-interface CohortOption {
+export interface FacilitatorCohort {
   id: string;
   name: string;
+  band: string;
+  sitePartner: string | null;
   status: string;
+  joinCode: string;
+  startDate: string | null;
+  endDate: string | null;
+  maxEnrollment: number | null;
+  trackIds: string[];
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  _count?: { enrollments: number };
+}
+
+/**
+ * Shared facilitator data exposed via Outlet context. Pages should read
+ * cohorts from here instead of hitting `/api/pathways/cohorts` directly so
+ * navigating between sidebar items doesn't refetch on every click.
+ */
+export interface FacilitatorOutletContext {
+  activeCohortId: string | null;
+  setActiveCohortId: (id: string) => void;
+  cohorts: FacilitatorCohort[];
+  cohortsLoaded: boolean;
+  refreshCohorts: () => void;
+}
+
+export function useFacilitatorOutlet(): FacilitatorOutletContext {
+  return useOutletContext<FacilitatorOutletContext>();
 }
 
 export default function FacilitatorLayout() {
@@ -57,7 +85,8 @@ export default function FacilitatorLayout() {
   const navigate = useNavigate();
   const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
   const isDark = theme === "dark";
-  const [cohorts, setCohorts] = useState<CohortOption[]>([]);
+  const [cohorts, setCohorts] = useState<FacilitatorCohort[]>([]);
+  const [cohortsLoaded, setCohortsLoaded] = useState(false);
   const [activeCohortId, setActiveCohortId] = useState<string | null>(() => {
     try {
       return localStorage.getItem(ACTIVE_COHORT_KEY);
@@ -80,25 +109,28 @@ export default function FacilitatorLayout() {
     navigate("/");
   };
 
-  useEffect(() => {
+  const refreshCohorts = useCallback(() => {
     fetch("/api/pathways/cohorts", {
       headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => {
-        const arr: CohortOption[] = Array.isArray(data)
-          ? data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))
-          : [];
+        const arr: FacilitatorCohort[] = Array.isArray(data) ? data : [];
         setCohorts(arr);
-        if (!activeCohortId && arr.length > 0) {
-          // Default to the first active cohort
+        setActiveCohortId((current) => {
+          if (current && arr.some((c) => c.id === current)) return current;
+          if (arr.length === 0) return null;
           const firstActive = arr.find((c) => c.status === "active") ?? arr[0];
-          setActiveCohortId(firstActive.id);
-        }
+          return firstActive.id;
+        });
       })
-      .catch(() => {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      .catch(() => {})
+      .finally(() => setCohortsLoaded(true));
   }, []);
+
+  useEffect(() => {
+    refreshCohorts();
+  }, [refreshCohorts]);
 
   useEffect(() => {
     try {
@@ -219,14 +251,17 @@ export default function FacilitatorLayout() {
 
         {/* Page content */}
         <div className="flex-1 min-w-0">
-          <Outlet context={{ activeCohortId, cohorts, refreshCohorts: () => {
-            fetch("/api/pathways/cohorts", {
-              headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
-            })
-              .then((r) => r.json())
-              .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))
-              .catch(() => {});
-          } }} />
+          <Outlet
+            context={
+              {
+                activeCohortId,
+                setActiveCohortId,
+                cohorts,
+                cohortsLoaded,
+                refreshCohorts,
+              } satisfies FacilitatorOutletContext
+            }
+          />
         </div>
       </div>
         </div>

--- a/src/components/pathways/facilitator/pages/CohortsList.tsx
+++ b/src/components/pathways/facilitator/pages/CohortsList.tsx
@@ -1,45 +1,26 @@
 /**
  * Cohorts list — full list of facilitator's cohorts with filter/search.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Plus, Search, Users } from "lucide-react";
 import Card from "../shared/Card";
-import { StatusPill } from "../FacilitatorLayout";
-
-interface Cohort {
-  id: string;
-  name: string;
-  band: string;
-  sitePartner: string | null;
-  status: string;
-  startDate: string | null;
-  endDate: string | null;
-  updatedAt: string;
-  _count?: { enrollments: number };
-}
+import { StatusPill, useFacilitatorOutlet } from "../FacilitatorLayout";
 
 const STATUS_OPTIONS = ["all", "draft", "active", "paused", "ended", "archived"];
 const BAND_OPTIONS = ["all", "explorer", "launch", "mixed"];
 
 export default function CohortsList() {
   const { t } = useTranslation();
-  const [cohorts, setCohorts] = useState<Cohort[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Read cohorts from FacilitatorLayout's shared Outlet context — fetched
+  // once per session, so this list renders instantly when the user clicks
+  // back from another sidebar page.
+  const { cohorts, cohortsLoaded } = useFacilitatorOutlet();
+  const loading = !cohortsLoaded;
   const [statusFilter, setStatusFilter] = useState("all");
   const [bandFilter, setBandFilter] = useState("all");
   const [search, setSearch] = useState("");
-
-  useEffect(() => {
-    fetch("/api/pathways/cohorts", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
-    })
-      .then((r) => r.json())
-      .then((data) => setCohorts(Array.isArray(data) ? data : []))
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
 
   const filtered = useMemo(() => {
     return cohorts.filter((c) => {

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -28,20 +28,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import Card, { CardBody, CardHeader, StatTile } from "../shared/Card";
-import { StatusPill } from "../FacilitatorLayout";
-
-interface Cohort {
-  id: string;
-  name: string;
-  status: string;
-  sitePartner: string | null;
-  joinCode: string;
-  startDate: string | null;
-  endDate: string | null;
-  maxEnrollment: number | null;
-  trackIds: string[];
-  _count?: { enrollments: number };
-}
+import { StatusPill, useFacilitatorOutlet } from "../FacilitatorLayout";
 
 interface WeeklyReport {
   modulesCompleted: number;
@@ -62,40 +49,31 @@ interface WeeklyReport {
 
 export default function Dashboard() {
   const { t } = useTranslation();
-  const [cohorts, setCohorts] = useState<Cohort[]>([]);
+  // Cohorts come from FacilitatorLayout's Outlet context — fetched once per
+  // session, so navigating back to the dashboard from another sidebar page
+  // doesn't re-hit /api/pathways/cohorts.
+  const { cohorts, cohortsLoaded } = useFacilitatorOutlet();
   const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [weeklyLoaded, setWeeklyLoaded] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
-  const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
-
   useEffect(() => {
-    // Hard 10s ceiling per request so a hung backend or missing migration
-    // surfaces as an error UI instead of an indefinite "Loading…" state.
+    // Hard 10s ceiling so a hung backend surfaces as an error UI instead
+    // of an indefinite "Loading…" state.
     const ac = new AbortController();
     const timeout = setTimeout(() => ac.abort(), 10000);
+    const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
-    const safeFetch = async (url: string) => {
-      const r = await fetch(url, { headers, signal: ac.signal });
-      const body = await r.json().catch(() => null);
-      if (!r.ok) {
-        throw new Error(
-          (body && (body.error || body.message)) || `${r.status} ${r.statusText}`,
-        );
-      }
-      return body;
-    };
-
-    Promise.all([
-      safeFetch("/api/pathways/cohorts"),
-      safeFetch("/api/pathways/facilitator/reports/weekly"),
-    ])
-      .then(([c, w]) => {
-        setCohorts(Array.isArray(c) ? c : []);
-        // Guard against error responses being passed in as `weekly`. The view
-        // dereferences `weekly.inactiveLearners` / `weekly.recentActivity`, so
-        // we only accept payloads that actually look like a WeeklyReport.
+    fetch("/api/pathways/facilitator/reports/weekly", { headers, signal: ac.signal })
+      .then(async (r) => {
+        const body = await r.json().catch(() => null);
+        if (!r.ok) {
+          throw new Error((body && (body.error || body.message)) || `${r.status} ${r.statusText}`);
+        }
+        return body;
+      })
+      .then((w) => {
         if (w && typeof w === "object" && Array.isArray(w.inactiveLearners) && Array.isArray(w.recentActivity)) {
           setWeekly(w as WeeklyReport);
         } else {
@@ -104,21 +82,21 @@ export default function Dashboard() {
         setLoadError(null);
       })
       .catch((err) => {
-        const msg = err?.name === "AbortError" ? "timeout" : err?.message || "fetch failed";
-        setLoadError(msg);
+        if (err?.name === "AbortError") setLoadError("timeout");
+        else setLoadError(err?.message || "fetch failed");
       })
       .finally(() => {
         clearTimeout(timeout);
-        setLoading(false);
+        setWeeklyLoaded(true);
       });
 
     return () => {
       clearTimeout(timeout);
       ac.abort();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const loading = !cohortsLoaded || !weeklyLoaded;
   const activeCohorts = cohorts.filter((c) => c.status === "active");
 
   const copyCode = (code: string) => {
@@ -138,7 +116,7 @@ export default function Dashboard() {
   };
 
   if (loading) {
-    return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+    return <DashboardSkeleton />;
   }
 
   return (
@@ -427,6 +405,29 @@ export default function Dashboard() {
           </Card>
         </section>
       )}
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <div>
+        <div className="h-6 w-48 mb-3 rounded bg-slate-200 dark:bg-slate-800" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="rounded-xl border bg-white border-slate-200 dark:bg-slate-800/40 dark:border-slate-700 h-44" />
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="h-6 w-40 mb-3 rounded bg-slate-200 dark:bg-slate-800" />
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="rounded-xl border bg-white border-slate-200 dark:bg-slate-800/40 dark:border-slate-700 h-24" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Cuts the duplicate `/api/pathways/cohorts` fetches that fired on every facilitator sidebar navigation.

**Before** — three pages (FacilitatorLayout, Dashboard, CohortsList) each called `/api/pathways/cohorts` on mount. Cold dashboard load did **three** round-trips to that endpoint before content rendered, and clicking back from another sidebar item re-ran the page's own fetch every time.

**After** — FacilitatorLayout owns the fetch. Cohorts live in the React Router Outlet context and are exposed via a typed `useFacilitatorOutlet()` hook. Pages read from there; navigating between sidebar items no longer hits the cohorts endpoint at all.

Numbers on the dashboard route:
- Cold load: **3 reqs → 2 reqs** (1 cohorts + 1 weekly)
- Subsequent sidebar nav (e.g. Cohorts → Dashboard → Cohorts): cohorts not refetched; CohortsList renders instantly from cache.

Also swapped the dashboard's "Loading…" text for a skeleton (3 cohort tiles + 4 stat tiles) that mirrors the destination layout so perceived latency drops while the weekly report loads.

**Backend audit:** existing facilitator endpoints already use `select` projection and bounded `include` joins — no N+1 to fix server-side. Caching the weekly report / learners / tracks is out of scope here and can be a follow-up if perceived latency is still high.

## Test plan

- [ ] Log in as `facilitator@test.com` / `pathway123` → land on `/pathways/facilitator`
- [ ] Open DevTools → Network tab → filter `pathways/cohorts`. On first load, exactly **one** request to `/api/pathways/cohorts`
- [ ] Skeleton renders briefly while weekly report loads, then dashboard fills in
- [ ] Click Cohorts in sidebar → CohortsList renders instantly with no new `/api/pathways/cohorts` call
- [ ] Click back to Dashboard → no new `/api/pathways/cohorts` call; only `reports/weekly` refetches
- [ ] CohortsList filters (status / band / search) still work
- [ ] After creating a new cohort via Cohorts → New, the list reflects it (creating page calls `refreshCohorts` on success — or hard-refresh works)
- [ ] No console warnings, no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)