### PR TITLE
feat: expand Cyber Launch modules with full 6-section learning experience

### DIFF
--- a/backend/prisma/migrations/20260514_add_milestone_section_progress/migration.sql
+++ b/backend/prisma/migrations/20260514_add_milestone_section_progress/migration.sql
@@ -1,0 +1,15 @@
+-- Cyber Launch modules now use a 6-section learning flow (hook / reading /
+-- lesson / practice / homework / quiz). Track completion at the section
+-- level so facilitators can see where a learner is and so the homework
+-- task can store a free-text response that the facilitator reviews.
+-- Idempotent so it is safe to re-run on any environment.
+
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "hookCompleted"     BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "readingCompleted"  BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "lessonCompleted"   BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "practiceCompleted" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "homeworkSubmitted" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "homeworkResponse"  TEXT;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "quizCompleted"     BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "quizScore"         INTEGER;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "timeSpentMinutes"  INTEGER NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -729,6 +729,16 @@ model PathwayMilestone {
   artifacts   Json?
   createdAt   DateTime  @default(now())
 
+  hookCompleted     Boolean @default(false)
+  readingCompleted  Boolean @default(false)
+  lessonCompleted   Boolean @default(false)
+  practiceCompleted Boolean @default(false)
+  homeworkSubmitted Boolean @default(false)
+  homeworkResponse  String?
+  quizCompleted     Boolean @default(false)
+  quizScore         Int?
+  timeSpentMinutes  Int     @default(0)
+
   user User @relation(fields: [userId], references: [id])
 
   @@unique([userId, trackSlug, moduleSlug])

--- a/backend/src/routes/pathways.ts
+++ b/backend/src/routes/pathways.ts
@@ -262,6 +262,104 @@ router.get(
   },
 );
 
+// ── Section-level progress for the 6-section Cyber Launch flow ─────────────
+
+const SECTION_KEYS = [
+  "hook",
+  "reading",
+  "lesson",
+  "practice",
+  "homework",
+  "quiz",
+] as const;
+type SectionKey = (typeof SECTION_KEYS)[number];
+
+const sectionProgressSchema = z.object({
+  trackSlug: z.string().min(1),
+  moduleSlug: z.string().min(1),
+  section: z.enum(SECTION_KEYS),
+  completed: z.boolean(),
+  timeSpentMinutes: z.number().int().min(0).max(600).optional(),
+});
+
+const SECTION_COLUMN: Record<SectionKey, string> = {
+  hook: "hookCompleted",
+  reading: "readingCompleted",
+  lesson: "lessonCompleted",
+  practice: "practiceCompleted",
+  homework: "homeworkSubmitted",
+  quiz: "quizCompleted",
+};
+
+router.patch(
+  "/pathways/student/milestones/section",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    const parsed = sectionProgressSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
+    const { trackSlug, moduleSlug, section, completed, timeSpentMinutes } = parsed.data;
+
+    const data: Record<string, unknown> = { [SECTION_COLUMN[section]]: completed };
+    if (timeSpentMinutes && timeSpentMinutes > 0) {
+      data.timeSpentMinutes = { increment: timeSpentMinutes };
+    }
+    // Bumping any section transitions the module out of "not_started".
+    if (completed) data.status = "in_progress";
+
+    const milestone = await prisma.pathwayMilestone.upsert({
+      where: {
+        userId_trackSlug_moduleSlug: { userId: req.user!.id, trackSlug, moduleSlug },
+      },
+      create: {
+        userId: req.user!.id,
+        trackSlug,
+        moduleSlug,
+        status: completed ? "in_progress" : "not_started",
+        [SECTION_COLUMN[section]]: completed,
+        timeSpentMinutes: timeSpentMinutes ?? 0,
+      },
+      update: data,
+    });
+    res.json(milestone);
+  },
+);
+
+const homeworkSchema = z.object({
+  trackSlug: z.string().min(1),
+  moduleSlug: z.string().min(1),
+  response: z.string().min(1).max(5000),
+});
+
+router.post(
+  "/pathways/student/milestones/homework",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    const parsed = homeworkSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.issues[0].message });
+    const { trackSlug, moduleSlug, response } = parsed.data;
+
+    const milestone = await prisma.pathwayMilestone.upsert({
+      where: {
+        userId_trackSlug_moduleSlug: { userId: req.user!.id, trackSlug, moduleSlug },
+      },
+      create: {
+        userId: req.user!.id,
+        trackSlug,
+        moduleSlug,
+        status: "in_progress",
+        homeworkSubmitted: true,
+        homeworkResponse: response,
+      },
+      update: {
+        homeworkSubmitted: true,
+        homeworkResponse: response,
+        status: "in_progress",
+      },
+    });
+    res.json(milestone);
+  },
+);
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Facilitator: cohort lifecycle and operations
 // ═══════════════════════════════════════════════════════════════════════════

--- a/prisma/migrations/20260514_add_milestone_section_progress/migration.sql
+++ b/prisma/migrations/20260514_add_milestone_section_progress/migration.sql
@@ -1,0 +1,15 @@
+-- Cyber Launch modules now use a 6-section learning flow (hook / reading /
+-- lesson / practice / homework / quiz). Track completion at the section
+-- level so facilitators can see where a learner is and so the homework
+-- task can store a free-text response that the facilitator reviews.
+-- Idempotent so it is safe to re-run on any environment.
+
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "hookCompleted"     BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "readingCompleted"  BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "lessonCompleted"   BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "practiceCompleted" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "homeworkSubmitted" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "homeworkResponse"  TEXT;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "quizCompleted"     BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "quizScore"         INTEGER;
+ALTER TABLE "PathwayMilestone" ADD COLUMN IF NOT EXISTS "timeSpentMinutes"  INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -735,6 +735,19 @@ model PathwayMilestone {
   artifacts   Json?
   createdAt   DateTime  @default(now())
 
+  // Section-level progress for the Cyber Launch 6-section flow
+  // (hook, reading, lesson, practice, homework, quiz). Modules that don't
+  // use this flow leave the fields at their defaults.
+  hookCompleted     Boolean @default(false)
+  readingCompleted  Boolean @default(false)
+  lessonCompleted   Boolean @default(false)
+  practiceCompleted Boolean @default(false)
+  homeworkSubmitted Boolean @default(false)
+  homeworkResponse  String?
+  quizCompleted     Boolean @default(false)
+  quizScore         Int?
+  timeSpentMinutes  Int     @default(0)
+
   user User @relation(fields: [userId], references: [id])
 
   @@unique([userId, trackSlug, moduleSlug])

--- a/src/components/pathways/facilitator/FacilitatorLayout.tsx
+++ b/src/components/pathways/facilitator/FacilitatorLayout.tsx
@@ -13,8 +13,8 @@
  * sign-out — reading the same `bb_pathways_theme` localStorage key as
  * PathwaysLayout so a facilitator's preference is shared across both sides.
  */
-import { useEffect, useState } from "react";
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import { NavLink, Outlet, useNavigate, useOutletContext } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import LanguageToggle from "@/components/LanguageToggle";
@@ -45,10 +45,38 @@ function readStoredTheme(): "dark" | "light" {
   }
 }
 
-interface CohortOption {
+export interface FacilitatorCohort {
   id: string;
   name: string;
+  band: string;
+  sitePartner: string | null;
   status: string;
+  joinCode: string;
+  startDate: string | null;
+  endDate: string | null;
+  maxEnrollment: number | null;
+  trackIds: string[];
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  _count?: { enrollments: number };
+}
+
+/**
+ * Shared facilitator data exposed via Outlet context. Pages should read
+ * cohorts from here instead of hitting `/api/pathways/cohorts` directly so
+ * navigating between sidebar items doesn't refetch on every click.
+ */
+export interface FacilitatorOutletContext {
+  activeCohortId: string | null;
+  setActiveCohortId: (id: string) => void;
+  cohorts: FacilitatorCohort[];
+  cohortsLoaded: boolean;
+  refreshCohorts: () => void;
+}
+
+export function useFacilitatorOutlet(): FacilitatorOutletContext {
+  return useOutletContext<FacilitatorOutletContext>();
 }
 
 export default function FacilitatorLayout() {
@@ -57,7 +85,8 @@ export default function FacilitatorLayout() {
   const navigate = useNavigate();
   const [theme, setTheme] = useState<"dark" | "light">(() => readStoredTheme());
   const isDark = theme === "dark";
-  const [cohorts, setCohorts] = useState<CohortOption[]>([]);
+  const [cohorts, setCohorts] = useState<FacilitatorCohort[]>([]);
+  const [cohortsLoaded, setCohortsLoaded] = useState(false);
   const [activeCohortId, setActiveCohortId] = useState<string | null>(() => {
     try {
       return localStorage.getItem(ACTIVE_COHORT_KEY);
@@ -80,25 +109,28 @@ export default function FacilitatorLayout() {
     navigate("/");
   };
 
-  useEffect(() => {
+  const refreshCohorts = useCallback(() => {
     fetch("/api/pathways/cohorts", {
       headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
     })
       .then((r) => r.json())
       .then((data) => {
-        const arr: CohortOption[] = Array.isArray(data)
-          ? data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))
-          : [];
+        const arr: FacilitatorCohort[] = Array.isArray(data) ? data : [];
         setCohorts(arr);
-        if (!activeCohortId && arr.length > 0) {
-          // Default to the first active cohort
+        setActiveCohortId((current) => {
+          if (current && arr.some((c) => c.id === current)) return current;
+          if (arr.length === 0) return null;
           const firstActive = arr.find((c) => c.status === "active") ?? arr[0];
-          setActiveCohortId(firstActive.id);
-        }
+          return firstActive.id;
+        });
       })
-      .catch(() => {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      .catch(() => {})
+      .finally(() => setCohortsLoaded(true));
   }, []);
+
+  useEffect(() => {
+    refreshCohorts();
+  }, [refreshCohorts]);
 
   useEffect(() => {
     try {
@@ -219,14 +251,17 @@ export default function FacilitatorLayout() {
 
         {/* Page content */}
         <div className="flex-1 min-w-0">
-          <Outlet context={{ activeCohortId, cohorts, refreshCohorts: () => {
-            fetch("/api/pathways/cohorts", {
-              headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
-            })
-              .then((r) => r.json())
-              .then((data) => Array.isArray(data) && setCohorts(data.map((c: { id: string; name: string; status: string }) => ({ id: c.id, name: c.name, status: c.status }))))
-              .catch(() => {});
-          } }} />
+          <Outlet
+            context={
+              {
+                activeCohortId,
+                setActiveCohortId,
+                cohorts,
+                cohortsLoaded,
+                refreshCohorts,
+              } satisfies FacilitatorOutletContext
+            }
+          />
         </div>
       </div>
         </div>

--- a/src/components/pathways/facilitator/pages/CohortsList.tsx
+++ b/src/components/pathways/facilitator/pages/CohortsList.tsx
@@ -1,45 +1,26 @@
 /**
  * Cohorts list — full list of facilitator's cohorts with filter/search.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Plus, Search, Users } from "lucide-react";
 import Card from "../shared/Card";
-import { StatusPill } from "../FacilitatorLayout";
-
-interface Cohort {
-  id: string;
-  name: string;
-  band: string;
-  sitePartner: string | null;
-  status: string;
-  startDate: string | null;
-  endDate: string | null;
-  updatedAt: string;
-  _count?: { enrollments: number };
-}
+import { StatusPill, useFacilitatorOutlet } from "../FacilitatorLayout";
 
 const STATUS_OPTIONS = ["all", "draft", "active", "paused", "ended", "archived"];
 const BAND_OPTIONS = ["all", "explorer", "launch", "mixed"];
 
 export default function CohortsList() {
   const { t } = useTranslation();
-  const [cohorts, setCohorts] = useState<Cohort[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Read cohorts from FacilitatorLayout's shared Outlet context — fetched
+  // once per session, so this list renders instantly when the user clicks
+  // back from another sidebar page.
+  const { cohorts, cohortsLoaded } = useFacilitatorOutlet();
+  const loading = !cohortsLoaded;
   const [statusFilter, setStatusFilter] = useState("all");
   const [bandFilter, setBandFilter] = useState("all");
   const [search, setSearch] = useState("");
-
-  useEffect(() => {
-    fetch("/api/pathways/cohorts", {
-      headers: { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` },
-    })
-      .then((r) => r.json())
-      .then((data) => setCohorts(Array.isArray(data) ? data : []))
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
 
   const filtered = useMemo(() => {
     return cohorts.filter((c) => {

--- a/src/components/pathways/facilitator/pages/Dashboard.tsx
+++ b/src/components/pathways/facilitator/pages/Dashboard.tsx
@@ -28,20 +28,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import Card, { CardBody, CardHeader, StatTile } from "../shared/Card";
-import { StatusPill } from "../FacilitatorLayout";
-
-interface Cohort {
-  id: string;
-  name: string;
-  status: string;
-  sitePartner: string | null;
-  joinCode: string;
-  startDate: string | null;
-  endDate: string | null;
-  maxEnrollment: number | null;
-  trackIds: string[];
-  _count?: { enrollments: number };
-}
+import { StatusPill, useFacilitatorOutlet } from "../FacilitatorLayout";
 
 interface WeeklyReport {
   modulesCompleted: number;
@@ -62,40 +49,31 @@ interface WeeklyReport {
 
 export default function Dashboard() {
   const { t } = useTranslation();
-  const [cohorts, setCohorts] = useState<Cohort[]>([]);
+  // Cohorts come from FacilitatorLayout's Outlet context — fetched once per
+  // session, so navigating back to the dashboard from another sidebar page
+  // doesn't re-hit /api/pathways/cohorts.
+  const { cohorts, cohortsLoaded } = useFacilitatorOutlet();
   const [weekly, setWeekly] = useState<WeeklyReport | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [weeklyLoaded, setWeeklyLoaded] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
 
-  const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
-
   useEffect(() => {
-    // Hard 10s ceiling per request so a hung backend or missing migration
-    // surfaces as an error UI instead of an indefinite "Loading…" state.
+    // Hard 10s ceiling so a hung backend surfaces as an error UI instead
+    // of an indefinite "Loading…" state.
     const ac = new AbortController();
     const timeout = setTimeout(() => ac.abort(), 10000);
+    const headers = { Authorization: `Bearer ${localStorage.getItem("bb_access_token")}` };
 
-    const safeFetch = async (url: string) => {
-      const r = await fetch(url, { headers, signal: ac.signal });
-      const body = await r.json().catch(() => null);
-      if (!r.ok) {
-        throw new Error(
-          (body && (body.error || body.message)) || `${r.status} ${r.statusText}`,
-        );
-      }
-      return body;
-    };
-
-    Promise.all([
-      safeFetch("/api/pathways/cohorts"),
-      safeFetch("/api/pathways/facilitator/reports/weekly"),
-    ])
-      .then(([c, w]) => {
-        setCohorts(Array.isArray(c) ? c : []);
-        // Guard against error responses being passed in as `weekly`. The view
-        // dereferences `weekly.inactiveLearners` / `weekly.recentActivity`, so
-        // we only accept payloads that actually look like a WeeklyReport.
+    fetch("/api/pathways/facilitator/reports/weekly", { headers, signal: ac.signal })
+      .then(async (r) => {
+        const body = await r.json().catch(() => null);
+        if (!r.ok) {
+          throw new Error((body && (body.error || body.message)) || `${r.status} ${r.statusText}`);
+        }
+        return body;
+      })
+      .then((w) => {
         if (w && typeof w === "object" && Array.isArray(w.inactiveLearners) && Array.isArray(w.recentActivity)) {
           setWeekly(w as WeeklyReport);
         } else {
@@ -104,21 +82,21 @@ export default function Dashboard() {
         setLoadError(null);
       })
       .catch((err) => {
-        const msg = err?.name === "AbortError" ? "timeout" : err?.message || "fetch failed";
-        setLoadError(msg);
+        if (err?.name === "AbortError") setLoadError("timeout");
+        else setLoadError(err?.message || "fetch failed");
       })
       .finally(() => {
         clearTimeout(timeout);
-        setLoading(false);
+        setWeeklyLoaded(true);
       });
 
     return () => {
       clearTimeout(timeout);
       ac.abort();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const loading = !cohortsLoaded || !weeklyLoaded;
   const activeCohorts = cohorts.filter((c) => c.status === "active");
 
   const copyCode = (code: string) => {
@@ -138,7 +116,7 @@ export default function Dashboard() {
   };
 
   if (loading) {
-    return <div className="text-center py-20 text-slate-600 dark:text-slate-400">{t("pathways.common.loading")}</div>;
+    return <DashboardSkeleton />;
   }
 
   return (
@@ -427,6 +405,29 @@ export default function Dashboard() {
           </Card>
         </section>
       )}
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <div>
+        <div className="h-6 w-48 mb-3 rounded bg-slate-200 dark:bg-slate-800" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="rounded-xl border bg-white border-slate-200 dark:bg-slate-800/40 dark:border-slate-700 h-44" />
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="h-6 w-40 mb-3 rounded bg-slate-200 dark:bg-slate-800" />
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="rounded-xl border bg-white border-slate-200 dark:bg-slate-800/40 dark:border-slate-700 h-24" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/pathways/facilitator/pages/LearnerDetail.tsx
+++ b/src/components/pathways/facilitator/pages/LearnerDetail.tsx
@@ -4,9 +4,26 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, CheckCircle2, Clock, XCircle } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Clock, XCircle, FileText } from "lucide-react";
 import Card, { CardBody, CardHeader } from "../shared/Card";
 import { StatusPill } from "../FacilitatorLayout";
+
+interface Milestone {
+  moduleSlug: string;
+  trackSlug: string;
+  status: string;
+  score: number | null;
+  completedAt: string | null;
+  createdAt: string;
+  hookCompleted?: boolean;
+  readingCompleted?: boolean;
+  lessonCompleted?: boolean;
+  practiceCompleted?: boolean;
+  homeworkSubmitted?: boolean;
+  homeworkResponse?: string | null;
+  quizCompleted?: boolean;
+  quizScore?: number | null;
+}
 
 interface LearnerDetailData {
   user: { id: string; name: string | null; email: string | null; ageBand: string | null; birthYear: number | null };
@@ -16,7 +33,34 @@ interface LearnerDetailData {
     status: string;
     cohort: { id: string; name: string; status: string };
   }>;
-  milestones: Array<{ moduleSlug: string; trackSlug: string; status: string; score: number | null; completedAt: string | null; createdAt: string }>;
+  milestones: Milestone[];
+}
+
+const SECTION_LABELS: Array<{ key: keyof Milestone; label: string }> = [
+  { key: "hookCompleted", label: "Hook" },
+  { key: "readingCompleted", label: "Read" },
+  { key: "lessonCompleted", label: "Lesson" },
+  { key: "practiceCompleted", label: "Practice" },
+  { key: "homeworkSubmitted", label: "HW" },
+  { key: "quizCompleted", label: "Quiz" },
+];
+
+function SectionDots({ milestone }: { milestone: Milestone }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {SECTION_LABELS.map(({ key, label }) => {
+        const done = milestone[key] === true;
+        return (
+          <span
+            key={String(key)}
+            title={`${label}: ${done ? "complete" : "not yet"}`}
+            className={`w-2 h-2 rounded-full ${done ? "bg-emerald-500 dark:bg-emerald-400" : "bg-slate-300 dark:bg-slate-700"}`}
+            aria-label={`${label} ${done ? "complete" : "not complete"}`}
+          />
+        );
+      })}
+    </div>
+  );
 }
 
 export default function LearnerDetail() {
@@ -139,28 +183,41 @@ export default function LearnerDetail() {
               {t("pathways.facilitator.learnerDetail.noMilestones")}
             </p>
           ) : (
-            <ul className="space-y-1">
+            <ul className="space-y-2">
               {data.milestones.map((m, i) => (
                 <li
                   key={i}
-                  className="flex items-center gap-3 p-2 rounded text-sm"
+                  className="rounded-lg border border-slate-200 dark:border-slate-700/60 p-3"
                 >
-                  {m.status === "completed" ? (
-                    <CheckCircle2 className="w-4 h-4 text-emerald-700 dark:text-emerald-400 shrink-0" />
-                  ) : m.status === "in_progress" ? (
-                    <Clock className="w-4 h-4 text-indigo-700 dark:text-indigo-400 shrink-0" />
-                  ) : (
-                    <XCircle className="w-4 h-4 text-slate-400 dark:text-slate-600 shrink-0" />
+                  <div className="flex items-center gap-3 text-sm">
+                    {m.status === "completed" ? (
+                      <CheckCircle2 className="w-4 h-4 text-emerald-700 dark:text-emerald-400 shrink-0" />
+                    ) : m.status === "in_progress" ? (
+                      <Clock className="w-4 h-4 text-indigo-700 dark:text-indigo-400 shrink-0" />
+                    ) : (
+                      <XCircle className="w-4 h-4 text-slate-400 dark:text-slate-600 shrink-0" />
+                    )}
+                    <span className="flex-1 text-slate-800 dark:text-slate-300">
+                      {t(`pathways.tracks.modules.${m.moduleSlug}.name`, m.moduleSlug)}
+                    </span>
+                    <SectionDots milestone={m} />
+                    <span className="text-xs text-slate-600 dark:text-slate-500 w-12 text-right">
+                      {m.score !== null ? `${m.score}%` : ""}
+                    </span>
+                    <span className="text-xs text-slate-500 w-24 text-right">
+                      {m.completedAt ? new Date(m.completedAt).toLocaleDateString() : ""}
+                    </span>
+                  </div>
+                  {m.homeworkResponse && (
+                    <details className="mt-2 ml-7">
+                      <summary className="text-xs text-indigo-700 dark:text-indigo-400 hover:underline cursor-pointer inline-flex items-center gap-1">
+                        <FileText className="w-3 h-3" /> Homework submission
+                      </summary>
+                      <pre className="mt-2 whitespace-pre-wrap text-xs text-slate-700 dark:text-slate-300 bg-slate-50 dark:bg-slate-900/40 rounded p-3 border border-slate-200 dark:border-slate-700/40 font-sans">
+{m.homeworkResponse}
+                      </pre>
+                    </details>
                   )}
-                  <span className="flex-1 text-slate-800 dark:text-slate-300">
-                    {t(`pathways.tracks.modules.${m.moduleSlug}.name`, m.moduleSlug)}
-                  </span>
-                  <span className="text-xs text-slate-600 dark:text-slate-500">
-                    {m.score !== null ? `${m.score}%` : ""}
-                  </span>
-                  <span className="text-xs text-slate-500 w-24 text-right">
-                    {m.completedAt ? new Date(m.completedAt).toLocaleDateString() : ""}
-                  </span>
                 </li>
               ))}
             </ul>

--- a/src/components/pathways/modules/CyberLaunchModules.tsx
+++ b/src/components/pathways/modules/CyberLaunchModules.tsx
@@ -1,177 +1,136 @@
 /**
- * Cyber Launch Track — BrightBoost Pathways
+ * Cyber Launch Track — BrightBoost Pathways.
  *
- * 7 self-contained modules for teens (14-17).
- * Each exports a named component accepting { onComplete, onBack }.
- * Light/dark aware via Tailwind `dark:` variants — inherits the `.dark`
- * class scope from PathwaysLayout.
+ * Each module is now a thin wrapper around <ModuleStructure>, which renders
+ * the full 6-section learning flow (Hook / Reading / Lesson / Practice /
+ * Homework / Quiz). The substantive content lives in cyberLaunchContent.ts;
+ * this file just maps module slugs to their content, supplies the final
+ * quiz, and exports a router that ModulePlayer.tsx mounts.
  *
- * i18n: Module 1 (CyberFoundations) slide/role/quiz content reads from
- * the `pathways.modules.foundations.*` keys. Modules 2-7 are wired for
- * UI chrome (titles, buttons) but interior scenario content remains in
- * English — see docs/pathways-translation-status.md for the path forward.
+ * For module 1 (Cyber Foundations), the quiz prompts are i18n-keyed for
+ * parity with the prior implementation. The other modules' quizzes are
+ * English-only for now — see docs/pathways-translation-status.md.
+ *
+ * Capstone (module 7) skips the quiz section; its assessment is the
+ * homework submission (the written security plan).
  */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-
-// ── Shared types & helpers ────────────────────────────────────────────────
+import ModuleStructure from "./ModuleStructure";
+import { CYBER_LAUNCH_CONTENT } from "./cyberLaunchContent";
 
 interface ModuleProps {
   onComplete: (score: number) => void;
   onBack: () => void;
 }
 
-function ProgressBar({ current, total }: { current: number; total: number }) {
-  const pct = Math.round((current / total) * 100);
-  return (
-    <div className="w-full bg-slate-200 dark:bg-slate-700 rounded h-1.5">
-      <div
-        className="bg-indigo-600 dark:bg-indigo-500 h-1.5 rounded transition-all duration-300"
-        style={{ width: `${pct}%` }}
-      />
-    </div>
-  );
+// ── StandaloneQuiz ─────────────────────────────────────────────────────────
+
+interface QuizQuestion {
+  q: string;
+  opts: string[];
+  ans: number;
 }
 
-function ModuleShell({
-  title,
-  step,
-  totalSteps,
-  onBack,
-  children,
+function StandaloneQuiz({
+  questions,
+  onComplete,
 }: {
-  title: string;
-  step: number;
-  totalSteps: number;
-  onBack: () => void;
-  children: React.ReactNode;
+  questions: QuizQuestion[];
+  onComplete: (score: number) => void;
 }) {
-  const { t } = useTranslation();
+  const [idx, setIdx] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [answered, setAnswered] = useState(false);
+  const [correct, setCorrect] = useState(0);
+
+  const total = questions.length;
+  const q = questions[idx];
+
+  const handleAnswer = (i: number) => {
+    if (answered) return;
+    setSelected(i);
+    setAnswered(true);
+    if (i === q.ans) setCorrect((c) => c + 1);
+  };
+
+  const handleNext = () => {
+    if (idx + 1 >= total) {
+      const score = Math.round((correct / total) * 100);
+      onComplete(score);
+      return;
+    }
+    setIdx(idx + 1);
+    setSelected(null);
+    setAnswered(false);
+  };
+
   return (
-    <div className="bg-white text-slate-900 dark:bg-slate-900 dark:text-white p-4 sm:p-6 rounded-2xl border border-slate-200 dark:border-slate-800">
-      <div className="max-w-2xl mx-auto space-y-4">
-        <div className="flex items-center justify-between">
-          <button
-            onClick={onBack}
-            className="text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white transition-colors"
-          >
-            &larr; {t("pathways.common.back")}
-          </button>
-          <span className="text-xs text-slate-500 dark:text-slate-500">
-            {step}/{totalSteps}
-          </span>
-        </div>
-        <h1 className="text-xl font-bold tracking-tight">{title}</h1>
-        <ProgressBar current={step} total={totalSteps} />
-        {children}
+    <div className="space-y-4">
+      <div className="text-xs text-slate-500">
+        Question {idx + 1} of {total}
       </div>
+      <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{q.q}</h3>
+      <div className="space-y-2">
+        {q.opts.map((opt, i) => {
+          const isPicked = selected === i;
+          const isCorrect = i === q.ans;
+          const cls = !answered
+            ? "border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800"
+            : isCorrect
+              ? "border-emerald-400 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-900/30"
+              : isPicked
+                ? "border-amber-400 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/30"
+                : "border-slate-200 dark:border-slate-700 opacity-60";
+          return (
+            <button
+              key={i}
+              onClick={() => handleAnswer(i)}
+              disabled={answered}
+              className={`w-full text-left rounded-lg border p-3 transition-colors text-sm ${cls}`}
+            >
+              {opt}
+            </button>
+          );
+        })}
+      </div>
+      {answered && (
+        <div className="flex items-center justify-between pt-2">
+          <p className="text-xs text-slate-600 dark:text-slate-400">
+            {selected === q.ans ? "Correct." : `The right answer was: ${q.opts[q.ans]}`}
+          </p>
+          <button
+            onClick={handleNext}
+            className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
+          >
+            {idx + 1 >= total ? "Finish →" : "Next →"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }
 
-function Card({
-  children,
-  className = "",
-  onClick,
-  selected,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  onClick?: () => void;
-  selected?: boolean;
-}) {
-  const base =
-    "border rounded-lg p-4 transition-all duration-200 " +
-    (selected
-      ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-900/40 shadow-lg shadow-indigo-500/10"
-      : "border-slate-200 bg-white dark:border-slate-200 dark:border-slate-700 dark:bg-white dark:bg-slate-800 shadow-sm");
-  const interactive = onClick
-    ? " cursor-pointer hover:border-indigo-400 hover:bg-slate-50 dark:hover:bg-slate-750 active:scale-[0.98]"
-    : "";
-  return (
-    <div className={`${base}${interactive} ${className}`} onClick={onClick}>
-      {children}
-    </div>
-  );
-}
+// ── Quiz banks per module ──────────────────────────────────────────────────
 
-function PrimaryButton({
-  onClick,
-  disabled,
-  children,
-}: {
-  onClick: () => void;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 disabled:text-slate-500 dark:hover:bg-indigo-500 dark:disabled:bg-slate-700 dark:disabled:text-slate-500 text-white text-sm font-medium rounded-lg transition-colors"
-    >
-      {children}
-    </button>
-  );
-}
-
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 1 — CyberFoundations (Lesson)
-// ═══════════════════════════════════════════════════════════════════════════
-
-const CYBER_SLIDES = [
-  {
-    title: "What is Cybersecurity?",
-    body: "Cybersecurity is the practice of protecting systems, networks, and data from digital attacks. Every device connected to the internet is a potential target — and defending them is a growing global priority.",
-  },
-  {
-    title: "Why It Matters",
-    body: "Data breaches cost businesses an average of $4.45 million per incident (IBM Cost of a Data Breach Report, 2023). Personal data — passwords, financial info, medical records — is constantly at risk. Critical infrastructure like power grids and hospitals depends on strong cyber defense.",
-  },
-  {
-    title: "Real Breaches",
-    body: "In 2017, a single breach exposed the personal data of 147 million people — names, Social Security numbers, birth dates. In 2020, a ransomware attack shut down a major hospital network, diverting emergency patients and delaying care for days. Real incidents like these are why every organization now treats cybersecurity as a business risk, not just an IT problem.",
-  },
-  {
-    title: "Who Works in Cyber?",
-    roles: [
-      { name: "Security Analyst", desc: "Monitors networks for threats and investigates alerts", pay: "$75K–$110K" },
-      { name: "Penetration Tester", desc: "Legally hacks systems to find vulnerabilities before attackers do", pay: "$85K–$130K" },
-      { name: "Incident Responder", desc: "Investigates breaches and leads the recovery effort", pay: "$70K–$105K" },
-      { name: "Security Engineer", desc: "Designs and builds security architecture and tools", pay: "$95K–$145K" },
-      { name: "GRC Analyst", desc: "Manages governance, risk, and compliance frameworks", pay: "$65K–$100K" },
-      { name: "Digital Forensics", desc: "Recovers evidence from devices after breaches and crimes", pay: "$75K–$120K" },
-      { name: "Security Architect", desc: "Designs the overall security strategy for an organization", pay: "$120K–$180K" },
-      { name: "CISO", desc: "Chief Information Security Officer — leads the entire security program", pay: "$150K–$250K" },
-    ],
-  },
-  {
-    title: "Many Ways In",
-    body: "You don't need a four-year degree to start a cyber career. People enter the field through bootcamps, free industry certifications (CompTIA Security+, ISC2 Certified in Cybersecurity), military service, IT help desk roles, and self-study with home labs. Employers care about what you can do, not just what's on your diploma.",
-  },
-  {
-    title: "The Opportunity",
-    body: "The U.S. had roughly 470,000 unfilled cybersecurity job openings as of mid-2024 (NIST CyberSeek). The U.S. Bureau of Labor Statistics projects Information Security Analyst employment to grow about 33% from 2023 to 2033 — much faster than the average for all occupations. The field rewards curiosity, problem-solving, and persistence over any single background.",
-  },
-];
-
-const CYBER_SOURCES = [
-  { label: "NIST CyberSeek (job market data)", url: "https://www.cyberseek.org/" },
-  { label: "BLS Information Security Analysts", url: "https://www.bls.gov/ooh/computer-and-information-technology/information-security-analysts.htm" },
-  { label: "ISC2 Certified in Cybersecurity (CC)", url: "https://www.isc2.org/Certifications/CC" },
-  { label: "CompTIA Security+", url: "https://www.comptia.org/certifications/security" },
-  { label: "NIST Cybersecurity Framework", url: "https://www.nist.gov/cyberframework" },
-];
-
-const CYBER_QUIZ = [
+const FOUNDATIONS_QUIZ: QuizQuestion[] = [
   {
     q: "What does cybersecurity protect?",
     opts: ["Only passwords", "Systems, networks, and data", "Just websites", "Hardware only"],
     ans: 1,
   },
   {
-    q: "Why is demand for cyber workers growing?",
+    q: "Which four properties does cybersecurity try to keep true?",
+    opts: [
+      "Speed, Storage, Bandwidth, Latency",
+      "Confidentiality, Integrity, Availability, Authentication",
+      "Encryption, Backup, Logging, Monitoring",
+      "Firewall, Antivirus, VPN, MFA",
+    ],
+    ans: 1,
+  },
+  {
+    q: "Why is the cyber workforce growing so quickly?",
     opts: [
       "Companies are reducing tech budgets",
       "Attacks are decreasing",
@@ -181,1565 +140,298 @@ const CYBER_QUIZ = [
     ans: 2,
   },
   {
-    q: "Which role investigates breaches?",
-    opts: ["GRC Analyst", "CISO", "Incident Responder", "Penetration Tester"],
-    ans: 2,
-  },
-];
-
-export function CyberFoundations({ onComplete, onBack }: ModuleProps) {
-  const { t } = useTranslation();
-  const [step, setStep] = useState(0);
-  const [quizIdx, setQuizIdx] = useState(0);
-  const [quizScore, setQuizScore] = useState(0);
-  const [selected, setSelected] = useState<number | null>(null);
-  const [answered, setAnswered] = useState(false);
-
-  // Read translated slide/role/quiz content via i18n with TS fallbacks.
-  const slides = t("pathways.modules.foundations.slides", { returnObjects: true }) as Array<{ title: string; body?: string }>;
-  const roles = t("pathways.modules.foundations.roles", { returnObjects: true }) as Array<{ name: string; desc: string; pay: string }>;
-  const quizItems = t("pathways.modules.foundations.quiz", { returnObjects: true }) as Array<{ q: string; opts: string[] }>;
-
-  const totalSlides = CYBER_SLIDES.length;
-  const inQuiz = step >= totalSlides;
-  const totalSteps = totalSlides + CYBER_QUIZ.length;
-
-  const handleAnswer = (idx: number) => {
-    if (answered) return;
-    setSelected(idx);
-    setAnswered(true);
-    if (idx === CYBER_QUIZ[quizIdx].ans) {
-      setQuizScore((s) => s + 1);
-    }
-  };
-
-  const handleNext = () => {
-    if (!inQuiz) {
-      setStep((s) => s + 1);
-    } else if (quizIdx < CYBER_QUIZ.length - 1) {
-      setQuizIdx((q) => q + 1);
-      setSelected(null);
-      setAnswered(false);
-      setStep((s) => s + 1);
-    } else {
-      const score = Math.round((quizScore / CYBER_QUIZ.length) * 100);
-      onComplete(score);
-    }
-  };
-
-  const currentStep = step + 1;
-  const englishSlide = !inQuiz ? CYBER_SLIDES[step] : null;
-  const localizedSlide = !inQuiz ? slides?.[step] : null;
-  const englishQuiz = inQuiz ? CYBER_QUIZ[quizIdx] : null;
-  const localizedQuiz = inQuiz ? quizItems?.[quizIdx] : null;
-
-  const slideTitle = localizedSlide?.title ?? englishSlide?.title ?? "";
-  const slideBody = localizedSlide?.body ?? (englishSlide && "body" in englishSlide ? englishSlide.body : "");
-  const slideHasRoles = englishSlide && "roles" in englishSlide && Array.isArray(englishSlide.roles);
-
-  return (
-    <ModuleShell title={t("pathways.modules.foundations.title")} step={currentStep} totalSteps={totalSteps} onBack={onBack}>
-      {englishSlide && !slideHasRoles && (
-        <Card className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-700 dark:text-indigo-300">{slideTitle}</h2>
-          <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">{slideBody}</p>
-        </Card>
-      )}
-
-      {englishSlide && slideHasRoles && (
-        <div className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-700 dark:text-indigo-300">{slideTitle}</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {englishSlide.roles!.map((r, i) => {
-              const lr = roles?.[i] ?? r;
-              return (
-                <Card key={r.name} className="space-y-1">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{lr.name}</p>
-                  <p className="text-xs text-slate-700 dark:text-slate-400">{lr.desc}</p>
-                  <p className="text-xs text-teal-700 dark:text-teal-400 font-medium">{lr.pay}</p>
-                </Card>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {englishQuiz && (
-        <div className="mt-4 space-y-4">
-          <Card className="space-y-1">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">
-              {t("pathways.common.knowledgeCheck")}
-            </p>
-            <p className="text-sm font-medium text-slate-900 dark:text-white">
-              {localizedQuiz?.q ?? englishQuiz.q}
-            </p>
-          </Card>
-          <div className="space-y-2">
-            {englishQuiz.opts.map((opt, i) => {
-              let border = "border-slate-200 dark:border-slate-200 dark:border-slate-700";
-              if (answered && i === englishQuiz.ans) border = "border-teal-500";
-              else if (answered && i === selected && i !== englishQuiz.ans) border = "border-red-500";
-              return (
-                <button
-                  key={i}
-                  onClick={() => handleAnswer(i)}
-                  disabled={answered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-white dark:bg-slate-800 text-sm text-slate-800 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-300 dark:disabled:hover:border-slate-200 dark:border-slate-700 transition-colors ${
-                    selected === i ? "ring-1 ring-indigo-500" : ""
-                  }`}
-                >
-                  {localizedQuiz?.opts?.[i] ?? opt}
-                </button>
-              );
-            })}
-          </div>
-          {answered && (
-            <p className="text-xs text-slate-700 dark:text-slate-400">
-              {selected === englishQuiz.ans
-                ? t("pathways.common.correct")
-                : t("pathways.common.incorrect", { answer: localizedQuiz?.opts?.[englishQuiz.ans] ?? englishQuiz.opts[englishQuiz.ans] })}
-            </p>
-          )}
-        </div>
-      )}
-
-      <div className="flex justify-end mt-6">
-        {!inQuiz && (
-          <PrimaryButton onClick={handleNext}>
-            {step < totalSlides - 1 ? t("pathways.common.next") : t("pathways.common.startQuiz")}
-          </PrimaryButton>
-        )}
-        {inQuiz && answered && (
-          <PrimaryButton onClick={handleNext}>
-            {quizIdx < CYBER_QUIZ.length - 1 ? t("pathways.common.nextQuestion") : t("pathways.common.finish")}
-          </PrimaryButton>
-        )}
-      </div>
-
-      {/* Sources — visible on every slide so claims are verifiable */}
-      <details className="mt-8 group">
-        <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 select-none">
-          {t("pathways.common.sourcesHeading")}
-        </summary>
-        <ul className="mt-2 space-y-1 pl-3 border-l border-slate-200 dark:border-slate-200 dark:border-slate-700">
-          {CYBER_SOURCES.map((s) => (
-            <li key={s.url} className="text-xs text-slate-700 dark:text-slate-400">
-              <a
-                href={s.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-indigo-700 dark:hover:text-indigo-700 dark:text-indigo-300 hover:underline"
-              >
-                {s.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-        <p className="text-[10px] text-slate-500 dark:text-slate-600 mt-2 pl-3">
-          {t("pathways.modules.foundations.sourcesDisclaimer")}
-        </p>
-      </details>
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 2 — DigitalSafetySim (Activity)
-// ═══════════════════════════════════════════════════════════════════════════
-
-interface Email {
-  from: string;
-  subject: string;
-  body: string;
-  isPhish: boolean;
-  flags?: string[];
-}
-
-const PHISH_EMAILS: Email[] = [
-  {
-    from: "support@amaz0n-security.net",
-    subject: "URGENT: Your account will be suspended!",
-    body: "Dear Customer, We detected unusual activity. Click here immediately to verify your identity or your account will be permanently locked within 24 hours.",
-    isPhish: true,
-    flags: ["Sender domain mismatch (amaz0n-security.net)", "Urgency/pressure tactics", "Suspicious link request"],
-  },
-  {
-    from: "noreply@school.edu",
-    subject: "Schedule change for next week",
-    body: "Hi, your Tuesday class has been moved to Room 204. Please check the updated schedule on the school portal.",
-    isPhish: false,
-  },
-  {
-    from: "hr@your-company.com",
-    subject: "Updated PTO policy",
-    body: "Team, we've updated our PTO policy for the new year. Please review the attached document on the HR portal at your convenience.",
-    isPhish: false,
-  },
-];
-
-const PASSWORDS = [
-  { pw: "password123", correct: "weak" },
-  { pw: "Tr0ub4dor&3", correct: "strong" },
-  { pw: "qwerty", correct: "weak" },
-  { pw: "k9$Lm#vR2xQ!", correct: "strong" },
-];
-
-const WIFI_ACTIONS = [
-  { action: "Online banking", safe: false },
-  { action: "Browsing news", safe: true },
-  { action: "Using a VPN", safe: true },
-  { action: "Logging into email without VPN", safe: false },
-];
-
-const BREACH_STEPS = [
-  "Change your password immediately",
-  "Enable two-factor authentication",
-  "Check if other accounts use the same password",
-  "Monitor accounts for suspicious activity",
-];
-
-export function DigitalSafetySim({ onComplete, onBack }: ModuleProps) {
-  const [step, setStep] = useState(0);
-  const [score, setScore] = useState(0);
-
-  // Scenario 1: Phishing
-  const [phishSelected, setPhishSelected] = useState<number | null>(null);
-  const [phishSubmitted, setPhishSubmitted] = useState(false);
-  const [flagsFound, setFlagsFound] = useState<Set<number>>(new Set());
-
-  // Scenario 2: Passwords
-  const [pwRatings, setPwRatings] = useState<Record<number, string>>({});
-  const [pwSubmitted, setPwSubmitted] = useState(false);
-
-  // Scenario 3: Social engineering
-  const [seChoice, setSeChoice] = useState<string | null>(null);
-
-  // Scenario 4: Wi-Fi
-  const [wifiRatings, setWifiRatings] = useState<Record<number, boolean>>({});
-  const [wifiSubmitted, setWifiSubmitted] = useState(false);
-
-  // Scenario 5: Breach response
-  const [breachOrder, setBreachOrder] = useState<number[]>([]);
-  const [breachSubmitted, setBreachSubmitted] = useState(false);
-
-  const totalSteps = 5;
-
-  const handlePhishSubmit = () => {
-    setPhishSubmitted(true);
-    let pts = 0;
-    if (phishSelected === 0) pts += 10; // correctly identified phishing email
-    pts += Math.min(flagsFound.size, 3) * 5; // up to 15 for flags
-    setScore((s) => s + pts);
-  };
-
-  const handlePwSubmit = () => {
-    setPwSubmitted(true);
-    let pts = 0;
-    PASSWORDS.forEach((p, i) => {
-      const rating = pwRatings[i];
-      if (
-        (p.correct === "weak" && rating === "weak") ||
-        (p.correct === "strong" && rating === "strong")
-      ) {
-        pts += 5;
-      }
-    });
-    setScore((s) => s + pts);
-  };
-
-  const handleSeChoice = (choice: string) => {
-    setSeChoice(choice);
-    if (choice === "verify") {
-      setScore((s) => s + 20);
-    }
-  };
-
-  const handleWifiSubmit = () => {
-    setWifiSubmitted(true);
-    let pts = 0;
-    WIFI_ACTIONS.forEach((a, i) => {
-      if (wifiRatings[i] === a.safe) pts += 5;
-    });
-    setScore((s) => s + pts);
-  };
-
-  const handleBreachSubmit = () => {
-    setBreachSubmitted(true);
-    let pts = 0;
-    breachOrder.forEach((val, idx) => {
-      if (val === idx) pts += 5;
-    });
-    setScore((s) => s + pts);
-  };
-
-  const toggleBreachItem = (idx: number) => {
-    if (breachSubmitted) return;
-    if (breachOrder.includes(idx)) {
-      setBreachOrder(breachOrder.filter((i) => i !== idx));
-    } else {
-      setBreachOrder([...breachOrder, idx]);
-    }
-  };
-
-  const canAdvance = () => {
-    switch (step) {
-      case 0: return phishSubmitted;
-      case 1: return pwSubmitted;
-      case 2: return seChoice !== null;
-      case 3: return wifiSubmitted;
-      case 4: return breachSubmitted;
-      default: return false;
-    }
-  };
-
-  const handleNext = () => {
-    if (step < totalSteps - 1) {
-      setStep((s) => s + 1);
-    } else {
-      onComplete(Math.min(score, 100));
-    }
-  };
-
-  return (
-    <ModuleShell title="Digital Safety Sim" step={step + 1} totalSteps={totalSteps} onBack={onBack}>
-      {/* Scenario 1: Phishing */}
-      {step === 0 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">Identify the phishing email, then tap the red flags.</p>
-          <div className="space-y-3">
-            {PHISH_EMAILS.map((email, i) => (
-              <Card
-                key={i}
-                onClick={() => !phishSubmitted && setPhishSelected(i)}
-                selected={phishSelected === i}
-                className="space-y-1"
-              >
-                <div className="flex justify-between">
-                  <p className="text-xs text-slate-500">From: {email.from}</p>
-                  {phishSubmitted && email.isPhish && (
-                    <span className="text-xs text-red-700 dark:text-red-400 font-medium">PHISHING</span>
-                  )}
-                </div>
-                <p className="text-sm font-medium">{email.subject}</p>
-                <p className="text-xs text-slate-600 dark:text-slate-400">{email.body}</p>
-              </Card>
-            ))}
-          </div>
-
-          {phishSelected === 0 && !phishSubmitted && (
-            <div className="space-y-2">
-              <p className="text-xs text-slate-500">Tap the red flags in this email:</p>
-              {PHISH_EMAILS[0].flags!.map((flag, i) => (
-                <button
-                  key={i}
-                  onClick={() => {
-                    const next = new Set(flagsFound);
-                    if (next.has(i)) next.delete(i);
-                    else next.add(i);
-                    setFlagsFound(next);
-                  }}
-                  className={`w-full text-left p-2 rounded-lg border text-xs transition-colors ${
-                    flagsFound.has(i)
-                      ? "border-red-500 bg-red-900/20 text-red-300"
-                      : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400"
-                  }`}
-                >
-                  {flag}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {!phishSubmitted && phishSelected !== null && (
-            <PrimaryButton onClick={handlePhishSubmit}>Submit</PrimaryButton>
-          )}
-          {phishSubmitted && (
-            <p className="text-xs text-teal-700 dark:text-teal-400">
-              {phishSelected === 0 ? "Correct! You spotted the phishing email." : "Not quite — the first email was the phishing attempt."}
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Scenario 2: Passwords */}
-      {step === 1 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">Rate each password as weak or strong.</p>
-          <div className="space-y-3">
-            {PASSWORDS.map((p, i) => (
-              <Card key={i} className="flex items-center justify-between">
-                <code className="text-sm text-slate-700 dark:text-slate-300 font-mono">{p.pw}</code>
-                <div className="flex gap-2">
-                  {["weak", "strong"].map((rating) => (
-                    <button
-                      key={rating}
-                      onClick={() => !pwSubmitted && setPwRatings({ ...pwRatings, [i]: rating })}
-                      disabled={pwSubmitted}
-                      className={`px-3 py-1 text-xs rounded-lg border transition-colors ${
-                        pwRatings[i] === rating
-                          ? rating === "weak"
-                            ? "border-red-500 bg-red-900/30 text-red-300"
-                            : "border-teal-500 bg-teal-900/30 text-teal-300"
-                          : "border-slate-600 text-slate-500 hover:border-slate-400"
-                      }`}
-                    >
-                      {rating}
-                    </button>
-                  ))}
-                </div>
-              </Card>
-            ))}
-          </div>
-          {!pwSubmitted && Object.keys(pwRatings).length === 4 && (
-            <PrimaryButton onClick={handlePwSubmit}>Submit</PrimaryButton>
-          )}
-          {pwSubmitted && (
-            <div className="text-xs text-teal-700 dark:text-teal-400 space-y-1">
-              <p>Modern NIST guidance (SP 800-63B): length beats complexity. A long passphrase like four random words is stronger than a short scramble — and you don't have to rotate passwords on a schedule if they aren't compromised.</p>
-              <p className="text-slate-500">A password manager lets you use a unique, long password for every account without memorizing them.</p>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Scenario 3: Social Engineering */}
-      {step === 2 && (
-        <div className="space-y-4 mt-4">
-          <Card className="space-y-2">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">Incoming Call</p>
-            <p className="text-sm text-slate-700 dark:text-slate-300">
-              "Hi, this is Mike from IT Support. We detected suspicious activity on your account. I need your password to reset it right now, or your account could be compromised."
-            </p>
-          </Card>
-          <p className="text-sm text-slate-600 dark:text-slate-400">What do you do?</p>
-          <div className="grid grid-cols-2 gap-3">
-            <Card
-              onClick={() => !seChoice && handleSeChoice("comply")}
-              selected={seChoice === "comply"}
-              className={seChoice === "comply" ? "border-red-500 bg-red-900/20" : ""}
-            >
-              <p className="text-sm font-medium">Give the password</p>
-              <p className="text-xs text-slate-500">They said it's urgent</p>
-            </Card>
-            <Card
-              onClick={() => !seChoice && handleSeChoice("verify")}
-              selected={seChoice === "verify"}
-              className={seChoice === "verify" ? "border-teal-500 bg-teal-900/20" : ""}
-            >
-              <p className="text-sm font-medium">Hang up and verify</p>
-              <p className="text-xs text-slate-500">Call IT directly</p>
-            </Card>
-          </div>
-          {seChoice && (
-            <p className={`text-xs ${seChoice === "verify" ? "text-teal-400" : "text-red-400"}`}>
-              {seChoice === "verify"
-                ? "Correct. Always verify through official channels. Legitimate IT will never ask for your password."
-                : "Careful — legitimate IT staff will never ask for your password over the phone. Always verify independently."}
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Scenario 4: Public Wi-Fi */}
-      {step === 3 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">You're on public Wi-Fi. Mark each action as safe or unsafe.</p>
-          <div className="space-y-3">
-            {WIFI_ACTIONS.map((a, i) => (
-              <Card key={i} className="flex items-center justify-between">
-                <p className="text-sm text-slate-700 dark:text-slate-300">{a.action}</p>
-                <div className="flex gap-2">
-                  {[true, false].map((val) => (
-                    <button
-                      key={String(val)}
-                      onClick={() => !wifiSubmitted && setWifiRatings({ ...wifiRatings, [i]: val })}
-                      disabled={wifiSubmitted}
-                      className={`px-3 py-1 text-xs rounded-lg border transition-colors ${
-                        wifiRatings[i] === val
-                          ? val
-                            ? "border-teal-500 bg-teal-900/30 text-teal-300"
-                            : "border-red-500 bg-red-900/30 text-red-300"
-                          : "border-slate-600 text-slate-500 hover:border-slate-400"
-                      }`}
-                    >
-                      {val ? "Safe" : "Unsafe"}
-                    </button>
-                  ))}
-                </div>
-              </Card>
-            ))}
-          </div>
-          {!wifiSubmitted && Object.keys(wifiRatings).length === 4 && (
-            <PrimaryButton onClick={handleWifiSubmit}>Submit</PrimaryButton>
-          )}
-          {wifiSubmitted && (
-            <p className="text-xs text-teal-700 dark:text-teal-400">
-              On public Wi-Fi: use a VPN, avoid banking and unencrypted logins.
-            </p>
-          )}
-        </div>
-      )}
-
-      {/* Scenario 5: Breach Response */}
-      {step === 4 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            Your email was in a data breach. Order the response steps (tap in order):
-          </p>
-          <div className="space-y-2">
-            {BREACH_STEPS.map((s, i) => {
-              const orderIdx = breachOrder.indexOf(i);
-              return (
-                <button
-                  key={i}
-                  onClick={() => toggleBreachItem(i)}
-                  className={`w-full text-left p-3 rounded-lg border text-sm transition-colors flex items-center gap-3 ${
-                    orderIdx >= 0
-                      ? "border-indigo-500 bg-indigo-900/20 text-slate-900 dark:text-white"
-                      : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-slate-500"
-                  }`}
-                >
-                  <span
-                    className={`w-6 h-6 rounded flex items-center justify-center text-xs font-bold ${
-                      orderIdx >= 0 ? "bg-indigo-600 text-white" : "bg-slate-700 text-slate-500"
-                    }`}
-                  >
-                    {orderIdx >= 0 ? orderIdx + 1 : "-"}
-                  </span>
-                  {s}
-                </button>
-              );
-            })}
-          </div>
-          {!breachSubmitted && breachOrder.length === 4 && (
-            <PrimaryButton onClick={handleBreachSubmit}>Submit</PrimaryButton>
-          )}
-          {breachSubmitted && (
-            <p className="text-xs text-teal-700 dark:text-teal-400">
-              The ideal order: change password, enable 2FA, check other accounts, then monitor.
-            </p>
-          )}
-        </div>
-      )}
-
-      {canAdvance() && (
-        <div className="flex justify-end mt-6">
-          <PrimaryButton onClick={handleNext}>
-            {step < totalSteps - 1 ? "Next Scenario" : "Finish"}
-          </PrimaryButton>
-        </div>
-      )}
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 3 — NetworkBasics (Lesson)
-// ═══════════════════════════════════════════════════════════════════════════
-
-const NET_SLIDES = [
-  {
-    title: "What happens when you load a webpage?",
-    body: "1. You type a URL. 2. Your browser asks a DNS server for the IP address. 3. Your device sends a request to that IP. 4. The server processes the request and sends back data. 5. Your browser assembles and renders the page. All of this happens in milliseconds.",
-  },
-  {
-    title: "Packets & Protocols",
-    body: "Data doesn't travel as one big file — it's broken into small packets, like letters in the mail. Each packet has a destination address, a return address, and a piece of the message. Protocols (TCP/IP) are the rules that ensure every packet arrives and gets reassembled correctly.",
-  },
-  {
-    title: "IP, DNS, HTTP",
-    body: "IP addresses are like street addresses — every device has one. DNS is the phone book that translates domain names (google.com) into IP addresses. HTTP is the language browsers and servers use to talk — HTTPS adds encryption so no one can eavesdrop.",
-  },
-  {
-    title: "Firewalls & Security",
-    body: "A firewall is the bouncer at the door. It inspects incoming and outgoing traffic and blocks anything that doesn't match the rules. Firewalls can be hardware, software, or cloud-based — and they're one of the first lines of defense in any network.",
-  },
-];
-
-const TRACE_NODES = [
-  { label: "Your Device", id: 0 },
-  { label: "DNS Server", id: 1 },
-  { label: "Web Server", id: 2 },
-  { label: "Firewall", id: 3 },
-  { label: "Your Device (Response)", id: 4 },
-];
-
-const NET_QUIZ = [
-  {
-    q: "What does DNS do?",
-    opts: ["Encrypts data", "Translates domain names to IP addresses", "Blocks malware", "Compresses files"],
-    ans: 1,
-  },
-  {
-    q: "What is a packet?",
-    opts: ["A type of virus", "A small piece of data sent over a network", "A firewall rule", "An email attachment"],
-    ans: 1,
-  },
-  {
-    q: "What does a firewall do?",
+    q: "Which is the most accessible starting credential for someone 16+ with no prior experience?",
     opts: [
-      "Speeds up your internet",
-      "Stores passwords",
-      "Inspects and filters network traffic",
-      "Translates domain names",
+      "CISSP",
+      "OSCP",
+      "ISC2 Certified in Cybersecurity (CC)",
+      "GIAC Security Expert",
     ],
     ans: 2,
   },
 ];
 
-export function NetworkBasics({ onComplete, onBack }: ModuleProps) {
-  const [step, setStep] = useState(0);
-  const [traceClicked, setTraceClicked] = useState<number[]>([]);
-  const [traceSubmitted, setTraceSubmitted] = useState(false);
-  const [quizIdx, setQuizIdx] = useState(0);
-  const [quizScore, setQuizScore] = useState(0);
-  const [selected, setSelected] = useState<number | null>(null);
-  const [answered, setAnswered] = useState(false);
-
-  const slideCount = NET_SLIDES.length;
-  const traceStep = slideCount;
-  const quizStart = traceStep + 1;
-  const totalSteps = quizStart + NET_QUIZ.length;
-  const currentStep = step + 1;
-
-  const inSlides = step < slideCount;
-  const inTrace = step === traceStep;
-  const inQuiz = step >= quizStart;
-
-  const handleTraceClick = (id: number) => {
-    if (traceSubmitted) return;
-    if (traceClicked.includes(id)) {
-      setTraceClicked(traceClicked.filter((x) => x !== id));
-    } else {
-      setTraceClicked([...traceClicked, id]);
-    }
-  };
-
-  const handleTraceSubmit = () => {
-    setTraceSubmitted(true);
-    // Correct order: 0,1,2,3,4
-    let pts = 0;
-    traceClicked.forEach((id, idx) => {
-      if (id === idx) pts++;
-    });
-    if (pts === 5) setQuizScore((s) => s + 1); // bonus point
-  };
-
-  const handleAnswer = (idx: number) => {
-    if (answered) return;
-    setSelected(idx);
-    setAnswered(true);
-    if (idx === NET_QUIZ[quizIdx].ans) setQuizScore((s) => s + 1);
-  };
-
-  const handleNext = () => {
-    if (inSlides || (inTrace && traceSubmitted)) {
-      setStep((s) => s + 1);
-      if (step + 1 === quizStart) {
-        setSelected(null);
-        setAnswered(false);
-      }
-    } else if (inQuiz && answered) {
-      if (quizIdx < NET_QUIZ.length - 1) {
-        setQuizIdx((q) => q + 1);
-        setSelected(null);
-        setAnswered(false);
-        setStep((s) => s + 1);
-      } else {
-        // total possible: 1 (trace) + 3 (quiz) = 4
-        const score = Math.round((quizScore / 4) * 100);
-        onComplete(score);
-      }
-    }
-  };
-
-  const canNext =
-    (inSlides) ||
-    (inTrace && traceSubmitted) ||
-    (inQuiz && answered);
-
-  return (
-    <ModuleShell title="Network Basics" step={currentStep} totalSteps={totalSteps} onBack={onBack}>
-      {inSlides && (
-        <Card className="mt-4 space-y-3">
-          <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-300">{NET_SLIDES[step].title}</h2>
-          <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-line">{NET_SLIDES[step].body}</p>
-        </Card>
-      )}
-
-      {inTrace && (
-        <div className="mt-4 space-y-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            Trace the packet: click the network nodes in the correct order.
-          </p>
-          <div className="flex flex-wrap gap-3 justify-center">
-            {/* Shuffle display order */}
-            {[3, 0, 4, 1, 2].map((id) => {
-              const node = TRACE_NODES[id];
-              const orderIdx = traceClicked.indexOf(id);
-              let borderColor = "border-slate-200 dark:border-slate-700";
-              if (traceSubmitted) {
-                const correctPos = traceClicked.indexOf(id);
-                borderColor = correctPos === id ? "border-teal-500" : "border-red-500";
-                if (orderIdx < 0) borderColor = "border-red-500";
-              }
-              return (
-                <button
-                  key={id}
-                  onClick={() => handleTraceClick(id)}
-                  className={`px-4 py-3 rounded-lg border ${borderColor} bg-white dark:bg-slate-800 text-sm transition-colors hover:border-indigo-400 flex items-center gap-2`}
-                >
-                  {orderIdx >= 0 && (
-                    <span className="w-5 h-5 rounded bg-indigo-600 text-white text-xs flex items-center justify-center font-bold">
-                      {orderIdx + 1}
-                    </span>
-                  )}
-                  {node.label}
-                </button>
-              );
-            })}
-          </div>
-          {!traceSubmitted && traceClicked.length === 5 && (
-            <PrimaryButton onClick={handleTraceSubmit}>Check Order</PrimaryButton>
-          )}
-          {traceSubmitted && (
-            <p className="text-xs text-teal-700 dark:text-teal-400">
-              Correct path: Your Device &rarr; DNS Server &rarr; Web Server &rarr; Firewall &rarr; Your Device (Response)
-            </p>
-          )}
-        </div>
-      )}
-
-      {inQuiz && (
-        <div className="mt-4 space-y-4">
-          <Card className="space-y-1">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">Knowledge Check</p>
-            <p className="text-sm font-medium text-slate-900 dark:text-white">{NET_QUIZ[quizIdx].q}</p>
-          </Card>
-          <div className="space-y-2">
-            {NET_QUIZ[quizIdx].opts.map((opt, i) => {
-              let border = "border-slate-200 dark:border-slate-700";
-              if (answered && i === NET_QUIZ[quizIdx].ans) border = "border-teal-500";
-              else if (answered && i === selected) border = "border-red-500";
-              return (
-                <button
-                  key={i}
-                  onClick={() => handleAnswer(i)}
-                  disabled={answered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-slate-800 text-sm text-slate-700 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-200 dark:border-slate-700 transition-colors`}
-                >
-                  {opt}
-                </button>
-              );
-            })}
-          </div>
-          {answered && (
-            <p className="text-xs text-slate-600 dark:text-slate-400">
-              {selected === NET_QUIZ[quizIdx].ans ? "Correct." : `Incorrect. Answer: ${NET_QUIZ[quizIdx].opts[NET_QUIZ[quizIdx].ans]}`}
-            </p>
-          )}
-        </div>
-      )}
-
-      {canNext && (
-        <div className="flex justify-end mt-6">
-          <PrimaryButton onClick={handleNext}>
-            {inSlides && step < slideCount - 1
-              ? "Next"
-              : inSlides
-                ? "Start Activity"
-                : inTrace
-                  ? "Continue"
-                  : quizIdx < NET_QUIZ.length - 1
-                    ? "Next Question"
-                    : "Finish"}
-          </PrimaryButton>
-        </div>
-      )}
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 4 — ThreatDetective (Activity)
-// ═══════════════════════════════════════════════════════════════════════════
-
-interface LogEntry {
-  time: string;
-  ip: string;
-  action: string;
-  suspicious: boolean;
-}
-
-const LOG_ENTRIES: LogEntry[] = [
-  { time: "02:14:33", ip: "192.168.1.10", action: "User login — admin portal", suspicious: false },
-  { time: "02:14:35", ip: "10.0.0.45", action: "Failed login attempt (1 of 500)", suspicious: true },
-  { time: "02:14:36", ip: "10.0.0.45", action: "Failed login attempt (2 of 500)", suspicious: true },
-  { time: "02:15:01", ip: "192.168.1.22", action: "File download — Q4_report.pdf", suspicious: false },
-  { time: "02:15:12", ip: "10.0.0.45", action: "Successful login after 500 attempts", suspicious: true },
-  { time: "02:16:00", ip: "192.168.1.10", action: "User logout — admin portal", suspicious: false },
+const SAFETY_QUIZ: QuizQuestion[] = [
+  {
+    q: "Most successful attacks start with…",
+    opts: ["A zero-day exploit", "Brute-forcing a server", "A person clicking a link or handing over credentials", "Physical theft"],
+    ans: 2,
+  },
+  {
+    q: "According to current NIST guidance, what matters most for password strength?",
+    opts: ["Special characters", "Frequent rotation", "Length and uniqueness", "Capital letters"],
+    ans: 2,
+  },
+  {
+    q: "Your phone keeps getting MFA push prompts at 2 AM that you didn't trigger. What do you do?",
+    opts: [
+      "Tap Approve so they stop",
+      "Ignore them and go back to sleep",
+      "Deny each one and change your password from a clean device",
+      "Turn off MFA temporarily",
+    ],
+    ans: 2,
+  },
+  {
+    q: "Why is verifying out-of-band important?",
+    opts: [
+      "It speeds up the response",
+      "It bypasses an attacker who controls the channel that contacted you",
+      "It logs the interaction",
+      "It encrypts the conversation",
+    ],
+    ans: 1,
+  },
 ];
 
-const LOG_QUESTIONS = [
+const NETWORK_QUIZ: QuizQuestion[] = [
   {
-    q: "What time did the attack begin?",
-    opts: ["02:14:33", "02:14:35", "02:15:01", "02:16:00"],
+    q: "What is the role of DNS?",
+    opts: [
+      "Encrypts traffic between two endpoints",
+      "Translates domain names into IP addresses",
+      "Filters malicious packets",
+      "Stores user passwords",
+    ],
     ans: 1,
   },
   {
-    q: "Which IP address is the attacker?",
-    opts: ["192.168.1.10", "192.168.1.22", "10.0.0.45", "127.0.0.1"],
+    q: "What does the 'S' in HTTPS add?",
+    opts: ["Speed", "Storage", "Security via TLS encryption", "A subdomain"],
     ans: 2,
   },
   {
-    q: "What type of attack is this?",
-    opts: ["Phishing", "DDoS", "Brute force", "Insider threat"],
+    q: "On an open public WiFi network, which traffic is most at risk?",
+    opts: [
+      "HTTPS-encrypted traffic",
+      "Traffic from a connected VPN",
+      "Plain HTTP traffic that another device on the network can see",
+      "Traffic going over cellular data",
+    ],
     ans: 2,
   },
-];
-
-const SEVERITY_OPTS = ["Low", "Medium", "High", "Critical"];
-const TYPE_OPTS = ["Phishing", "Brute Force", "DDoS", "Insider Threat", "Malware"];
-const ACTION_OPTS = ["Monitor only", "Block IP and reset passwords", "Shut down server", "Notify law enforcement"];
-
-export function ThreatDetective({ onComplete, onBack }: ModuleProps) {
-  const [phase, setPhase] = useState(0); // 0=logs, 1=questions, 2=report
-  const [selectedLogs, setSelectedLogs] = useState<Set<number>>(new Set());
-  const [logsSubmitted, setLogsSubmitted] = useState(false);
-  const [score, setScore] = useState(0);
-
-  const [qIdx, setQIdx] = useState(0);
-  const [qSelected, setQSelected] = useState<number | null>(null);
-  const [qAnswered, setQAnswered] = useState(false);
-
-  const [severity, setSeverity] = useState("");
-  const [attackType, setAttackType] = useState("");
-  const [recAction, setRecAction] = useState("");
-  const [summary, setSummary] = useState("");
-
-  const totalSteps = 3;
-
-  const toggleLog = (idx: number) => {
-    if (logsSubmitted) return;
-    const next = new Set(selectedLogs);
-    if (next.has(idx)) next.delete(idx);
-    else next.add(idx);
-    setSelectedLogs(next);
-  };
-
-  const submitLogs = () => {
-    setLogsSubmitted(true);
-    let pts = 0;
-    LOG_ENTRIES.forEach((entry, i) => {
-      if (entry.suspicious && selectedLogs.has(i)) pts += 10;
-      if (!entry.suspicious && selectedLogs.has(i)) pts -= 5;
-    });
-    setScore((s) => s + Math.max(0, pts));
-  };
-
-  const handleAnswer = (idx: number) => {
-    if (qAnswered) return;
-    setQSelected(idx);
-    setQAnswered(true);
-    if (idx === LOG_QUESTIONS[qIdx].ans) setScore((s) => s + 10);
-  };
-
-  const submitReport = () => {
-    let pts = 0;
-    if (severity === "High" || severity === "Critical") pts += 5;
-    if (attackType === "Brute Force") pts += 10;
-    if (recAction === "Block IP and reset passwords") pts += 10;
-    if (summary.trim().length >= 20) pts += 5;
-    setScore((s) => s + pts);
-    onComplete(Math.min(score + pts, 100));
-  };
-
-  const nextQuestion = () => {
-    if (qIdx < LOG_QUESTIONS.length - 1) {
-      setQIdx((q) => q + 1);
-      setQSelected(null);
-      setQAnswered(false);
-    } else {
-      setPhase(2);
-    }
-  };
-
-  return (
-    <ModuleShell title="Threat Detective" step={phase + 1} totalSteps={totalSteps} onBack={onBack}>
-      {/* Phase 1: Log Analysis */}
-      {phase === 0 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">Review the server logs. Select the suspicious entries.</p>
-          <div className="space-y-2">
-            {LOG_ENTRIES.map((entry, i) => (
-              <button
-                key={i}
-                onClick={() => toggleLog(i)}
-                className={`w-full text-left p-3 rounded-lg border text-xs font-mono transition-colors ${
-                  selectedLogs.has(i)
-                    ? "border-red-500 bg-red-900/20 text-red-300"
-                    : "border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-slate-500"
-                }`}
-              >
-                <span className="text-slate-500">[{entry.time}]</span>{" "}
-                <span className="text-slate-500">{entry.ip}</span>{" "}
-                {entry.action}
-                {logsSubmitted && entry.suspicious && (
-                  <span className="ml-2 text-red-700 dark:text-red-400">SUSPICIOUS</span>
-                )}
-              </button>
-            ))}
-          </div>
-          {!logsSubmitted && (
-            <PrimaryButton onClick={submitLogs}>Submit Selections</PrimaryButton>
-          )}
-          {logsSubmitted && (
-            <div className="flex justify-end">
-              <PrimaryButton onClick={() => setPhase(1)}>Analyze</PrimaryButton>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Phase 2: Questions */}
-      {phase === 1 && (
-        <div className="space-y-4 mt-4">
-          <Card className="space-y-1">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">
-              Question {qIdx + 1} of {LOG_QUESTIONS.length}
-            </p>
-            <p className="text-sm font-medium text-slate-900 dark:text-white">{LOG_QUESTIONS[qIdx].q}</p>
-          </Card>
-          <div className="space-y-2">
-            {LOG_QUESTIONS[qIdx].opts.map((opt, i) => {
-              let border = "border-slate-200 dark:border-slate-700";
-              if (qAnswered && i === LOG_QUESTIONS[qIdx].ans) border = "border-teal-500";
-              else if (qAnswered && i === qSelected) border = "border-red-500";
-              return (
-                <button
-                  key={i}
-                  onClick={() => handleAnswer(i)}
-                  disabled={qAnswered}
-                  className={`w-full text-left p-3 rounded-lg border ${border} bg-white dark:bg-slate-800 text-sm text-slate-700 dark:text-slate-300 hover:border-indigo-400 disabled:hover:border-slate-200 dark:border-slate-700 transition-colors`}
-                >
-                  {opt}
-                </button>
-              );
-            })}
-          </div>
-          {qAnswered && (
-            <div className="flex justify-end">
-              <PrimaryButton onClick={nextQuestion}>
-                {qIdx < LOG_QUESTIONS.length - 1 ? "Next Question" : "Write Report"}
-              </PrimaryButton>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Phase 3: Incident Report */}
-      {phase === 2 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">Complete the incident report.</p>
-          <Card className="space-y-4">
-            <div>
-              <label className="text-xs text-slate-500 block mb-1">Severity</label>
-              <select
-                value={severity}
-                onChange={(e) => setSeverity(e.target.value)}
-                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
-              >
-                <option value="">Select...</option>
-                {SEVERITY_OPTS.map((o) => (
-                  <option key={o} value={o}>{o}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="text-xs text-slate-500 block mb-1">Attack Type</label>
-              <select
-                value={attackType}
-                onChange={(e) => setAttackType(e.target.value)}
-                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
-              >
-                <option value="">Select...</option>
-                {TYPE_OPTS.map((o) => (
-                  <option key={o} value={o}>{o}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="text-xs text-slate-500 block mb-1">Recommended Action</label>
-              <select
-                value={recAction}
-                onChange={(e) => setRecAction(e.target.value)}
-                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
-              >
-                <option value="">Select...</option>
-                {ACTION_OPTS.map((o) => (
-                  <option key={o} value={o}>{o}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="text-xs text-slate-500 block mb-1">Brief Summary</label>
-              <textarea
-                value={summary}
-                onChange={(e) => setSummary(e.target.value)}
-                placeholder="Describe the incident in 1-2 sentences..."
-                className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white resize-none h-20"
-              />
-            </div>
-          </Card>
-          <div className="flex justify-end">
-            <PrimaryButton
-              onClick={submitReport}
-              disabled={!severity || !attackType || !recAction || summary.trim().length < 10}
-            >
-              Submit Report
-            </PrimaryButton>
-          </div>
-        </div>
-      )}
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 5 — CyberCareerMap (Activity)
-// ═══════════════════════════════════════════════════════════════════════════
-
-interface CareerCard {
-  role: string;
-  what: string;
-  salary: string;
-  education: string;
-  tags: string[];
-}
-
-const CAREERS: CareerCard[] = [
   {
-    role: "Security Analyst",
-    what: "Monitors networks for threats and responds to security alerts. Acts as the frontline defense for an organization.",
-    salary: "$75K–$110K",
-    education: "Bachelor's in CS/Cybersecurity, or Security+ cert + experience",
-    tags: ["Detail-oriented", "Analytical", "Calm under pressure"],
-  },
-  {
-    role: "Penetration Tester",
-    what: "Legally hacks into systems to find vulnerabilities before real attackers do. Writes reports explaining what they found and how to fix it.",
-    salary: "$85K–$130K",
-    education: "CEH or OSCP cert, CS degree helpful but not required",
-    tags: ["Creative thinker", "Persistent", "Curious"],
-  },
-  {
-    role: "Incident Responder",
-    what: "Investigates security breaches and leads the recovery effort. Works under pressure to contain damage and restore systems.",
-    salary: "$70K–$105K",
-    education: "GCIH cert, experience in SOC or IT operations",
-    tags: ["Cool-headed", "Fast learner", "Team player"],
-  },
-  {
-    role: "Security Engineer",
-    what: "Designs and builds security systems, tools, and architecture. Automates defenses and hardens infrastructure.",
-    salary: "$95K–$145K",
-    education: "CS degree + cloud/security certs (AWS, CISSP)",
-    tags: ["Builder", "Systems thinker", "Technical depth"],
-  },
-  {
-    role: "GRC Analyst",
-    what: "Manages governance, risk, and compliance. Ensures the organization meets legal and regulatory security standards.",
-    salary: "$65K–$100K",
-    education: "Business or IT degree, CISA or CRISC cert",
-    tags: ["Organized", "Policy-minded", "Strong communicator"],
-  },
-  {
-    role: "Digital Forensics",
-    what: "Recovers and analyzes evidence from devices after breaches, crimes, or insider incidents. Often works with law enforcement or legal teams.",
-    salary: "$75K–$120K",
-    education: "GIAC GCFE/GCFA cert, criminal justice or CS background, EnCase or FTK training",
-    tags: ["Patient", "Detail-obsessed", "Evidence-driven"],
-  },
-  {
-    role: "Security Architect",
-    what: "Designs the overall security strategy and reference architecture for an organization. Translates business risk into technical controls.",
-    salary: "$120K–$180K",
-    education: "10+ years experience, CISSP-ISSAP, deep network and cloud knowledge",
-    tags: ["Big-picture", "Designer", "Risk-aware"],
-  },
-  {
-    role: "CISO",
-    what: "Chief Information Security Officer. Leads the entire security program, sets strategy, and reports to the board.",
-    salary: "$150K–$250K",
-    education: "10+ years experience, CISSP, MBA helpful",
-    tags: ["Leadership", "Strategic", "Business-savvy"],
+    q: "Which device decides which traffic is allowed to pass based on a set of rules?",
+    opts: ["Firewall", "DNS server", "Switch", "Modem"],
+    ans: 0,
   },
 ];
 
-export function CyberCareerMap({ onComplete, onBack }: ModuleProps) {
-  const [starred, setStarred] = useState<Set<number>>(new Set());
-  const [showSummary, setShowSummary] = useState(false);
-
-  const toggleStar = (idx: number) => {
-    const next = new Set(starred);
-    if (next.has(idx)) {
-      next.delete(idx);
-    } else if (next.size < 3) {
-      next.add(idx);
-    }
-    setStarred(next);
-  };
-
-  const nextSteps: Record<string, string[]> = {
-    "Security Analyst": ["ISC2 Certified in Cybersecurity (CC) — free for first year", "CompTIA Security+ certification", "Home lab + SOC analyst internship"],
-    "Penetration Tester": ["TryHackMe / HackTheBox practice", "CEH or OSCP certification", "Bug bounty programs (HackerOne, Bugcrowd)"],
-    "Incident Responder": ["SANS GCIH certification", "IT help desk role to learn the environment", "Tabletop incident-response simulations"],
-    "Security Engineer": ["AWS/Azure cloud certifications", "Learn Python scripting", "Contribute to open-source security tooling"],
-    "GRC Analyst": ["ISACA CISA certification", "Study NIST CSF and ISO 27001 frameworks", "Build clear technical-writing samples"],
-    "Digital Forensics": ["SANS GCFE certification", "Practice with Autopsy / FTK Imager on test drives", "Learn chain-of-custody basics"],
-    "Security Architect": ["Earn CISSP first, then CISSP-ISSAP", "Get deep on cloud (AWS/Azure security)", "Study NIST 800-53 controls"],
-    "CISO": ["Build broad security experience first", "MBA or security management coursework", "Leadership and board-communication training"],
-  };
-
-  if (showSummary) {
-    const picks = Array.from(starred).map((i) => CAREERS[i]);
-    return (
-      <ModuleShell title="Cyber Career Map" step={2} totalSteps={2} onBack={() => setShowSummary(false)}>
-        <div className="space-y-6 mt-4">
-          <div>
-            <h2 className="text-lg font-semibold text-indigo-700 dark:text-indigo-300 mb-3">Your Top Interests</h2>
-            <div className="space-y-3">
-              {picks.map((career) => (
-                <Card key={career.role} className="space-y-2">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">{career.role}</p>
-                  <p className="text-xs text-teal-700 dark:text-teal-400">{career.salary}</p>
-                  <div>
-                    <p className="text-xs text-slate-500 mb-1">Next Steps:</p>
-                    <ul className="space-y-1">
-                      {nextSteps[career.role]?.map((step) => (
-                        <li key={step} className="text-xs text-slate-600 dark:text-slate-400 flex items-start gap-2">
-                          <span className="text-indigo-400 mt-0.5">-</span> {step}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          </div>
-          <div className="flex justify-end">
-            <PrimaryButton onClick={() => onComplete(100)}>
-              Confirm and Complete
-            </PrimaryButton>
-          </div>
-        </div>
-      </ModuleShell>
-    );
-  }
-
-  return (
-    <ModuleShell title="Cyber Career Map" step={1} totalSteps={2} onBack={onBack}>
-      <div className="space-y-4 mt-4">
-        <p className="text-sm text-slate-600 dark:text-slate-400">
-          Explore the roles below. Star 1-3 that interest you most.
-          <span className="text-indigo-400 ml-1">{starred.size}/3 selected</span>
-        </p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {CAREERS.map((career, i) => (
-            <Card
-              key={career.role}
-              onClick={() => toggleStar(i)}
-              selected={starred.has(i)}
-              className="space-y-2"
-            >
-              <div className="flex items-start justify-between">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">{career.role}</p>
-                <span className={`text-lg ${starred.has(i) ? "text-yellow-400" : "text-slate-600"}`}>
-                  {starred.has(i) ? "\u2605" : "\u2606"}
-                </span>
-              </div>
-              <p className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">{career.what}</p>
-              <p className="text-xs text-teal-700 dark:text-teal-400 font-medium">{career.salary}</p>
-              <p className="text-xs text-slate-500">{career.education}</p>
-              <div className="flex flex-wrap gap-1">
-                {career.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="px-2 py-0.5 text-[10px] rounded bg-slate-700 text-slate-600 dark:text-slate-400 border border-slate-600"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </Card>
-          ))}
-        </div>
-        <div className="flex justify-end">
-          <PrimaryButton onClick={() => setShowSummary(true)} disabled={starred.size === 0}>
-            View Summary
-          </PrimaryButton>
-        </div>
-      </div>
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 6 — CiscoNetacadLink (External)
-// ═══════════════════════════════════════════════════════════════════════════
-
-const NETACAD_URL =
-  "https://www.cisco.com/site/us/en/learn/training-certifications/training/netacad/index.html";
-
-const RECOMMENDED_NETACAD_COURSES = [
+const THREAT_QUIZ: QuizQuestion[] = [
   {
-    name: "Introduction to Cybersecurity",
-    detail: "~15 hr, no prerequisites. Best starting point after this module.",
+    q: "Which login pattern is the strongest indicator of compromise?",
+    opts: [
+      "A user typing their password wrong once and then succeeding",
+      "Many failed login attempts followed by a successful one",
+      "A single successful login during business hours",
+      "A logout shortly after login",
+    ],
+    ans: 1,
   },
   {
-    name: "Cybersecurity Essentials",
-    detail: "~30 hr, builds on the intro. Maps to CompTIA Security+ and Cisco CyberOps Associate.",
+    q: "What does 'impossible travel' mean in threat detection?",
+    opts: [
+      "A flight cancellation",
+      "Two logins from one user in locations too far apart in too little time",
+      "An employee who works remotely",
+      "A VPN session",
+    ],
+    ans: 1,
   },
   {
-    name: "CCNA (Introduction to Networks)",
-    detail: "Deeper networking foundation — useful for SOC, security engineering, and incident response roles.",
+    q: "What is the most valuable part of a post-incident report?",
+    opts: [
+      "A detailed timeline only",
+      "A list of every command run",
+      "Root cause and a recommendation that prevents the next one",
+      "Quotes from affected users",
+    ],
+    ans: 2,
+  },
+  {
+    q: "Which NIST framework guides incident response?",
+    opts: ["SP 800-53", "SP 800-61", "SP 800-171", "SP 800-207"],
+    ans: 1,
   },
 ];
 
-export function CiscoNetacadLink({ onComplete, onBack }: ModuleProps) {
-  const [clicked, setClicked] = useState(false);
-
-  const handleOpen = () => {
-    window.open(NETACAD_URL, "_blank", "noopener,noreferrer");
-    setClicked(true);
-    onComplete(100);
-  };
-
-  return (
-    <ModuleShell title="Cisco NetAcad" step={1} totalSteps={1} onBack={onBack}>
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <Card className="max-w-md w-full space-y-4 p-6">
-          <div className="text-center space-y-3">
-            {/* Cisco logo placeholder */}
-            <div className="w-16 h-16 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
-              <span className="text-2xl font-bold text-teal-700 dark:text-teal-400">C</span>
-            </div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Cisco Networking Academy</h2>
-            <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
-              Cisco NetAcad offers free, industry-recognized courses in networking, cybersecurity, and IT fundamentals. Build skills that employers actively look for.
-            </p>
-          </div>
-
-          <div className="space-y-2 pt-2 border-t border-slate-200 dark:border-slate-700">
-            <p className="text-xs text-slate-500 uppercase tracking-wider">Recommended after this module</p>
-            {RECOMMENDED_NETACAD_COURSES.map((c) => (
-              <div key={c.name} className="text-left">
-                <p className="text-sm font-medium text-slate-200">{c.name}</p>
-                <p className="text-xs text-slate-600 dark:text-slate-400">{c.detail}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="space-y-2">
-            <button
-              onClick={handleOpen}
-              className="w-full px-6 py-3 bg-teal-600 hover:bg-teal-500 text-white text-sm font-medium rounded-lg transition-colors"
-            >
-              Open Cisco NetAcad
-            </button>
-            {clicked && (
-              <p className="text-xs text-teal-700 dark:text-teal-400 text-center">
-                Link opened. Module complete.
-              </p>
-            )}
-          </div>
-        </Card>
-      </div>
-    </ModuleShell>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// MODULE 7 — CyberCapstone (Project)
-// ═══════════════════════════════════════════════════════════════════════════
-
-interface Business {
-  name: string;
-  desc: string;
-  icon: string;
-}
-
-const BUSINESSES: Business[] = [
-  { name: "Barbershop", desc: "Local shop with appointment software, payment terminal, and customer database.", icon: "B" },
-  { name: "Food Truck", desc: "Mobile business with POS system, social media, and delivery app integration.", icon: "F" },
-  { name: "Community Center", desc: "Non-profit with member database, event registration, and public Wi-Fi.", icon: "C" },
+const CAREER_QUIZ: QuizQuestion[] = [
+  {
+    q: "Which is NOT one of the five major cyber pillars in this module?",
+    opts: [
+      "Security Operations",
+      "Offensive Security",
+      "Quantum Cryptography Research",
+      "Governance, Risk, and Compliance",
+    ],
+    ans: 2,
+  },
+  {
+    q: "Why is the 'experience paradox' a real problem in cyber hiring?",
+    opts: [
+      "Entry-level postings often require 1-2 years of experience already",
+      "There are no entry-level jobs",
+      "Certifications are not respected",
+      "Salaries are too low",
+    ],
+    ans: 0,
+  },
+  {
+    q: "Which certification is generally the most accessible first step?",
+    opts: ["CISSP", "ISC2 Certified in Cybersecurity (CC)", "OSCP", "CCIE"],
+    ans: 1,
+  },
+  {
+    q: "Which is a real path into cyber for someone without a CS degree?",
+    opts: [
+      "IT help desk → SOC analyst",
+      "Military intelligence → contractor",
+      "Self-taught + portfolio of CTF write-ups",
+      "All of the above",
+    ],
+    ans: 3,
+  },
 ];
 
-const RISKS = [
-  "Data theft",
-  "Ransomware",
-  "Weak passwords",
-  "Phishing attacks",
-  "Unsecured Wi-Fi",
-  "No data backups",
+const NETACAD_QUIZ: QuizQuestion[] = [
+  {
+    q: "Cisco Networking Academy coursework is…",
+    opts: [
+      "Paid subscription required",
+      "Free and self-paced",
+      "Only for college students",
+      "Only available in the U.S.",
+    ],
+    ans: 1,
+  },
+  {
+    q: "Which is a sensible first course for someone new to cyber?",
+    opts: [
+      "CCIE Security",
+      "Introduction to Cybersecurity",
+      "Advanced Penetration Testing",
+      "Cloud Security Architect path",
+    ],
+    ans: 1,
+  },
+  {
+    q: "What's the most reliable way to make progress on a multi-week course?",
+    opts: [
+      "A specific recurring schedule each week",
+      "Cramming one Saturday a month",
+      "Studying only when motivated",
+      "Skipping the labs",
+    ],
+    ans: 0,
+  },
+  {
+    q: "Why share your study plan with someone else?",
+    opts: [
+      "It's required by Cisco",
+      "Accountability makes follow-through measurably more likely",
+      "It earns extra credit",
+      "It saves bandwidth",
+    ],
+    ans: 1,
+  },
 ];
 
-const PROTECTIONS = [
-  "Encryption",
-  "Security awareness training",
-  "Firewalls",
-  "Multi-factor authentication",
-  "VPN",
-  "Automated backups",
-];
+// Capstone skips the quiz — its homework submission IS the assessment.
 
-// Correct risk-protection pairings
-const RISK_PROTECTION_MAP: Record<string, string> = {
-  "Data theft": "Encryption",
-  "Ransomware": "Automated backups",
-  "Weak passwords": "Multi-factor authentication",
-  "Phishing attacks": "Security awareness training",
-  "Unsecured Wi-Fi": "VPN",
-  "No data backups": "Automated backups",
+const QUIZ_BY_SLUG: Record<string, QuizQuestion[]> = {
+  "cyber-foundations": FOUNDATIONS_QUIZ,
+  "digital-safety-sim": SAFETY_QUIZ,
+  "network-basics": NETWORK_QUIZ,
+  "threat-detective": THREAT_QUIZ,
+  "career-map": CAREER_QUIZ,
+  "cisco-netacad-link": NETACAD_QUIZ,
 };
 
-export function CyberCapstone({ onComplete, onBack }: ModuleProps) {
-  const [step, setStep] = useState(0);
-  const totalSteps = 5;
+// ── Module exports — each is a thin wrapper around ModuleStructure ─────────
 
-  // Step 1: Business
-  const [selectedBiz, setSelectedBiz] = useState<number | null>(null);
-
-  // Step 2: Risks
-  const [selectedRisks, setSelectedRisks] = useState<Set<number>>(new Set());
-
-  // Step 3: Protections
-  const [protections, setProtections] = useState<Record<number, string>>({});
-
-  // Step 4: Summary
-  const [summaryText, setSummaryText] = useState(
-    "The biggest risk is...\nI recommend...\nThis will help because..."
-  );
-
-  const toggleRisk = (idx: number) => {
-    const next = new Set(selectedRisks);
-    if (next.has(idx)) {
-      next.delete(idx);
-      // Remove protection mapping too
-      const np = { ...protections };
-      delete np[idx];
-      setProtections(np);
-    } else if (next.size < 3) {
-      next.add(idx);
-    }
-    setSelectedRisks(next);
-  };
-
-  const setProtection = (riskIdx: number, protection: string) => {
-    setProtections({ ...protections, [riskIdx]: protection });
-  };
-
-  const calculateScore = () => {
-    let pts = 0;
-    const riskArr = Array.from(selectedRisks);
-    riskArr.forEach((riskIdx) => {
-      const riskName = RISKS[riskIdx];
-      const chosen = protections[riskIdx];
-      if (chosen === RISK_PROTECTION_MAP[riskName]) {
-        pts += 30;
-      } else {
-        // Partial credit if protection is reasonable
-        pts += 10;
-      }
-    });
-    // Summary completion bonus
-    const lines = summaryText.split("\n").filter((l) => l.trim().length > 20);
-    if (lines.length >= 3) pts += 10;
-    return Math.min(pts, 100);
-  };
-
-  const handleFinish = () => {
-    onComplete(calculateScore());
-  };
-
-  const canAdvance = () => {
-    switch (step) {
-      case 0: return selectedBiz !== null;
-      case 1: return selectedRisks.size === 3;
-      case 2: return Array.from(selectedRisks).every((r) => protections[r]);
-      case 3: return summaryText.trim().length >= 40;
-      case 4: return true;
-      default: return false;
-    }
-  };
-
-  const riskArr = Array.from(selectedRisks);
-  const business = selectedBiz !== null ? BUSINESSES[selectedBiz] : null;
-
-  return (
-    <ModuleShell title="Cyber Capstone" step={step + 1} totalSteps={totalSteps} onBack={step === 0 ? onBack : () => setStep((s) => s - 1)}>
-      {/* Step 1: Pick Business */}
-      {step === 0 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            You're building a security plan. Pick a business to protect:
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            {BUSINESSES.map((biz, i) => (
-              <Card
-                key={biz.name}
-                onClick={() => setSelectedBiz(i)}
-                selected={selectedBiz === i}
-                className="text-center space-y-2"
-              >
-                <div className="w-10 h-10 mx-auto rounded-lg bg-slate-700 border border-slate-600 flex items-center justify-center">
-                  <span className="text-lg font-bold text-indigo-400">{biz.icon}</span>
-                </div>
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">{biz.name}</p>
-                <p className="text-xs text-slate-600 dark:text-slate-400">{biz.desc}</p>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Step 2: Pick Risks */}
-      {step === 1 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            Select the 3 biggest risks for {business?.name}:
-            <span className="text-indigo-400 ml-1">{selectedRisks.size}/3</span>
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {RISKS.map((risk, i) => (
-              <Card
-                key={risk}
-                onClick={() => toggleRisk(i)}
-                selected={selectedRisks.has(i)}
-                className="flex items-center gap-3"
-              >
-                <div
-                  className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
-                    selectedRisks.has(i)
-                      ? "border-indigo-500 bg-indigo-600"
-                      : "border-slate-600 bg-transparent"
-                  }`}
-                >
-                  {selectedRisks.has(i) && (
-                    <span className="text-white text-xs font-bold">{"\u2713"}</span>
-                  )}
-                </div>
-                <span className="text-sm text-slate-700 dark:text-slate-300">{risk}</span>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Step 3: Match Protections */}
-      {step === 2 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">Match each risk to the best protection:</p>
-          <div className="space-y-3">
-            {riskArr.map((riskIdx) => (
-              <Card key={riskIdx} className="space-y-2">
-                <p className="text-sm font-medium text-red-700 dark:text-red-400">{RISKS[riskIdx]}</p>
-                <select
-                  value={protections[riskIdx] || ""}
-                  onChange={(e) => setProtection(riskIdx, e.target.value)}
-                  className="w-full p-2 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white"
-                >
-                  <option value="">Select protection...</option>
-                  {PROTECTIONS.map((p) => (
-                    <option key={p} value={p}>{p}</option>
-                  ))}
-                </select>
-              </Card>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Step 4: Executive Summary */}
-      {step === 3 && (
-        <div className="space-y-4 mt-4">
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            Write a 3-sentence executive summary for your security plan:
-          </p>
-          <Card className="space-y-2">
-            <textarea
-              value={summaryText}
-              onChange={(e) => setSummaryText(e.target.value)}
-              rows={6}
-              className="w-full p-3 rounded-lg bg-white border border-slate-300 dark:bg-slate-700 dark:border-slate-600 text-sm text-slate-900 dark:text-white resize-none leading-relaxed"
-            />
-            <p className="text-xs text-slate-500">
-              Use the sentence starters as a guide. Replace them with your analysis.
-            </p>
-          </Card>
-        </div>
-      )}
-
-      {/* Step 5: Security Plan One-Pager */}
-      {step === 4 && (
-        <div className="space-y-4 mt-4">
-          <Card className="space-y-5 p-6">
-            <div className="border-b border-slate-200 dark:border-slate-700 pb-3">
-              <p className="text-xs text-slate-500 uppercase tracking-wider">Security Plan</p>
-              <h2 className="text-lg font-bold text-slate-900 dark:text-white">{business?.name} Security Assessment</h2>
-            </div>
-
-            <div>
-              <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">Business Profile</p>
-              <p className="text-sm text-slate-700 dark:text-slate-300">{business?.desc}</p>
-            </div>
-
-            <div>
-              <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">Identified Risks & Mitigations</p>
-              <div className="space-y-2">
-                {riskArr.map((riskIdx) => (
-                  <div key={riskIdx} className="flex items-center gap-3 text-sm">
-                    <span className="text-red-400 w-40 flex-shrink-0">{RISKS[riskIdx]}</span>
-                    <span className="text-slate-600">&rarr;</span>
-                    <span className="text-teal-400">{protections[riskIdx]}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <p className="text-xs text-slate-500 uppercase tracking-wider mb-2">Executive Summary</p>
-              <p className="text-sm text-slate-700 dark:text-slate-300 whitespace-pre-line leading-relaxed">{summaryText}</p>
-            </div>
-
-            <div className="border-t border-slate-200 dark:border-slate-700 pt-3">
-              <p className="text-xs text-slate-500">
-                Prepared by: Student &middot; BrightBoost Cyber Launch Track
-              </p>
-            </div>
-          </Card>
-        </div>
-      )}
-
-      <div className="flex justify-end mt-6">
-        {step < 4 && (
-          <PrimaryButton onClick={() => setStep((s) => s + 1)} disabled={!canAdvance()}>
-            Next
-          </PrimaryButton>
-        )}
-        {step === 4 && (
-          <PrimaryButton onClick={handleFinish}>
-            Submit Plan
-          </PrimaryButton>
-        )}
+function moduleFor(slug: string, props: ModuleProps) {
+  const content = CYBER_LAUNCH_CONTENT[slug];
+  if (!content) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-slate-400">Unknown module: {slug}</p>
       </div>
-    </ModuleShell>
+    );
+  }
+  const quiz = QUIZ_BY_SLUG[slug] ?? [];
+  return (
+    <ModuleStructure
+      content={content}
+      onBack={props.onBack}
+      onComplete={props.onComplete}
+      renderQuiz={({ onQuizComplete }) => (
+        <StandaloneQuiz questions={quiz} onComplete={onQuizComplete} />
+      )}
+    />
   );
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// DEFAULT EXPORT — Module router for ModulePlayer
-// ═══════════════════════════════════════════════════════════════════════════
+export function CyberFoundations(props: ModuleProps) {
+  // Module 1's quiz prompts can be localized via i18n keys defined in
+  // src/locales/*/pathways.json under pathways.modules.foundations.quiz.
+  // If present, use them; otherwise fall back to the English bank above.
+  const { t } = useTranslation();
+  const localized = useMemo(() => {
+    const items = t("pathways.modules.foundations.quiz", { returnObjects: true });
+    if (!Array.isArray(items)) return null;
+    // Only accept if shape matches.
+    const ok = items.every(
+      (it) => it && typeof it === "object" && typeof it.q === "string" && Array.isArray(it.opts),
+    );
+    if (!ok) return null;
+    return items.map((it, i) => ({
+      q: it.q,
+      opts: it.opts,
+      ans: FOUNDATIONS_QUIZ[i]?.ans ?? 0,
+    })) as QuizQuestion[];
+  }, [t]);
+
+  const content = CYBER_LAUNCH_CONTENT["cyber-foundations"];
+  const quiz = localized ?? FOUNDATIONS_QUIZ;
+  return (
+    <ModuleStructure
+      content={content}
+      onBack={props.onBack}
+      onComplete={props.onComplete}
+      renderQuiz={({ onQuizComplete }) => (
+        <StandaloneQuiz questions={quiz} onComplete={onQuizComplete} />
+      )}
+    />
+  );
+}
+
+export function DigitalSafetySim(props: ModuleProps) {
+  return moduleFor("digital-safety-sim", props);
+}
+
+export function NetworkBasics(props: ModuleProps) {
+  return moduleFor("network-basics", props);
+}
+
+export function ThreatDetective(props: ModuleProps) {
+  return moduleFor("threat-detective", props);
+}
+
+export function CyberCareerMap(props: ModuleProps) {
+  return moduleFor("career-map", props);
+}
+
+export function CiscoNetacadLink(props: ModuleProps) {
+  return moduleFor("cisco-netacad-link", props);
+}
+
+export function CyberCapstone(props: ModuleProps) {
+  // Capstone: skipQuiz=true in its content; ModuleStructure will not render
+  // the quiz section. Pass a no-op renderQuiz that won't actually be called.
+  return moduleFor("capstone-security-plan", props);
+}
+
+// ── Router ─────────────────────────────────────────────────────────────────
 
 const MODULE_MAP: Record<string, React.FC<ModuleProps>> = {
   "cyber-foundations": CyberFoundations,

--- a/src/components/pathways/modules/ModuleStructure.tsx
+++ b/src/components/pathways/modules/ModuleStructure.tsx
@@ -1,0 +1,698 @@
+/**
+ * ModuleStructure — shared 6-section learning shell for Cyber Launch modules.
+ *
+ * Each module renders Hook → Reading → Lesson → Practice → Homework → Quiz
+ * (the Capstone skips Quiz). The progress bar across the top lets a learner
+ * see where they are at a glance and navigate to any unlocked section. The
+ * Quiz unlocks only when the previous five sections have been marked done.
+ *
+ * Each section persists its completion to PathwayMilestone via
+ * PATCH /api/pathways/student/milestones/section so a learner can leave and
+ * resume. Homework submission posts to a dedicated endpoint that also flips
+ * the section's completion bit.
+ *
+ * Quiz content stays in the existing module file — this shell hands off to
+ * a render-prop so the existing per-module scenarios/scoring keep working.
+ */
+import { useMemo, useRef, useState } from "react";
+import {
+  BookOpen,
+  GraduationCap,
+  Lightbulb,
+  PencilLine,
+  PlayCircle,
+  Sparkles,
+  Lock,
+  Check,
+  ChevronRight,
+  ArrowLeft,
+} from "lucide-react";
+import type { ModuleContent, ReadingSection, LessonScene, PracticeItem } from "./cyberLaunchContent";
+
+const TRACK_SLUG = "cyber-launch";
+
+const SECTIONS = ["hook", "reading", "lesson", "practice", "homework", "quiz"] as const;
+export type SectionKey = (typeof SECTIONS)[number];
+
+const SECTION_META: Record<SectionKey, { label: string; icon: typeof BookOpen }> = {
+  hook: { label: "Hook", icon: Sparkles },
+  reading: { label: "Read", icon: BookOpen },
+  lesson: { label: "Lesson", icon: PlayCircle },
+  practice: { label: "Practice", icon: Lightbulb },
+  homework: { label: "Homework", icon: PencilLine },
+  quiz: { label: "Quiz", icon: GraduationCap },
+};
+
+interface SectionProgress {
+  hook: boolean;
+  reading: boolean;
+  lesson: boolean;
+  practice: boolean;
+  homework: boolean;
+  quiz: boolean;
+}
+
+const ZERO_PROGRESS: SectionProgress = {
+  hook: false,
+  reading: false,
+  lesson: false,
+  practice: false,
+  homework: false,
+  quiz: false,
+};
+
+interface QuizHandoffArgs {
+  /** Call when the quiz is finished with a 0-100 score. */
+  onQuizComplete: (score: number) => void;
+}
+
+export interface ModuleStructureProps {
+  content: ModuleContent;
+  /** Existing module quiz rendered as the final stage. */
+  renderQuiz: (args: QuizHandoffArgs) => React.ReactNode;
+  onBack: () => void;
+  /** Called when the module is fully complete with the final score (quiz score, or 100 for Capstone). */
+  onComplete: (score: number) => void;
+  /** Existing milestone progress for resume support. */
+  initialProgress?: Partial<SectionProgress>;
+  /** Existing homework response if the learner has already submitted. */
+  initialHomework?: string;
+}
+
+function authHeader(): Record<string, string> {
+  const token = localStorage.getItem("bb_access_token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Best-effort POST; failures are non-fatal — UI optimistic, server eventually consistent. */
+function persistSection(moduleSlug: string, section: SectionKey, completed: boolean) {
+  fetch("/api/pathways/student/milestones/section", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...authHeader() },
+    body: JSON.stringify({ trackSlug: TRACK_SLUG, moduleSlug, section, completed }),
+  }).catch(() => {});
+}
+
+export default function ModuleStructure({
+  content,
+  renderQuiz,
+  onBack,
+  onComplete,
+  initialProgress,
+  initialHomework,
+}: ModuleStructureProps) {
+  const sections = useMemo<SectionKey[]>(
+    () => (content.skipQuiz ? ["hook", "reading", "lesson", "practice", "homework"] : [...SECTIONS]),
+    [content.skipQuiz],
+  );
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [progress, setProgress] = useState<SectionProgress>({ ...ZERO_PROGRESS, ...initialProgress });
+  const current = sections[currentIdx];
+
+  // Quiz unlocks only after the first five sections are complete (or the
+  // skip-quiz capstone reaches its final section).
+  const quizUnlocked =
+    progress.hook && progress.reading && progress.lesson && progress.practice && progress.homework;
+
+  const markCompleted = (section: SectionKey) => {
+    setProgress((p) => {
+      if (p[section]) return p; // idempotent
+      persistSection(content.slug, section, true);
+      return { ...p, [section]: true };
+    });
+  };
+
+  const goNext = () => {
+    if (currentIdx + 1 < sections.length) setCurrentIdx(currentIdx + 1);
+  };
+
+  const goTo = (idx: number) => {
+    const target = sections[idx];
+    if (target === "quiz" && !quizUnlocked) return;
+    setCurrentIdx(idx);
+  };
+
+  const handleQuizComplete = (score: number) => {
+    markCompleted("quiz");
+    onComplete(score);
+  };
+
+  const handleCapstoneComplete = () => {
+    // Capstone has no quiz — completing all 5 sections is the submission.
+    onComplete(100);
+  };
+
+  return (
+    <div className="bg-white text-slate-900 dark:bg-slate-900 dark:text-white p-4 sm:p-6 rounded-2xl border border-slate-200 dark:border-slate-800">
+      <div className="max-w-3xl mx-auto space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back
+          </button>
+          <span className="text-xs text-slate-500">~{content.totalMinutes} min</span>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">{content.title}</h1>
+
+        {/* Progress bar */}
+        <ProgressBar
+          sections={sections}
+          currentIdx={currentIdx}
+          progress={progress}
+          quizUnlocked={quizUnlocked}
+          onSelect={goTo}
+        />
+
+        {/* Section content */}
+        {current === "hook" && (
+          <HookSection
+            content={content}
+            done={progress.hook}
+            onContinue={() => {
+              markCompleted("hook");
+              goNext();
+            }}
+          />
+        )}
+        {current === "reading" && (
+          <ReadingSectionView
+            content={content}
+            done={progress.reading}
+            onContinue={() => {
+              markCompleted("reading");
+              goNext();
+            }}
+          />
+        )}
+        {current === "lesson" && (
+          <LessonSectionView
+            content={content}
+            done={progress.lesson}
+            onContinue={() => {
+              markCompleted("lesson");
+              goNext();
+            }}
+          />
+        )}
+        {current === "practice" && (
+          <PracticeSectionView
+            content={content}
+            done={progress.practice}
+            onContinue={() => {
+              markCompleted("practice");
+              goNext();
+            }}
+          />
+        )}
+        {current === "homework" && (
+          <HomeworkSectionView
+            content={content}
+            moduleSlug={content.slug}
+            done={progress.homework}
+            initialResponse={initialHomework ?? ""}
+            isCapstone={!!content.skipQuiz}
+            onContinue={() => {
+              markCompleted("homework");
+              if (content.skipQuiz) handleCapstoneComplete();
+              else goNext();
+            }}
+          />
+        )}
+        {current === "quiz" && !content.skipQuiz && (
+          <div className="space-y-3">
+            <SectionHeader
+              icon={GraduationCap}
+              title="Quiz"
+              estMinutes={8}
+              subtitle="The final assessment. Bring what you learned in the previous sections."
+            />
+            {quizUnlocked ? (
+              renderQuiz({ onQuizComplete: handleQuizComplete })
+            ) : (
+              <LockedNotice />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Progress bar ────────────────────────────────────────────────────────────
+
+function ProgressBar({
+  sections,
+  currentIdx,
+  progress,
+  quizUnlocked,
+  onSelect,
+}: {
+  sections: SectionKey[];
+  currentIdx: number;
+  progress: SectionProgress;
+  quizUnlocked: boolean;
+  onSelect: (idx: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 sm:gap-2 overflow-x-auto py-1">
+      {sections.map((section, idx) => {
+        const meta = SECTION_META[section];
+        const Icon = meta.icon;
+        const isCurrent = idx === currentIdx;
+        const isDone = progress[section];
+        const isLocked = section === "quiz" && !quizUnlocked;
+        const base =
+          "flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 rounded-lg text-[10px] font-semibold uppercase tracking-wider transition-colors min-w-[64px]";
+        const cls = isLocked
+          ? "text-slate-400 dark:text-slate-600 cursor-not-allowed"
+          : isCurrent
+            ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-600/30 dark:text-indigo-200 cursor-pointer"
+            : isDone
+              ? "text-emerald-700 dark:text-emerald-400 cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-800"
+              : "text-slate-600 dark:text-slate-400 cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-800";
+        return (
+          <div key={section} className="flex items-center">
+            <button
+              type="button"
+              onClick={() => onSelect(idx)}
+              disabled={isLocked}
+              className={`${base} ${cls}`}
+            >
+              <span className="relative">
+                {isLocked ? <Lock className="w-4 h-4" /> : isDone ? <Check className="w-4 h-4" /> : <Icon className="w-4 h-4" />}
+              </span>
+              <span>{meta.label}</span>
+            </button>
+            {idx < sections.length - 1 && (
+              <ChevronRight className="w-3 h-3 text-slate-300 dark:text-slate-700" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  estMinutes,
+  subtitle,
+}: {
+  icon: typeof BookOpen;
+  title: string;
+  estMinutes: number;
+  subtitle?: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 pb-3 border-b border-slate-200 dark:border-slate-800">
+      <div className="w-9 h-9 rounded-lg bg-indigo-100 text-indigo-700 dark:bg-indigo-600/30 dark:text-indigo-300 flex items-center justify-center">
+        <Icon className="w-5 h-5" />
+      </div>
+      <div className="flex-1">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-lg font-bold">{title}</h2>
+          <span className="text-xs text-slate-500">~{estMinutes} min</span>
+        </div>
+        {subtitle && <p className="text-sm text-slate-600 dark:text-slate-400 mt-0.5">{subtitle}</p>}
+      </div>
+    </div>
+  );
+}
+
+function NextButton({ label = "Next →", onClick }: { label?: string; onClick: () => void }) {
+  return (
+    <div className="flex justify-end pt-2">
+      <button
+        onClick={onClick}
+        className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}
+
+function LockedNotice() {
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-900/20 p-4 text-sm text-amber-900 dark:text-amber-200">
+      <p className="font-semibold">Quiz is locked until the earlier sections are complete.</p>
+      <p className="text-xs mt-1">Finish Hook, Reading, Lesson, Practice, and Homework first — then come back.</p>
+    </div>
+  );
+}
+
+/** Render a paragraph string with **bold** markers turned into <strong>. Plain-text only — no markdown. */
+function renderInline(text: string): React.ReactNode[] {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return (
+        <strong key={i} className="font-semibold text-slate-900 dark:text-slate-100">
+          {part.slice(2, -2)}
+        </strong>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+function HookSection({
+  content,
+  done,
+  onContinue,
+}: {
+  content: ModuleContent;
+  done: boolean;
+  onContinue: () => void;
+}) {
+  const { hook } = content;
+  return (
+    <div className="space-y-4">
+      <SectionHeader icon={Sparkles} title={hook.title} estMinutes={hook.estMinutes} />
+      <div className="space-y-3 text-[15px] leading-relaxed text-slate-800 dark:text-slate-200">
+        {hook.paragraphs.map((p, i) => (
+          <p key={i}>{renderInline(p)}</p>
+        ))}
+        <p className="text-indigo-700 dark:text-indigo-300 font-medium italic">{hook.closer}</p>
+      </div>
+      <NextButton label={done ? "Continue →" : "I'm ready →"} onClick={onContinue} />
+    </div>
+  );
+}
+
+// ── Reading ────────────────────────────────────────────────────────────────
+
+function ReadingSectionView({
+  content,
+  done,
+  onContinue,
+}: {
+  content: ModuleContent;
+  done: boolean;
+  onContinue: () => void;
+}) {
+  const { reading } = content;
+  return (
+    <div className="space-y-5">
+      <SectionHeader
+        icon={BookOpen}
+        title="Reading"
+        estMinutes={reading.estMinutes}
+        subtitle="Substantive background. Take notes if it helps."
+      />
+      <div className="space-y-6">
+        {reading.sections.map((section, i) => (
+          <ReadingSectionBlock key={i} section={section} />
+        ))}
+      </div>
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">
+          Sources
+        </p>
+        <ul className="text-xs text-slate-600 dark:text-slate-400 space-y-1">
+          {reading.citations.map((c, i) => (
+            <li key={i}>• {c}</li>
+          ))}
+        </ul>
+      </div>
+      <NextButton label={done ? "Continue →" : "Done reading →"} onClick={onContinue} />
+    </div>
+  );
+}
+
+function ReadingSectionBlock({ section }: { section: ReadingSection }) {
+  return (
+    <div>
+      <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-2">{section.heading}</h3>
+      <div className="space-y-2 text-[15px] leading-relaxed text-slate-800 dark:text-slate-200">
+        {section.paragraphs.map((p, i) => (
+          <p key={i}>{renderInline(p)}</p>
+        ))}
+      </div>
+      {section.callout && (
+        <blockquote className="mt-3 pl-3 border-l-4 border-indigo-400 dark:border-indigo-600 text-sm text-indigo-900 dark:text-indigo-200 italic">
+          {section.callout}
+        </blockquote>
+      )}
+      {section.keyTerms && section.keyTerms.length > 0 && (
+        <div className="mt-3 rounded-lg bg-slate-100 dark:bg-slate-800/60 p-3">
+          <p className="text-[11px] uppercase tracking-wider text-slate-500 font-semibold mb-1">Key terms</p>
+          <dl className="text-sm space-y-1">
+            {section.keyTerms.map((kt) => (
+              <div key={kt.term}>
+                <dt className="inline font-semibold text-slate-900 dark:text-slate-200">{kt.term}:</dt>{" "}
+                <dd className="inline text-slate-700 dark:text-slate-400">{kt.definition}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Lesson ─────────────────────────────────────────────────────────────────
+
+function LessonSectionView({
+  content,
+  done,
+  onContinue,
+}: {
+  content: ModuleContent;
+  done: boolean;
+  onContinue: () => void;
+}) {
+  const { lesson } = content;
+  const [sceneIdx, setSceneIdx] = useState(0);
+  const totalScenes = lesson.scenes.length;
+  const onLast = sceneIdx === totalScenes - 1;
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader icon={PlayCircle} title="Lesson" estMinutes={lesson.estMinutes} subtitle={lesson.intro} />
+      <div className="text-xs text-slate-500">Scene {sceneIdx + 1} of {totalScenes}</div>
+      <LessonSceneView scene={lesson.scenes[sceneIdx]} />
+      <div className="flex items-center justify-between pt-2">
+        <button
+          onClick={() => setSceneIdx((i) => Math.max(0, i - 1))}
+          disabled={sceneIdx === 0}
+          className="text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 disabled:opacity-40"
+        >
+          ← Previous
+        </button>
+        {onLast ? (
+          <button
+            onClick={onContinue}
+            className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
+          >
+            {done ? "Continue →" : "Finish lesson →"}
+          </button>
+        ) : (
+          <button
+            onClick={() => setSceneIdx((i) => Math.min(totalScenes - 1, i + 1))}
+            className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
+          >
+            Next scene →
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LessonSceneView({ scene }: { scene: LessonScene }) {
+  const [picked, setPicked] = useState<number | null>(null);
+  // Reset selection when the scene changes.
+  const lastScene = useRef<string | null>(null);
+  if (lastScene.current !== scene.title) {
+    lastScene.current = scene.title;
+    if (picked !== null) setPicked(null);
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-slate-50 dark:bg-slate-800/40">
+      <h3 className="font-bold text-slate-900 dark:text-slate-100 mb-1">{scene.title}</h3>
+      <p className="text-[15px] text-slate-700 dark:text-slate-300 leading-relaxed">{scene.body}</p>
+      {scene.choice && (
+        <div className="mt-4 space-y-2">
+          <p className="text-sm font-semibold text-slate-800 dark:text-slate-200">{scene.choice.prompt}</p>
+          {scene.choice.options.map((opt, i) => (
+            <button
+              key={i}
+              onClick={() => setPicked(i)}
+              className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                picked === i
+                  ? "border-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 dark:border-indigo-600"
+                  : "border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700/50"
+              }`}
+            >
+              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{opt.label}</p>
+              {picked === i && (
+                <p className="text-xs text-slate-600 dark:text-slate-400 mt-1.5">{opt.feedback}</p>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Practice ───────────────────────────────────────────────────────────────
+
+function PracticeSectionView({
+  content,
+  done,
+  onContinue,
+}: {
+  content: ModuleContent;
+  done: boolean;
+  onContinue: () => void;
+}) {
+  const { practice } = content;
+  return (
+    <div className="space-y-4">
+      <SectionHeader icon={Lightbulb} title="Practice" estMinutes={practice.estMinutes} subtitle={practice.intro} />
+      <div className="space-y-4">
+        {practice.items.map((item, i) => (
+          <PracticeItemView key={i} item={item} index={i} />
+        ))}
+      </div>
+      <NextButton label={done ? "Continue →" : "Done with practice →"} onClick={onContinue} />
+    </div>
+  );
+}
+
+function PracticeItemView({ item, index }: { item: PracticeItem; index: number }) {
+  const [picked, setPicked] = useState<Set<number>>(new Set());
+
+  return (
+    <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-4">
+      <p className="text-sm font-semibold text-slate-900 dark:text-slate-100 mb-1">
+        {index + 1}. {item.prompt}
+      </p>
+      {item.detail && <p className="text-xs text-slate-600 dark:text-slate-400 mb-2">{item.detail}</p>}
+      <div className="space-y-1.5 mt-2">
+        {item.options.map((opt, i) => {
+          const chosen = picked.has(i);
+          return (
+            <button
+              key={i}
+              onClick={() => setPicked((p) => new Set(p).add(i))}
+              className={`w-full text-left rounded-lg border p-2.5 transition-colors ${
+                chosen
+                  ? opt.correct
+                    ? "border-emerald-300 bg-emerald-50 dark:bg-emerald-900/20 dark:border-emerald-800/50"
+                    : "border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800/50"
+                  : "border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800"
+              }`}
+            >
+              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{opt.label}</p>
+              {chosen && (
+                <p className="text-xs text-slate-700 dark:text-slate-300 mt-1.5">{opt.feedback}</p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-slate-500 mt-2">Tap any option to see the reasoning. Multiple may be correct.</p>
+    </div>
+  );
+}
+
+// ── Homework ───────────────────────────────────────────────────────────────
+
+function HomeworkSectionView({
+  content,
+  moduleSlug,
+  done,
+  initialResponse,
+  isCapstone,
+  onContinue,
+}: {
+  content: ModuleContent;
+  moduleSlug: string;
+  done: boolean;
+  initialResponse: string;
+  isCapstone: boolean;
+  onContinue: () => void;
+}) {
+  const { homework } = content;
+  const [response, setResponse] = useState(initialResponse);
+  const [submitting, setSubmitting] = useState(false);
+  const [submittedOk, setSubmittedOk] = useState(done);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/pathways/student/milestones/homework", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeader() },
+        body: JSON.stringify({ trackSlug: TRACK_SLUG, moduleSlug, response }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(
+          (body && (body.error || body.message)) || `${res.status} ${res.statusText}`,
+        );
+      }
+      setSubmittedOk(true);
+      onContinue();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "submission failed";
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader
+        icon={PencilLine}
+        title={homework.title}
+        estMinutes={homework.estMinutes}
+        subtitle={homework.prompt}
+      />
+      <ol className="list-decimal list-inside space-y-1.5 text-sm text-slate-800 dark:text-slate-200 pl-1">
+        {homework.instructions.map((line, i) => (
+          <li key={i}>{line}</li>
+        ))}
+      </ol>
+      <textarea
+        value={response}
+        onChange={(e) => setResponse(e.target.value)}
+        placeholder={homework.placeholder}
+        rows={isCapstone ? 12 : 8}
+        className="w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-100 p-3 text-sm focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+      />
+      <p className="text-[11px] text-slate-500">
+        Saved when you submit. Your facilitator can review your response from their dashboard.
+      </p>
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400">Couldn't submit: {error}</p>
+      )}
+      <div className="flex items-center justify-end gap-3">
+        {submittedOk && !error && (
+          <span className="text-xs text-emerald-700 dark:text-emerald-400 font-medium">Submitted ✓</span>
+        )}
+        <button
+          onClick={onSubmit}
+          disabled={submitting || response.trim().length === 0}
+          className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 disabled:text-slate-500 dark:disabled:bg-slate-700 text-white text-sm font-medium transition-colors"
+        >
+          {submitting ? "Submitting…" : isCapstone ? "Submit capstone →" : "Submit homework →"}
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/pathways/modules/cyberLaunchContent.ts
+++ b/src/components/pathways/modules/cyberLaunchContent.ts
@@ -1,0 +1,1584 @@
+/**
+ * Cyber Launch — module content data.
+ *
+ * Each of the 7 Cyber Launch modules is structured as a 60-minute learning
+ * experience built around a 6-section flow:
+ *
+ *   1. Hook      — short scene/story that frames why the module matters
+ *   2. Reading   — substantive written content with sections + citations
+ *   3. Lesson    — interactive walkthrough or guided scenes
+ *   4. Practice  — low-stakes attempts with immediate feedback
+ *   5. Homework  — a real-world task submitted as free text
+ *   6. Quiz      — the existing assessment, repositioned at the end
+ *
+ * Content here is intentionally separated from React components so the prose
+ * can be reviewed/edited without touching JSX, and so i18n can pick it up in
+ * a future pass. Citations point to current, publicly verifiable sources.
+ *
+ * Stories framed as "Imagine…" or "Picture…" are illustrative composites,
+ * not real individuals. Named real-world incidents (Equifax 2017, Colonial
+ * Pipeline 2021, WannaCry 2017, Target 2013) are well-documented public
+ * events. Statistics are cited to NIST CyberSeek, the U.S. Bureau of Labor
+ * Statistics (BLS) Occupational Outlook Handbook, and ISC2 — these numbers
+ * shift year over year so the prose uses approximate ranges where useful.
+ */
+
+export interface ReadingSection {
+  heading: string;
+  paragraphs: string[];
+  callout?: string;
+  keyTerms?: Array<{ term: string; definition: string }>;
+}
+
+export interface LessonScene {
+  title: string;
+  body: string;
+  choice?: {
+    prompt: string;
+    options: Array<{ label: string; feedback: string }>;
+  };
+}
+
+export interface PracticeItem {
+  prompt: string;
+  detail?: string;
+  options: Array<{ label: string; correct: boolean; feedback: string }>;
+}
+
+export interface ModuleContent {
+  slug: string;
+  title: string;
+  totalMinutes: number;
+  hook: {
+    estMinutes: number;
+    title: string;
+    paragraphs: string[];
+    closer: string;
+  };
+  reading: {
+    estMinutes: number;
+    sections: ReadingSection[];
+    citations: string[];
+  };
+  lesson: {
+    estMinutes: number;
+    intro: string;
+    scenes: LessonScene[];
+  };
+  practice: {
+    estMinutes: number;
+    intro: string;
+    items: PracticeItem[];
+  };
+  homework: {
+    estMinutes: number;
+    title: string;
+    prompt: string;
+    instructions: string[];
+    placeholder: string;
+  };
+  /** Module 7 is the capstone — the deliverable is the assessment, no quiz follows. */
+  skipQuiz?: boolean;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 1 — Cyber Foundations
+// ────────────────────────────────────────────────────────────────────────────
+
+const CYBER_FOUNDATIONS: ModuleContent = {
+  slug: "cyber-foundations",
+  title: "Cyber Foundations",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "Why this matters",
+    paragraphs: [
+      "In 2017, attackers stole personal information on about 147 million people from Equifax — names, Social Security numbers, birth dates, addresses. Equifax was one of the three largest credit-reporting companies in the United States. They were supposed to be experts at protecting personal data.",
+      "The attackers got in through a known software flaw that the company had been warned about for more than two months. The patch existed. Nobody applied it.",
+      "The people whose job it is to catch problems like that — and the people who clean it up when they aren't caught — are cybersecurity professionals. That's the field you're about to learn about.",
+    ],
+    closer: "Cybersecurity is a real job, with a real shortage of people, and a real path in. Let's get into the foundations.",
+  },
+  reading: {
+    estMinutes: 12,
+    sections: [
+      {
+        heading: "What cybersecurity actually is",
+        paragraphs: [
+          "**Cybersecurity** is the practice of protecting digital systems, networks, and data from people who shouldn't have access. That's the short version. The longer version is that cybersecurity professionals work to keep four things true about every important system: it stays private when it should, it stays accurate, it stays available, and only the right people get to use it.",
+          "Those four properties are sometimes called the **CIA triad** plus authentication: **Confidentiality** (only authorized people see the data), **Integrity** (the data hasn't been tampered with), **Availability** (the system is there when you need it), and **Authentication** (the system can prove who you are). Almost every defense you'll learn about maps back to one of these four.",
+          "You already use cybersecurity every day without thinking about it. The password on your phone is confidentiality. The little lock icon next to a website's URL is integrity and authentication. When TikTok keeps working through a holiday weekend, that's availability — and there's a team behind it keeping it that way.",
+        ],
+        callout: "Almost every defense you'll learn maps back to one of four ideas: Confidentiality, Integrity, Availability, Authentication.",
+        keyTerms: [
+          { term: "CIA triad", definition: "Confidentiality, Integrity, Availability — the three classic goals of information security." },
+          { term: "Authentication", definition: "Verifying that a person or system is who they claim to be." },
+        ],
+      },
+      {
+        heading: "Why the field is growing fast",
+        paragraphs: [
+          "The U.S. Bureau of Labor Statistics projects employment of **information security analysts** to grow about 33% from 2023 to 2033 — much faster than the average for all jobs. NIST's CyberSeek tool, which tracks live cyber job postings, has shown hundreds of thousands of open cybersecurity roles in the United States at any given time.",
+          "Why does the demand keep growing? Three reasons. First, there are more devices to defend every year — phones, laptops, smart TVs, doorbells, cars. Second, attackers have gotten more organized. Ransomware, where criminals lock up a company's files and demand payment, is now run like a business. Third, there aren't enough trained people to fill the open roles, so companies compete for the ones who exist.",
+          "Entry-level cybersecurity roles in the U.S. commonly start in the $60,000–$80,000 range, with bigger metro areas and specialized roles paying more. Two years of experience plus a recognized certification often pushes that higher.",
+        ],
+        callout: "Hundreds of thousands of open cyber roles. ~33% projected growth this decade. The shortage is the opportunity.",
+      },
+      {
+        heading: "Who actually works in cyber",
+        paragraphs: [
+          "Cybersecurity isn't one job. It's a family of jobs. A **security analyst** in a Security Operations Center (SOC) spends the day watching alerts and investigating suspicious activity. A **penetration tester** gets paid to break into systems — legally — and write reports about what they found. A **GRC analyst** (Governance, Risk, and Compliance) translates security requirements into policies and audits. An **incident responder** is the person you call at 3 AM when something has already gone wrong.",
+          "The people doing these jobs got there from different places. Some have computer science degrees. Some came up through IT help desk. Some came from the military. Some are self-taught through free coursework and home labs. The field cares more about whether you can do the work than where you learned it.",
+        ],
+        keyTerms: [
+          { term: "SOC", definition: "Security Operations Center — the team that monitors security alerts in real time." },
+          { term: "GRC", definition: "Governance, Risk, and Compliance — the policy, audit, and risk-management side of security." },
+          { term: "Pen test", definition: "Penetration test — authorized attempt to break into a system to find weaknesses." },
+        ],
+      },
+      {
+        heading: "The threats you'll hear about most",
+        paragraphs: [
+          "**Phishing** is the single most common starting point for a successful attack. An email or text pretends to be from a bank, a delivery service, or a coworker, and tries to get the target to click a link or hand over a password. Industry breach reports consistently put the share of breaches that started with phishing or social engineering above 70%.",
+          "**Ransomware** locks up a victim's files and demands payment for the decryption key. The 2017 WannaCry attack shut down hospitals across the UK. The 2021 Colonial Pipeline attack disrupted fuel supply across the U.S. East Coast for several days.",
+          "**Insider threats** include both malicious employees and well-meaning ones who click the wrong link. **Data breaches** like Equifax in 2017 and Target in 2013 lose huge volumes of personal data at once, often because of a single missed update or a stolen vendor login.",
+        ],
+        callout: "Most breaches start with a person, not a machine. Defending people is most of the job.",
+      },
+    ],
+    citations: [
+      "U.S. Bureau of Labor Statistics, Occupational Outlook Handbook: Information Security Analysts — https://www.bls.gov/ooh/computer-and-information-technology/information-security-analysts.htm",
+      "NIST CyberSeek — https://www.cyberseek.org/heatmap.html",
+      "ISC2 Cybersecurity Workforce Study — https://www.isc2.org/research",
+      "Equifax 2017 data breach: U.S. Government Accountability Office report (GAO-18-559)",
+      "Verizon Data Breach Investigations Report — https://www.verizon.com/business/resources/reports/dbir/",
+    ],
+  },
+  lesson: {
+    estMinutes: 18,
+    intro: "Walk through a day in the life of a Security Operations Center analyst. Each scene shows what the work actually looks like — and gives you a small choice. There are no wrong answers; the feedback explains what an experienced analyst would weigh.",
+    scenes: [
+      {
+        title: "7:00 AM — Reviewing the overnight queue",
+        body: "You open your laptop and a SIEM dashboard fills the screen. There are 412 alerts from the overnight shift. About 380 are routine — failed logins from people who fat-fingered their password. A handful look more interesting: repeated authentication failures from one IP, followed by a success.",
+        choice: {
+          prompt: "Where do you focus first?",
+          options: [
+            { label: "Start with the oldest alerts, work forward", feedback: "Methodical, but you'll burn the morning on noise. Most SOC analysts triage by severity, not chronology." },
+            { label: "The 'failed, failed, success' pattern from one IP", feedback: "Strong choice. That pattern is consistent with a password-guessing attack that eventually got in. It belongs at the top of the queue." },
+            { label: "Ignore all the failed logins — they happen all day", feedback: "Risky. Failed logins are noisy, but a successful login at the end of a series of failures is a classic indicator of compromise." },
+          ],
+        },
+      },
+      {
+        title: "9:00 AM — A flagged email",
+        body: "A user forwarded an email to the abuse@ inbox: 'Looks weird, can you check?' The email claims to be from the company's CFO and asks the recipient to buy gift cards for a client appreciation event, urgently, and reply with the codes.",
+        choice: {
+          prompt: "What do you do first?",
+          options: [
+            { label: "Reply telling the user it's almost certainly fake", feedback: "Good instinct, but reply too fast and you'll miss verifying. Confirm first." },
+            { label: "Look up whether the email actually came from the CFO's account", feedback: "Right. The 'From' line can be spoofed. Check the email headers and the actual sending domain before doing anything else." },
+            { label: "Forward it to the CFO directly to ask", feedback: "Avoid this — if the CFO's account is compromised, you've just tipped off the attacker. Verify through a separate channel." },
+          ],
+        },
+      },
+      {
+        title: "11:00 AM — Vulnerability briefing",
+        body: "A new vulnerability was published overnight in a piece of software your company uses on dozens of servers. The vendor has released a patch. Your job is to brief the engineering team.",
+        choice: {
+          prompt: "What does the team most need from you?",
+          options: [
+            { label: "The technical details of the bug", feedback: "Some of them want that, but not all. Start with what they actually need: how bad it is, what they have to do, and by when." },
+            { label: "A risk rating and a deadline for patching", feedback: "Yes. The job is to translate the vulnerability into a decision the team can act on." },
+            { label: "A complete copy of the vendor advisory", feedback: "They can read that themselves. Your value is making it short and clear." },
+          ],
+        },
+      },
+      {
+        title: "1:00 PM — Firewall rule change request",
+        body: "An engineer wants to open a port through the firewall so a new service can talk to a payment provider. They sent you a ticket with the source IP, destination IP, and port. They want it done today.",
+        choice: {
+          prompt: "What do you ask before approving?",
+          options: [
+            { label: "Nothing — they own the service, just open it", feedback: "Too fast. Firewall changes are reviewed because they widen the attack surface." },
+            { label: "Whether the destination is on an allowlist and what the service does", feedback: "Right. Least privilege and traceability — those are the questions every change should answer." },
+            { label: "Whether the change can wait until next month", feedback: "Maybe, but you don't have grounds to delay it without understanding the request." },
+          ],
+        },
+      },
+      {
+        title: "3:00 PM — Writing an incident report",
+        body: "Yesterday's phishing investigation is closed. The user clicked, but the attacker didn't get further than a single account, which you locked within 20 minutes. You're writing the after-action report.",
+        choice: {
+          prompt: "What's the single most valuable thing to include?",
+          options: [
+            { label: "A long technical timeline of every action you took", feedback: "Useful for the file, but not what makes the report valuable." },
+            { label: "The lesson learned and one change you'd recommend", feedback: "Right. Incident reports that don't change anything aren't worth writing." },
+            { label: "Quotes from the user about how it happened", feedback: "Helpful context, but secondary to the recommendation." },
+          ],
+        },
+      },
+      {
+        title: "5:00 PM — Handoff to the evening shift",
+        body: "You're about to leave. The evening analyst is just signing in. They ask: 'Anything I need to know?'",
+        choice: {
+          prompt: "What do you say?",
+          options: [
+            { label: "Nothing major, have a good shift", feedback: "Almost never the right answer. There's always context worth passing." },
+            { label: "The two open investigations and what's expected to come in tonight", feedback: "Right. Good handoffs are why incidents don't fall through the cracks." },
+            { label: "A long verbal recap of the whole day", feedback: "Too much. Hand off what's still open and what to watch for; the rest is in tickets." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 12,
+    intro: "Match each person to the cyber role that fits them best. There are no single right answers — the feedback explains what an experienced mentor would say. Take multiple attempts; this is about pattern recognition, not a test.",
+    items: [
+      {
+        prompt: '"I love puzzles. I notice patterns nobody else does. I want to work from home and not have to be on calls all day."',
+        options: [
+          { label: "Threat Hunter / SOC Analyst", correct: true, feedback: "Strong match. Threat hunting is heavy pattern-recognition work and remote-friendly at many companies." },
+          { label: "Sales Engineer (cyber tools)", correct: false, feedback: "Sales engineers spend a lot of time on calls — probably not the right fit." },
+          { label: "Penetration Tester", correct: true, feedback: "Also a good fit. Pen testers solve puzzles for a living, and a lot of the work is remote." },
+        ],
+      },
+      {
+        prompt: '"I\'m a strong writer and a strong communicator. I like translating tech for people who don\'t live in it."',
+        options: [
+          { label: "GRC Analyst", correct: true, feedback: "Yes. GRC roles translate technical risk into policy and decisions for non-technical leaders." },
+          { label: "Reverse Engineer / Malware Analyst", correct: false, feedback: "Communication matters, but this role is deeply technical with less writing." },
+          { label: "Security Awareness Trainer", correct: true, feedback: "Strong fit. Half the job is writing and presenting." },
+        ],
+      },
+      {
+        prompt: '"I\'m into infrastructure. I want to build secure systems, not just monitor them."',
+        options: [
+          { label: "Security Engineer / Cloud Security Engineer", correct: true, feedback: "Right match. These roles design and build the defenses other people use." },
+          { label: "Incident Responder", correct: false, feedback: "Incident response is reactive — focused on what's already gone wrong, not on building." },
+          { label: "Identity & Access Management (IAM) Engineer", correct: true, feedback: "Also a strong fit. IAM is a core piece of system design." },
+        ],
+      },
+      {
+        prompt: '"I want a job where I respond to real emergencies. I do well under pressure."',
+        options: [
+          { label: "Incident Responder / DFIR", correct: true, feedback: "Exactly. Digital forensics and incident response is built around emergencies." },
+          { label: "Compliance Auditor", correct: false, feedback: "Important work, but slower-paced and process-driven." },
+          { label: "SOC Tier-2/Tier-3 Analyst", correct: true, feedback: "Tier-2 and Tier-3 SOC roles handle live incidents that the front-line couldn't resolve." },
+        ],
+      },
+      {
+        prompt: '"I have a non-technical background. I want to get into cyber but I don\'t know where to start."',
+        options: [
+          { label: "Start with ISC2 Certified in Cybersecurity (CC) — free, 16+ eligible", correct: true, feedback: "Yes. ISC2 CC is the most accessible starting credential, and the first year is free under their One Million pledge." },
+          { label: "Get a four-year degree first", correct: false, feedback: "Some people do, but it isn't required. Certifications and home-lab work can get you to entry-level faster." },
+          { label: "Start with IT help desk or technical support", correct: true, feedback: "Also a real path. Many SOC analysts came from help desk." },
+        ],
+      },
+      {
+        prompt: '"I want to break things. Legally."',
+        options: [
+          { label: "Penetration Tester / Red Team", correct: true, feedback: "Exact match. Pen testers are paid to break in legally and write up what they found." },
+          { label: "Bug Bounty Hunter", correct: true, feedback: "Also a fit. Bug bounty platforms let you do this on a freelance basis." },
+          { label: "Compliance Auditor", correct: false, feedback: "Auditors check whether controls exist, not whether they hold up against an attacker." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "Cyber in your world",
+    prompt: "For the next week, notice how often cybersecurity touches your daily life. Then come back to this module and submit your reflection.",
+    instructions: [
+      "Keep a running count: every time a system asks you to log in, every 2FA code you get, every 'this site is not secure' warning, every app update — count it.",
+      "List 3 specific examples that stood out to you.",
+      "Write one thing that surprised you. Was it more often than you expected? Less?",
+    ],
+    placeholder: "Example: I noticed I unlocked my phone 67 times in one day. The most surprising one was the school portal asking for 2FA every time — I usually just click through it without thinking.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 2 — Digital Safety Sim
+// ────────────────────────────────────────────────────────────────────────────
+
+const DIGITAL_SAFETY: ModuleContent = {
+  slug: "digital-safety-sim",
+  title: "Digital Safety Sim",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "It doesn't happen to dumb people",
+    paragraphs: [
+      "Picture this: it's a Tuesday afternoon. You're between classes. Your phone buzzes with a text from what looks like your bank: 'Suspicious login detected. Verify your account at the link below to keep access.' The link looks right. The logo looks right. You're in a hurry.",
+      "You tap. You log in. Twenty minutes later, your account is empty.",
+      "This is not a story about a person who didn't know better. It's a story about a person who was busy. That's how almost every successful attack works — not by outsmarting you, but by catching you while you're not paying attention.",
+    ],
+    closer: "The good news: a handful of habits stop most of these attacks cold. Let's build them.",
+  },
+  reading: {
+    estMinutes: 12,
+    sections: [
+      {
+        heading: "How attackers actually think",
+        paragraphs: [
+          "When you picture a hacker, you probably picture someone typing furiously, breaking through a firewall. That's a movie. The real version is more boring and a lot more effective.",
+          "Real attackers don't usually break in. They get invited in. Their main tool is **social engineering** — the art of manipulating people into giving up information or access. It works because humans are predictable. We trust messages that look familiar, we respond to urgency, we want to help, and we don't want to look stupid.",
+          "An attacker who can get one person on the inside to click one link almost always gets further than one who tries to brute-force their way through the technical defenses.",
+        ],
+        callout: "Most attacks don't break in. They get invited in.",
+        keyTerms: [
+          { term: "Social engineering", definition: "Manipulating people to disclose information or perform actions, instead of attacking systems directly." },
+        ],
+      },
+      {
+        heading: "The big five attacks aimed at you",
+        paragraphs: [
+          "**Phishing** is a fake message — usually email — that tries to get you to click, log in, or pay. Industry breach reports consistently find that the majority of breaches involve a human element, and phishing is the most common entry point.",
+          "**Smishing** is the same idea, by text message. People tend to be less skeptical of texts than email, which makes smishing more dangerous, not less.",
+          "**Vishing** is phone-based. A caller claims to be from the IRS, your bank, or your school's tech support. The urgency feels real because it's a live human voice on the other end.",
+          "**Credential stuffing** is when an attacker takes a list of passwords leaked from one site and tries them on every other site. It works because most people reuse passwords. If your email/password combination has ever appeared in a breach, someone has tried it on a hundred other services.",
+          "**MFA fatigue** is newer. An attacker who already has your password spams login attempts at 2 AM. The push notification keeps buzzing. Eventually, half-asleep, you tap Approve. They're in.",
+        ],
+      },
+      {
+        heading: "Your defense layers",
+        paragraphs: [
+          "**Long, unique passwords on every account.** The current NIST guidance (SP 800-63B) is that length beats complexity — a 16-character passphrase is stronger and easier to remember than 'P@ssw0rd1!'. The most important rule is uniqueness: never reuse passwords across accounts that matter.",
+          "**Use a password manager.** You cannot keep track of 80 unique passwords in your head. Free options that work well: Bitwarden, KeePassXC, and the password manager built into your browser. Pick one and start with your most important accounts.",
+          "**Turn on multi-factor authentication everywhere it's offered.** Especially for email — your email is the recovery channel for everything else. An attacker who controls your email can reset most of your other passwords.",
+          "**Develop a healthy skepticism.** If a message feels urgent — 'act now,' 'verify immediately,' 'your account will be closed' — that urgency is the attack. Real institutions don't demand instant action through unverified links.",
+          "**Verify out-of-band.** If your bank texts you, don't tap the link. Open the bank's app or type the URL yourself. If your boss emails you urgently, message them on a separate channel before you act.",
+        ],
+        callout: "Length beats complexity. Uniqueness beats both. A password manager makes both possible.",
+      },
+      {
+        heading: "When you slip up anyway",
+        paragraphs: [
+          "Everyone slips eventually. The difference between a small incident and a bad one is what you do in the first hour.",
+          "Don't panic. Change the password on the compromised account immediately, then change it on every other account where you reused that password. Turn on MFA if it wasn't already on. Check **Have I Been Pwned** to see if your email has appeared in known breaches. Monitor financial accounts and your inbox for the next 30 days for suspicious activity.",
+          "If a school, work, or government account is affected, report it through the proper channel. Reporting matters even if nothing visibly bad happened — your report is what helps the security team catch the next attempt.",
+        ],
+      },
+    ],
+    citations: [
+      "NIST SP 800-63B Digital Identity Guidelines — https://pages.nist.gov/800-63-3/sp800-63b.html",
+      "Verizon Data Breach Investigations Report — https://www.verizon.com/business/resources/reports/dbir/",
+      "Have I Been Pwned — https://haveibeenpwned.com/",
+      "CISA Phishing Guidance — https://www.cisa.gov/news-events/news/avoiding-social-engineering-and-phishing-attacks",
+    ],
+  },
+  lesson: {
+    estMinutes: 18,
+    intro: "Five scenarios. In each one, you're the person being targeted. Pick the move that an experienced person would make. Feedback explains the reasoning.",
+    scenes: [
+      {
+        title: "The 'bank' text",
+        body: "It's lunch break. Your phone buzzes: 'CHASE ALERT: A $480 charge was attempted on your card. If this wasn't you, verify at chase-secure-verify.com/login within 30 minutes.'",
+        choice: {
+          prompt: "What do you do?",
+          options: [
+            { label: "Tap the link and log in to check", feedback: "This is the trap. The domain isn't actually Chase's. Once you log in, your credentials are in attacker hands." },
+            { label: "Open the Chase app yourself and check your account", feedback: "Right. Always verify through the channel you trust, not the channel that contacted you." },
+            { label: "Ignore it — it's probably nothing", feedback: "Risky. The right move is to verify, not to ignore. But the verification path should be your own." },
+          ],
+        },
+      },
+      {
+        title: "The new password",
+        body: "You're setting up a new account. The site asks for a password. You usually pick one of three passwords you've memorized.",
+        choice: {
+          prompt: "What do you pick?",
+          options: [
+            { label: "One of your three usual passwords", feedback: "If any of those passwords has ever appeared in a breach, this new account is already at risk." },
+            { label: "A long passphrase generated by your password manager", feedback: "Best move. Unique per account, long enough to resist guessing, and you don't have to remember it." },
+            { label: "Your dog's name with a number on the end", feedback: "Common pattern, easy to guess from your social media. Skip it." },
+          ],
+        },
+      },
+      {
+        title: "The 'IT help desk' call",
+        body: "A caller says they're from your school's IT help desk and need your login to clear a problem with your account. They sound professional and have your name.",
+        choice: {
+          prompt: "What do you say?",
+          options: [
+            { label: "Give them your login — they're from the school", feedback: "Real IT will not ask for your password over the phone. This is vishing." },
+            { label: "Hang up and call the school's IT line yourself", feedback: "Right. Verify through a channel you initiate. Real IT will be unsurprised by a callback." },
+            { label: "Tell them to email you instead", feedback: "Better than handing over your password, but you've left the door open. End the call and verify on your terms." },
+          ],
+        },
+      },
+      {
+        title: "The coffee-shop WiFi",
+        body: "You sit down at a café. There are three open WiFi networks: 'CafeGuest_Free', 'Cafe-WiFi', and 'CafeFreeFastWiFi'. None ask for a password.",
+        choice: {
+          prompt: "What do you do?",
+          options: [
+            { label: "Pick whichever has the strongest signal", feedback: "Risky. One of these is probably the real café network, but the others could be attacker hotspots watching your traffic." },
+            { label: "Ask the staff which network is theirs, then use it", feedback: "Right. Confirm the actual network name. Avoid the imposters." },
+            { label: "Use your phone's hotspot instead", feedback: "Also right. Cellular data is encrypted between your phone and the carrier — a fine fallback." },
+          ],
+        },
+      },
+      {
+        title: "The 2 AM MFA spam",
+        body: "It's 2 AM. Your phone keeps buzzing with login approval requests for your school email account. You're half-asleep. Tapping Approve would make it stop.",
+        choice: {
+          prompt: "What do you do?",
+          options: [
+            { label: "Tap Approve so you can sleep", feedback: "Don't. This is MFA fatigue — the attacker already has your password and is hoping you'll cave. Approving lets them in." },
+            { label: "Deny each request and change your password immediately", feedback: "Exactly right. The fact that you're getting prompts at all means someone else knows your password." },
+            { label: "Turn the phone on silent and deal with it tomorrow", feedback: "You'll stop the buzzing, but the attacker is still trying. Change the password now." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 12,
+    intro: "Six phishing-style messages. For each one, pick the red flag that should make you slow down. Multiple flags can be correct — the feedback explains the call.",
+    items: [
+      {
+        prompt: "From: amaz0n-orders@account-verify.net — Subject: ⚠️ Your order has been suspended — verify now",
+        options: [
+          { label: "The sender domain is wrong", correct: true, feedback: "Right. Real Amazon emails come from @amazon.com, not @account-verify.net." },
+          { label: "The urgency language", correct: true, feedback: "Right. 'Verify now' urgency is a classic phishing pressure tactic." },
+          { label: "The emoji in the subject line", correct: false, feedback: "Real companies use emoji sometimes. Not by itself a red flag." },
+        ],
+      },
+      {
+        prompt: "From: principal@your-school.edu — Subject: Urgent — student aid forms — please pay $50 by 5pm",
+        options: [
+          { label: "Schools don't ask for payment through email links", correct: true, feedback: "Right. Verify through the school portal, not an email link." },
+          { label: "The principal would not send this personally", correct: true, feedback: "Often true. Even if the address looks right, the request pattern is the suspicious part." },
+          { label: "The subject line is in all caps", correct: false, feedback: "It isn't actually in all caps here. The real flags are the payment request and the urgency." },
+        ],
+      },
+      {
+        prompt: "Text from +1-555-019-3344: 'USPS: Your package could not be delivered. Update address: usps-redelivery.info/update'",
+        options: [
+          { label: "The URL is not a USPS domain", correct: true, feedback: "Right. Real USPS messages link to usps.com, not lookalike domains." },
+          { label: "USPS doesn't text you out of the blue", correct: true, feedback: "Right. If you didn't sign up for tracking texts, you shouldn't receive them." },
+          { label: "The phone number isn't formatted nicely", correct: false, feedback: "Many real messages come from short codes or odd numbers. That alone isn't the flag." },
+        ],
+      },
+      {
+        prompt: "From: cfo@company-name.com — Subject: Quick favor — need you to buy gift cards for client thank-yous",
+        options: [
+          { label: "Gift card requests are a classic scam pattern", correct: true, feedback: "Right. Any request to buy gift cards and send codes is almost always a scam." },
+          { label: "An executive would normally route this through accounting", correct: true, feedback: "Right. The shortcut around process is part of the scam." },
+          { label: "It's friendly and casual", correct: false, feedback: "Casual tone is normal. The red flags are the request type and the urgency." },
+        ],
+      },
+      {
+        prompt: "From: hr-benefits@yourcompany-mail.com — Subject: Re-confirm your direct deposit by EOD",
+        options: [
+          { label: "Sender domain is a lookalike, not the real company domain", correct: true, feedback: "Right. 'yourcompany-mail.com' ≠ 'yourcompany.com'." },
+          { label: "Direct deposit changes are an attacker's payday", correct: true, feedback: "Right. Payroll fraud is a major theme of business-email-compromise attacks." },
+          { label: "The deadline is the same day", correct: true, feedback: "Right. Urgency is the pressure tactic." },
+        ],
+      },
+      {
+        prompt: "DM from a 'recruiter' on LinkedIn: 'We have a $90K junior cyber role, fully remote. Please send your resume and SSN to confirm identity for the background check.'",
+        options: [
+          { label: "Legitimate recruiters never ask for an SSN before an interview", correct: true, feedback: "Right. SSN at first contact is identity theft, not recruiting." },
+          { label: "The salary is suspiciously high for entry-level remote", correct: true, feedback: "Right. 'Too good to be true' is itself a red flag." },
+          { label: "Recruiters reach out on LinkedIn all the time", correct: false, feedback: "True, but the ask is the problem, not the channel." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "Account audit",
+    prompt: "Pick the 5 most important accounts in your life. For each one, walk through this checklist and bring back the results.",
+    instructions: [
+      "Account name (just initials are fine if you'd rather not name it).",
+      "Is the password unique to this account? (Yes / No)",
+      "Is MFA turned on? (Yes / No / Not available)",
+      "Is the recovery email/phone current? (Yes / No)",
+      "One action you'll take in the next 7 days to make this account safer.",
+    ],
+    placeholder: "Example: 1) School email — password is unique, MFA on, recovery up to date — action: nothing needed. 2) Personal email — password reused, MFA off — action: turn on MFA this weekend.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 3 — Network Basics
+// ────────────────────────────────────────────────────────────────────────────
+
+const NETWORK_BASICS: ModuleContent = {
+  slug: "network-basics",
+  title: "Network Basics",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "Fifty milliseconds, a dozen systems",
+    paragraphs: [
+      "You tap a TikTok video. About fifty milliseconds later, the video starts playing. In that fifty milliseconds, your request travels through more than a dozen separate systems — your phone's WiFi chip, your home router, your internet provider, a DNS server, transit networks, a content delivery network, and the actual TikTok servers. Each one is a place where things can go right or wrong.",
+      "Almost every cybersecurity job comes back to this picture. The SOC analyst watching for attacks reads logs from these systems. The penetration tester finds gaps between them. The network engineer designs and defends them.",
+    ],
+    closer: "If you understand how data actually moves, the rest of cybersecurity gets simpler. Let's trace the path.",
+  },
+  reading: {
+    estMinutes: 13,
+    sections: [
+      {
+        heading: "What is a network?",
+        paragraphs: [
+          "A **network** is a group of computers that can talk to each other. Your home is a small network: your phone, laptop, smart TV, and game console all connect to the same router. Your school is a bigger one. The internet is the network of all networks.",
+          "Networks come in two main flavors. A **LAN** (Local Area Network) is contained — your house, your school, an office. A **WAN** (Wide Area Network) connects LANs across distance, usually through internet provider infrastructure. The path your TikTok request takes is mostly WAN.",
+          "Within any network, devices play different roles. A **client** is a device that asks for something — your phone asking for a video. A **server** is a device that provides something — TikTok's machines holding the video. The same device can play both roles, but at any given moment, one side is asking and the other is answering.",
+        ],
+        keyTerms: [
+          { term: "LAN", definition: "Local Area Network — devices in one physical location (a home, school, office)." },
+          { term: "WAN", definition: "Wide Area Network — connects networks across geographic distance, including the public internet." },
+        ],
+      },
+      {
+        heading: "How data actually travels",
+        paragraphs: [
+          "When you tap that video, your phone doesn't send 'play this video' as one big message. It breaks the request into **packets** — small numbered envelopes — and sends them out one at a time. Each packet has a header (where it's going, where it came from, what number it is in the sequence) and a payload (the actual data).",
+          "Each device on a network has an **IP address** — a numeric label like 192.168.1.42 or an IPv6 equivalent. IP addresses work like street addresses for the internet. Without them, packets wouldn't know where to go.",
+          "But you don't type IP addresses. You type tiktok.com. That's what **DNS** (the Domain Name System) is for. DNS is the internet's phone book: it translates human-readable names into the IP addresses computers actually use. Most of the time you never notice DNS — until it breaks, and then nothing works.",
+          "All of this happens according to **protocols** — agreed-upon rules. **TCP** is the protocol that makes sure packets arrive in order and complete (your TikTok video can't have missing frames). **UDP** is faster but doesn't guarantee delivery (good for live video calls where 'now' beats 'perfect'). **HTTP** and **HTTPS** are the protocols that web traffic rides on top of TCP.",
+        ],
+        callout: "Packets, addresses, names, rules. Almost every network problem is one of these four things misbehaving.",
+        keyTerms: [
+          { term: "Packet", definition: "A small piece of data with addressing info — the basic unit networks move around." },
+          { term: "IP address", definition: "Numeric identifier for a device on a network." },
+          { term: "DNS", definition: "Domain Name System — translates names like tiktok.com into IP addresses." },
+          { term: "TCP / UDP", definition: "Transport protocols. TCP is reliable and ordered. UDP is fast and best-effort." },
+        ],
+      },
+      {
+        heading: "HTTP vs HTTPS — and why the lock matters",
+        paragraphs: [
+          "**HTTP** is the original protocol for the web. It's plain text. Anyone who can see the network traffic — your roommate on the same WiFi, the coffee shop's router operator, an attacker who set up a fake hotspot — can read everything you send and receive.",
+          "**HTTPS** is HTTP wrapped in **TLS** (Transport Layer Security), which encrypts the traffic. That's what the lock icon in your browser means. With HTTPS, even someone watching the network can see that you talked to a server, but not what you said.",
+          "This is why every login page should be HTTPS. If you ever see a site asking for a password over plain HTTP, walk away. Modern browsers will mark those sites with 'Not Secure.'",
+        ],
+        callout: "The 'S' in HTTPS is the difference between a postcard and a sealed envelope.",
+      },
+      {
+        heading: "Network security devices",
+        paragraphs: [
+          "**Firewalls** are filters that decide which traffic gets through. A firewall sits between your network and the rest of the internet and enforces rules: this kind of traffic to that destination is allowed, this other kind is blocked. Almost every business network has firewalls.",
+          "**VPNs** (Virtual Private Networks) create an encrypted tunnel between two endpoints. When you connect to your school's VPN, your laptop acts as if it were physically inside the school's network, even if you're at home. VPNs are how remote workers get safe access to internal systems.",
+          "**IDS** (Intrusion Detection Systems) watch network traffic and raise alerts when something looks suspicious. **IPS** (Intrusion Prevention Systems) do the same thing but also block the traffic automatically. SOC analysts spend a lot of time reviewing IDS alerts.",
+        ],
+      },
+    ],
+    citations: [
+      "Cisco Networking Basics — https://www.cisco.com/c/en/us/solutions/small-business/resource-center/networking/networking-basics.html",
+      "IETF RFC 9110 (HTTP Semantics) — https://datatracker.ietf.org/doc/rfc9110/",
+      "Mozilla MDN — How the Web Works — https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works",
+      "NIST SP 800-41 (Guidelines on Firewalls) — https://csrc.nist.gov/publications/detail/sp/800-41/rev-1/final",
+    ],
+  },
+  lesson: {
+    estMinutes: 18,
+    intro: "Trace a single web request from your laptop to a server and back. Each scene is one hop in the journey. Pick what you think happens at that hop — the feedback fills in what's actually going on.",
+    scenes: [
+      {
+        title: "You type the URL",
+        body: "You open a browser and type 'tiktok.com' in the address bar.",
+        choice: {
+          prompt: "What does the browser need to do first?",
+          options: [
+            { label: "Send a packet to tiktok.com", feedback: "Almost — but the browser doesn't yet know where tiktok.com is. It needs an IP address first." },
+            { label: "Ask a DNS server to look up the IP address for tiktok.com", feedback: "Right. DNS resolution happens before any actual data is sent." },
+            { label: "Encrypt the URL", feedback: "Encryption comes later, once the connection is being set up." },
+          ],
+        },
+      },
+      {
+        title: "DNS responds",
+        body: "The DNS server returns an IP address, like 142.250.190.78. Your laptop now knows where to send packets.",
+        choice: {
+          prompt: "What happens if DNS is slow or wrong?",
+          options: [
+            { label: "Pages fail to load even though your network is fine", feedback: "Right. Most 'the internet is broken' calls are actually DNS problems." },
+            { label: "Your IP address changes", feedback: "DNS doesn't change your IP — it just tells you the IP of where you're trying to reach." },
+            { label: "Your password is exposed", feedback: "DNS issues don't directly leak passwords — though attackers do try to poison DNS to redirect you somewhere malicious." },
+          ],
+        },
+      },
+      {
+        title: "Setting up HTTPS",
+        body: "Your laptop opens a TCP connection to the TikTok server, then begins the TLS handshake — agreeing on encryption keys with the server.",
+        choice: {
+          prompt: "Why does this handshake matter for security?",
+          options: [
+            { label: "It encrypts everything that comes after, so the network can't read it", feedback: "Right. Once the handshake is done, attackers on the network see noise, not your traffic." },
+            { label: "It makes the connection faster", feedback: "It actually adds a small delay — the trade-off is worth it for security." },
+            { label: "It hides your IP address", feedback: "TLS doesn't hide your IP. A VPN can, but TLS is about content encryption." },
+          ],
+        },
+      },
+      {
+        title: "Through the router",
+        body: "Your packets leave your laptop and hit your home router, which forwards them out to your internet provider.",
+        choice: {
+          prompt: "What does the router do at this point?",
+          options: [
+            { label: "Inspect the contents of every packet", feedback: "Most home routers don't inspect contents — they just route. Some business firewalls do deeper inspection." },
+            { label: "Add its own address so return packets know where to come back", feedback: "Right. This is called NAT (Network Address Translation) — it's how multiple devices share one public IP." },
+            { label: "Slow the packets down on purpose", feedback: "Not intentionally. Routers add a small amount of latency but they're trying to forward as fast as they can." },
+          ],
+        },
+      },
+      {
+        title: "Hitting a firewall",
+        body: "Somewhere between you and TikTok, packets pass through one or more firewalls — at your ISP, at TikTok's data center, or both.",
+        choice: {
+          prompt: "What does a firewall actually do?",
+          options: [
+            { label: "Lets through traffic that matches its allowed rules and blocks the rest", feedback: "Right. Firewalls enforce a policy — what's permitted, in which direction, on which port." },
+            { label: "Encrypts traffic", feedback: "That's TLS, not a firewall. Firewalls filter; they don't usually encrypt." },
+            { label: "Speeds up the connection", feedback: "Firewalls add a small overhead. They don't speed traffic up." },
+          ],
+        },
+      },
+      {
+        title: "Server responds",
+        body: "The TikTok server processes your request and sends back the video data, packet by packet.",
+        choice: {
+          prompt: "What ensures all the packets arrive in the right order?",
+          options: [
+            { label: "TCP", feedback: "Right. TCP handles ordering, retransmission of lost packets, and confirmation of receipt." },
+            { label: "DNS", feedback: "DNS is for name lookups, not data delivery." },
+            { label: "The firewall", feedback: "Firewalls filter — they don't reorder packets." },
+          ],
+        },
+      },
+      {
+        title: "Video plays",
+        body: "Your phone reassembles the packets and starts the video. The whole journey took about 50 milliseconds.",
+        choice: {
+          prompt: "Looking back at the path — where could an attacker most easily insert themselves?",
+          options: [
+            { label: "Between you and the WiFi router (e.g., on a public hotspot)", feedback: "Right. The closer to you, the easier to intercept — especially on open WiFi without HTTPS." },
+            { label: "Inside the TikTok data center", feedback: "Possible but far harder. Big cloud operators have heavy defenses inside their perimeter." },
+            { label: "Inside the DNS server's hard drive", feedback: "Not the typical attack — DNS attacks usually intercept the queries in flight or poison the cache, not the disk." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 12,
+    intro: "Six network scenarios. For each one, identify what is happening and what could go wrong. The feedback explains a defender's read.",
+    items: [
+      {
+        prompt: "A laptop joins an open coffee-shop WiFi network with no password.",
+        options: [
+          { label: "Anyone on the same network can potentially see plain-text traffic", correct: true, feedback: "Right. Open WiFi means no link-layer encryption. HTTPS still protects HTTPS traffic, but DNS and other plain protocols leak." },
+          { label: "The laptop is automatically encrypted by the WiFi", correct: false, feedback: "Open WiFi doesn't encrypt — that's the definition of 'open.'" },
+          { label: "A VPN would mitigate most of the eavesdropping risk", correct: true, feedback: "Right. A VPN tunnels everything through an encrypted connection, so the local network can't read it." },
+        ],
+      },
+      {
+        prompt: "A user clicks a link to 'paypa1.com' (with a number 1 instead of a letter L).",
+        options: [
+          { label: "This is a typosquat — a fake domain that looks like the real one", correct: true, feedback: "Right. Attackers register lookalike domains to catch fast-moving readers." },
+          { label: "DNS will refuse to resolve it because it's misspelled", correct: false, feedback: "DNS happily resolves any registered domain, including lookalikes." },
+          { label: "The browser will block it automatically", correct: false, feedback: "Sometimes a browser will flag a known phishing site, but it can't catch every new lookalike." },
+        ],
+      },
+      {
+        prompt: "A company server is getting 8,000 failed login attempts per minute from many different IP addresses.",
+        options: [
+          { label: "This looks like a distributed credential-stuffing or brute-force attack", correct: true, feedback: "Right. The 'many different IPs' part is the signature of a botnet trying to spread the attack." },
+          { label: "It is probably a single user typing fast", correct: false, feedback: "No human types 8,000 attempts per minute, especially not from many IPs at once." },
+          { label: "Rate-limiting and MFA would help mitigate", correct: true, feedback: "Right. Lock out IPs that fail repeatedly, and require MFA so a leaked password alone isn't enough." },
+        ],
+      },
+      {
+        prompt: "A DNS request that normally returns in 30 milliseconds is taking 8 seconds tonight.",
+        options: [
+          { label: "It could be a benign DNS server outage", correct: true, feedback: "Right. DNS slowness is often infrastructure trouble." },
+          { label: "It could be a sign of DNS-based attack or poisoning", correct: true, feedback: "Right — sometimes the attacker is in the way. A SOC analyst would check both possibilities." },
+          { label: "It means TikTok specifically is down", correct: false, feedback: "DNS slowness affects many sites, not just one." },
+        ],
+      },
+      {
+        prompt: "An employee's laptop is trying to send a 4 GB file to an external IP at 3 AM.",
+        options: [
+          { label: "This pattern matches data exfiltration", correct: true, feedback: "Right. Large outbound transfers at off-hours are a classic exfil indicator." },
+          { label: "It is probably a normal backup", correct: false, feedback: "Possible — but the SOC should verify, not assume. Backups should be documented." },
+          { label: "An IDS or DLP system should raise an alert", correct: true, feedback: "Right. Data Loss Prevention (DLP) and IDS are designed for exactly this pattern." },
+        ],
+      },
+      {
+        prompt: "A user sees 'Not Secure' in the browser address bar on the school portal login page.",
+        options: [
+          { label: "The page is being served over HTTP, not HTTPS", correct: true, feedback: "Right. Modern browsers flag any password field on plain HTTP." },
+          { label: "Entering credentials here exposes them on the network", correct: true, feedback: "Right. Any login over HTTP can be captured by anyone in the middle." },
+          { label: "It's safe — schools always use 'Not Secure' internally", correct: false, feedback: "Not true. Real internal portals use HTTPS. Report this to IT." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "Map your home network",
+    prompt: "On paper or digitally, draw your home (or family-permitted) network. The goal is to build the habit of seeing infrastructure you normally ignore.",
+    instructions: [
+      "Identify the router. Brand and model if you can read the label.",
+      "List every device connected to it: phones, laptops, TVs, game consoles, doorbells, smart speakers, anything online.",
+      "Pick the device you think is the highest security risk and explain why in one sentence.",
+      "One concrete change you would make to improve the network's security (e.g., change a default password, segment guest WiFi, update firmware).",
+    ],
+    placeholder: "Example: Router is a Netgear R6700. Connected devices: 4 phones, 2 laptops, smart TV, Ring doorbell, 2 smart bulbs, gaming console. Highest risk: the smart bulbs — they're old and haven't been updated. Change I'd make: move all smart-home devices to the guest WiFi to keep them off the main network.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 4 — Threat Detective
+// ────────────────────────────────────────────────────────────────────────────
+
+const THREAT_DETECTIVE: ModuleContent = {
+  slug: "threat-detective",
+  title: "Threat Detective",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "It's 3:47 AM",
+    paragraphs: [
+      "It's 3:47 AM. An on-call SOC analyst's pager goes off. The SIEM dashboard shows a successful login from an IP address geolocated in a country where the company has no employees. The user account is a senior engineer's.",
+      "The analyst has fifteen minutes to make a call. Is it an employee traveling on vacation who forgot to tell IT? Is the engineer's password sitting on a credential dump from a breach last year? Is this the first move of a coordinated intrusion?",
+      "This is the job. Reading clues fast and well, with limited information, and making a defensible decision.",
+    ],
+    closer: "Threat detection is part discipline, part pattern matching, part curiosity. Let's build the muscle.",
+  },
+  reading: {
+    estMinutes: 13,
+    sections: [
+      {
+        heading: "What threat detection actually looks like",
+        paragraphs: [
+          "Inside almost every medium or large company is a **Security Operations Center**. It might be a physical room with screens, or a virtual team scattered across time zones — either way, the job is the same: watch the systems, find the bad activity, raise the alarm.",
+          "SOCs are organized in tiers. **Tier 1** triages alerts as they come in — most are false positives, some get escalated. **Tier 2** investigates the escalations. **Tier 3** handles the hard cases and contributes to detection engineering. Getting hired into Tier 1 is a common entry point into the field.",
+          "The challenge isn't a lack of data. The challenge is too much data. A typical SOC sees thousands to millions of events per day. The job is **signal versus noise** — separating what matters from what doesn't, fast.",
+        ],
+        callout: "The job isn't 'find every alert.' The job is 'find the ones that matter — fast.'",
+      },
+      {
+        heading: "Reading the logs",
+        paragraphs: [
+          "Almost every defense generates **logs** — records of what happened, when, and who or what was involved. Logs come from authentication systems, firewalls, applications, endpoints, cloud services, and more.",
+          "A typical log line looks like: '2026-05-14 03:47:12 user=jchen action=login src_ip=185.94.111.23 result=success geo=RO ua=Mozilla/5.0...'. Timestamp, user, action, source IP, outcome, sometimes geography, sometimes user-agent. Once you can read this pattern, you can read most logs.",
+          "Logs are useful as a stream (watching events in real time) and as history (searching back for evidence of an incident). SIEM (Security Information and Event Management) tools collect logs from many sources, normalize them, and let analysts query and correlate across them.",
+        ],
+        keyTerms: [
+          { term: "SIEM", definition: "Security Information and Event Management — central system that collects, correlates, and lets analysts query security logs." },
+          { term: "Endpoint", definition: "An individual computer (laptop, server, phone) — as opposed to network infrastructure." },
+        ],
+      },
+      {
+        heading: "Indicators of compromise",
+        paragraphs: [
+          "**Indicators of compromise (IOCs)** are observable signs that something bad has happened — or is about to. Some classics every analyst learns to look for:",
+          "**Impossible travel.** A user logs in from New York at 2 PM, then from Romania at 2:15 PM. Unless they have a time machine, one of those is not them.",
+          "**Failed-then-successful logins.** Lots of failures followed by a success suggest password guessing that worked.",
+          "**Off-hours activity.** A normally 9–5 user logging in at 3 AM is worth a second look — especially if they're touching unusual systems.",
+          "**Lateral movement.** A compromised laptop suddenly trying to reach servers it never normally talks to.",
+          "**Data exfiltration patterns.** Large outbound transfers, especially to file-sharing services or unusual destinations.",
+          "**Privilege escalation.** A regular user account suddenly running admin commands.",
+        ],
+        callout: "Most attacks don't look 'wrong.' They look 'unusual.' Knowing 'normal' is half the job.",
+      },
+      {
+        heading: "The incident response process",
+        paragraphs: [
+          "When an alert turns out to be real, it becomes an **incident**, and there's a process for handling it. NIST's framework (SP 800-61) has four phases:",
+          "**Preparation** — the work you do before anything happens: building playbooks, training the team, making sure logs exist.",
+          "**Detection and Analysis** — recognizing that an incident is in progress, scoping it, understanding what's affected.",
+          "**Containment, Eradication, and Recovery** — stopping the spread, removing the attacker's access, getting systems back to normal.",
+          "**Post-Incident Activity** — writing the after-action report, updating playbooks, fixing the root cause so the same thing doesn't happen again.",
+          "Most of an analyst's day is in the first two phases. The third is where adrenaline runs high. The fourth is where the real learning happens.",
+        ],
+      },
+    ],
+    citations: [
+      "NIST SP 800-61 Rev. 2 — Computer Security Incident Handling Guide — https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final",
+      "MITRE ATT&CK Framework — https://attack.mitre.org/",
+      "SANS Reading Room — Incident Handling — https://www.sans.org/white-papers/",
+      "CISA Incident Reporting — https://www.cisa.gov/topics/cyber-threats-and-advisories/incident-detection-response",
+    ],
+  },
+  lesson: {
+    estMinutes: 18,
+    intro: "Work through a single investigation, scene by scene. The 3:47 AM alert from the hook is real, and you're the analyst.",
+    scenes: [
+      {
+        title: "The alert fires",
+        body: "Login success for user 'mchen' from IP 185.94.111.23 (geolocated: Romania). User normally logs in from Austin, TX. This is your first signal.",
+        choice: {
+          prompt: "What's your first move?",
+          options: [
+            { label: "Immediately disable the user's account", feedback: "Aggressive — and sometimes right — but you don't yet know if this is an attack or a vacationing employee. Investigate before you act." },
+            { label: "Check the user's other recent activity for 'impossible travel'", feedback: "Right. Look for a prior login from a normal location close in time. If both exist, the new one is suspicious." },
+            { label: "Ignore it — Romania isn't a high-risk country", feedback: "Geography matters less than the pattern. Plenty of legitimate users travel; plenty of attackers route through 'safe' countries." },
+          ],
+        },
+      },
+      {
+        title: "Pull the user's history",
+        body: "You search the past 24 hours for this user. You see: 09:14 login from Austin. 17:42 logout. 20:15 logout (from a different device). 03:47 login from Romania.",
+        choice: {
+          prompt: "What stands out?",
+          options: [
+            { label: "Two different logouts and then a foreign login", feedback: "Right. The pattern doesn't match a coherent travel story. This looks more like account use by someone else." },
+            { label: "The user works late", feedback: "20:15 isn't late by tech standards. The 03:47 foreign login is the signal." },
+            { label: "Nothing — perfectly normal", feedback: "It's not. Two device logouts and then a Romania login at 3:47 AM is not a clean story." },
+          ],
+        },
+      },
+      {
+        title: "What did they do after logging in?",
+        body: "Post-login activity for mchen at 03:47 shows: opened the engineering wiki, downloaded three internal documents, then queried the company directory for 'CFO'.",
+        choice: {
+          prompt: "How do you read this?",
+          options: [
+            { label: "Looks like reconnaissance — mapping the environment and looking for valuable targets", feedback: "Right. Downloads of internal docs plus searches for high-value people is a classic post-compromise recon pattern." },
+            { label: "Probably just catching up on work", feedback: "At 3:47 AM from Romania, having logged out twice earlier, querying for the CFO — no. This is recon." },
+            { label: "Engineering wiki access is normal — ignore", feedback: "Access is normal in isolation. In this context it isn't." },
+          ],
+        },
+      },
+      {
+        title: "Containment decision",
+        body: "Twelve minutes in. You have to make a call.",
+        choice: {
+          prompt: "What do you do?",
+          options: [
+            { label: "Disable the account, kill active sessions, and escalate to Tier 2", feedback: "Right. The evidence is strong enough to act. Containment first, full investigation in parallel." },
+            { label: "Email the user to ask if it's them", feedback: "Don't email a possibly compromised account — the attacker reads the mail. Reach out by phone, in person, or through a separate channel." },
+            { label: "Wait until 8 AM to ask the engineer in person", feedback: "Too slow. Every minute the attacker keeps access is a minute they can do damage." },
+          ],
+        },
+      },
+      {
+        title: "Reach out to the user",
+        body: "You call the user's known cell number. Half-asleep, mchen confirms: not them, not traveling, not on the system right now. They didn't sign in.",
+        choice: {
+          prompt: "What's next?",
+          options: [
+            { label: "Confirmed incident. Trigger the IR playbook.", feedback: "Right. You now have a confirmed account takeover. Containment is partly done; the rest of the playbook governs eradication and recovery." },
+            { label: "Tell the user not to worry, you handled it", feedback: "Premature. There's still a containment, eradication, and recovery cycle to run." },
+            { label: "Re-enable the account so the user can keep working", feedback: "Absolutely not. The account stays disabled until passwords are rotated and MFA is reconfigured." },
+          ],
+        },
+      },
+      {
+        title: "Post-incident",
+        body: "It's now 7 AM. The incident is contained. You're writing the report.",
+        choice: {
+          prompt: "What's the most important thing the report should answer?",
+          options: [
+            { label: "How did the attacker get the password in the first place — and how do we stop the next one?", feedback: "Right. Root cause and prevention. An IR report that doesn't change anything is wasted work." },
+            { label: "A blow-by-blow of every keystroke you typed", feedback: "Some level of detail is useful for the file, but it's not what makes the report valuable." },
+            { label: "Whether the user should be disciplined", feedback: "Almost never — most takeovers aren't the user's fault. Focus on systemic fixes." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 12,
+    intro: "Triage drill. Ten alerts in rapid succession. Pick the right priority for each. Critical = act now. Warning = investigate this shift. Informational = log it. False Positive = noise to filter out.",
+    items: [
+      {
+        prompt: "An admin account logs in successfully from a brand-new IP at 4 AM and immediately runs commands to disable logging.",
+        options: [
+          { label: "Critical", correct: true, feedback: "Right. Admin login + log tampering at off-hours is one of the highest-priority alerts in any SOC." },
+          { label: "Warning", correct: false, feedback: "Underweighting. The disable-logging step is the giveaway — this needs immediate action." },
+          { label: "False Positive", correct: false, feedback: "Disabling logging is almost never legitimate during a live session at 4 AM." },
+        ],
+      },
+      {
+        prompt: "A user types their password wrong twice, then gets it right on the third try, from their normal device and location.",
+        options: [
+          { label: "False Positive", correct: true, feedback: "Right. Two failed attempts followed by a success from a known device is everyday user behavior." },
+          { label: "Warning", correct: false, feedback: "Pattern matters. From a known device and location, this is just a typo." },
+          { label: "Critical", correct: false, feedback: "Far too aggressive. You'd burn the team on noise." },
+        ],
+      },
+      {
+        prompt: "A workstation starts encrypting files rapidly and renaming them with a .locked extension.",
+        options: [
+          { label: "Critical", correct: true, feedback: "Right. This is ransomware in the act. Isolate the machine immediately." },
+          { label: "Warning", correct: false, feedback: "Too soft. Ransomware can spread laterally in minutes." },
+          { label: "Informational", correct: false, feedback: "This is the textbook critical alert — drop everything." },
+        ],
+      },
+      {
+        prompt: "A monthly scheduled backup job runs at 2 AM and transfers 50 GB to the backup server.",
+        options: [
+          { label: "Informational", correct: true, feedback: "Right. Scheduled, documented, known destination — log it and move on." },
+          { label: "Critical", correct: false, feedback: "Without context this could look bad, but it matches the schedule and goes to a known server." },
+          { label: "Warning", correct: false, feedback: "If the SOC has the backup schedule documented, this should be a 'don't alert' rule. At worst informational." },
+        ],
+      },
+      {
+        prompt: "A new external IP address has tried 240 different usernames against the VPN in the last hour, all failed.",
+        options: [
+          { label: "Warning — investigate and rate-limit the IP", correct: true, feedback: "Right. Failures only is bad but not catastrophic — block the IP and watch for any successes." },
+          { label: "Critical — assume account takeover", correct: false, feedback: "If there are no successes, no account is taken over yet. Warning is the right tier; the action is to block before that changes." },
+          { label: "False Positive", correct: false, feedback: "240 usernames from a single new IP is not a false positive — it's a probing attempt." },
+        ],
+      },
+      {
+        prompt: "Antivirus on one laptop flagged a file as 'low-confidence' suspicious and quarantined it.",
+        options: [
+          { label: "Informational, then verify", correct: true, feedback: "Right. Low-confidence detections are common; check whether the file is benign or pivot up if it isn't." },
+          { label: "Critical", correct: false, feedback: "Too aggressive for a low-confidence detection. Save Critical for confirmed threats." },
+          { label: "False Positive without investigating", correct: false, feedback: "Never auto-dismiss without at least a quick look." },
+        ],
+      },
+      {
+        prompt: "A junior employee accidentally emailed a file with personal data of 50 customers to the wrong external recipient.",
+        options: [
+          { label: "Warning — privacy incident, follow data-breach process", correct: true, feedback: "Right. This is a real data incident even though it's accidental. Treat it as one." },
+          { label: "Informational — they didn't mean it", correct: false, feedback: "Intent doesn't change the regulatory or contractual exposure." },
+          { label: "Critical — call the FBI", correct: false, feedback: "Privacy incidents have a defined process — follow it. The FBI isn't typically the first call." },
+        ],
+      },
+      {
+        prompt: "A scheduled vulnerability scan generated 1,200 alerts overnight, mostly informational, all from the scanner's own IP.",
+        options: [
+          { label: "False Positive — tune the rule", correct: true, feedback: "Right. The SOC should exclude its own scanners from alerting; this is noise that risks hiding real signals." },
+          { label: "Critical", correct: false, feedback: "These are not real attack alerts. Tuning is the fix." },
+          { label: "Warning", correct: false, feedback: "Excludes belong in detection engineering. Don't escalate scanner noise." },
+        ],
+      },
+      {
+        prompt: "A developer pushed a config change that briefly opened a database port to the internet for 4 minutes.",
+        options: [
+          { label: "Warning — investigate whether anyone connected in that window", correct: true, feedback: "Right. The window was small, but it existed. Check logs for any external connections during that time." },
+          { label: "Informational — it's already closed", correct: false, feedback: "Too soft. Even short exposures need verification." },
+          { label: "Critical", correct: false, feedback: "Critical is for active or sustained exposure. Four minutes that's already closed is Warning." },
+        ],
+      },
+      {
+        prompt: "A senior engineer logs in normally, does normal work for two hours, then logs out.",
+        options: [
+          { label: "Informational (or no alert at all)", correct: true, feedback: "Right. Normal activity from a known user is exactly what should NOT alert. If it is alerting, the rule is too noisy." },
+          { label: "Warning", correct: false, feedback: "Nothing about this is suspicious." },
+          { label: "Critical", correct: false, feedback: "Far too aggressive — this would burn out any team." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "Tabletop: nonprofit phishing",
+    prompt: "A small nonprofit you're consulting for had this happen at 9 AM: the executive director clicked a phishing email. Their mailbox is now sending malware-laden replies to staff. They have eight employees, one IT contractor (offsite), and a shared cloud drive. They called you.",
+    instructions: [
+      "What's the first action in the first 5 minutes?",
+      "Who do you call, and in what order?",
+      "What do you contain or shut down to keep the incident from spreading?",
+      "Write a 3-step plan in plain language the executive director can act on right now.",
+    ],
+    placeholder: "Example: 1) First 5 min: have the director sign out of email everywhere and change their password from a clean device. 2) Calls: the IT contractor, then notify the rest of the staff to stop replying to anything from her account today. 3) Contain: revoke any active email sessions, scan the inbox rules for malicious forwards the attacker may have set up.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 5 — Cyber Career Map
+// ────────────────────────────────────────────────────────────────────────────
+
+const CAREER_MAP: ModuleContent = {
+  slug: "career-map",
+  title: "Cyber Career Map",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "The map is real",
+    paragraphs: [
+      "Imagine a 19-year-old, no degree, working part-time at a phone store. They start studying for ISC2 Certified in Cybersecurity in their off hours — the certification is free in year one. Then Cisco Networking Academy's free Introduction to Cybersecurity. Then a CompTIA Security+ certification. A year later, they apply for SOC analyst roles. Many of them get callbacks.",
+      "This isn't a fantasy. It's a documented pattern. Many entry-level cyber professionals don't have four-year computer science degrees. They have a certification or two, a clear interest, and the persistence to keep going through a hundred 'no's to find the 'yes.'",
+    ],
+    closer: "There isn't one path into cyber. There are dozens. Here's the map.",
+  },
+  reading: {
+    estMinutes: 13,
+    sections: [
+      {
+        heading: "The five major pillars",
+        paragraphs: [
+          "Cybersecurity is wide. Most jobs fit into one of five pillars.",
+          "**Security Operations** is the day-to-day defense — SOC analysts, threat hunters, incident responders. If you like investigating live problems and reading clues, this is your pillar.",
+          "**Offensive Security** is the legal-attacker side — penetration testers, red teamers, bug bounty hunters. If you like puzzles and reverse-engineering, this is your pillar.",
+          "**Governance, Risk, and Compliance (GRC)** is the policy and audit side — risk analysts, compliance auditors, security awareness leads. If you're a strong writer and communicator who can translate tech for non-tech, this pillar needs you.",
+          "**Engineering and Architecture** is the build side — security engineers, cloud security engineers, identity and access management specialists, network security engineers. If you like building defenses rather than just monitoring them, this is your pillar.",
+          "**Digital Forensics and Investigation** is the after-the-fact reconstruction — DFIR analysts, malware analysts, fraud investigators. If you like piecing together what happened from limited evidence, here.",
+        ],
+      },
+      {
+        heading: "The entry-level reality check",
+        paragraphs: [
+          "Most cybersecurity job postings labeled 'entry-level' ask for one to two years of relevant experience. This is the source of the famous 'cyber experience paradox': you can't get a job without experience, and you can't get experience without a job.",
+          "There are real ways out of the paradox. **Home labs** — running a virtual SOC environment, capture-the-flag (CTF) challenges, TryHackMe and HackTheBox accounts — count as experience for the right hiring managers. **Internships and apprenticeships** (CyberFastTrack, AFA CyberPatriot, NSA Stokes Educational Scholarship Program, government Pathways programs) build the resume. **Adjacent IT roles** like help desk, junior network admin, or systems support are how a lot of SOC analysts get their start.",
+          "Salary ranges in the U.S. for entry-level cyber roles commonly fall in the $60,000–$80,000 band, with significant variation by city and specialization. Mid-level (two to five years of experience) commonly reaches $90,000–$130,000.",
+        ],
+        callout: "The experience paradox is real — but home labs, internships, and IT roles are how people get past it.",
+      },
+      {
+        heading: "Certifications that actually open doors",
+        paragraphs: [
+          "Certifications aren't required, but the right ones are taken seriously by hiring managers.",
+          "**ISC2 Certified in Cybersecurity (CC).** Free first year of certification under ISC2's 'One Million Certified in Cybersecurity' pledge. Open to candidates 16 and up. The most accessible starting credential. It's the right first step for almost everyone.",
+          "**CompTIA Security+.** The most-requested certification in U.S. job postings. Vendor-neutral. Solid foundation across all five pillars. Required for many U.S. federal cybersecurity roles under the DoD 8570 / 8140 directive.",
+          "**Cisco CCNA / CyberOps Associate.** Network-focused. The CyberOps Associate path is purpose-built for SOC roles. Cisco Networking Academy offers the prep coursework free.",
+          "**CompTIA Network+ and A+.** If you want IT help desk first as a stepping stone, these two are the standard entry credentials.",
+          "More advanced certifications (CISSP, OSCP, CEH, GIAC family) come later in a career and require experience to qualify or to make sense.",
+        ],
+        keyTerms: [
+          { term: "ISC2 CC", definition: "Certified in Cybersecurity — entry-level certification, free in year one." },
+          { term: "Security+", definition: "CompTIA's foundational vendor-neutral cybersecurity certification." },
+        ],
+      },
+      {
+        heading: "Non-traditional paths",
+        paragraphs: [
+          "Plenty of people in cyber didn't follow a straight line. Some common alternate routes:",
+          "**IT help desk → SOC analyst.** Two of the most common pipelines into security. Help desk gives you real-world exposure to user problems, ticket systems, and basic networking. Many SOCs hire directly from internal help desk teams.",
+          "**Military / government intelligence → contractor or industry.** The U.S. military and federal agencies train tens of thousands of cyber operators every year. Many transition into private-sector roles after their service.",
+          "**Self-taught + portfolio.** People who spend a year doing CTFs, writing up findings, contributing to open-source security tools, or maintaining a public blog have landed roles without traditional credentials.",
+          "**Career changers from adjacent fields.** Software developers move into application security. Network engineers move into network security. Auditors move into GRC. Communicators move into security awareness and training.",
+          "What works at every entry point is the same: pick a pillar that fits how you're wired, build a credential or two, build a portfolio of work you can show, and keep applying.",
+        ],
+      },
+    ],
+    citations: [
+      "ISC2 One Million Certified in Cybersecurity — https://www.isc2.org/landing/1mcc",
+      "CompTIA Career Roadmap — https://www.comptia.org/certifications",
+      "Cisco Networking Academy — https://www.netacad.com/",
+      "BLS Information Security Analysts — https://www.bls.gov/ooh/computer-and-information-technology/information-security-analysts.htm",
+      "NIST NICE Cybersecurity Workforce Framework — https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center",
+    ],
+  },
+  lesson: {
+    estMinutes: 17,
+    intro: "Six role cards. Each shows a day in the life, education paths people have taken to get there, and a typical salary range. Pick the one that fits you best — but read all six. People often realize on the second pass which one they actually want.",
+    scenes: [
+      {
+        title: "SOC Analyst (Tier 1)",
+        body: "Day: triage alerts, investigate suspicious logins, escalate the hard ones. Salary band: ~$55K–$80K entry, more in major metros. Paths in: IT help desk, ISC2 CC + Security+, CyberOps Associate, military cyber MOS, or just a strong portfolio of CTFs.",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — investigating live problems sounds right", feedback: "Good signal. Many people start here and move into specialization within a year or two." },
+            { label: "Maybe — I'd want to know more about shift work", feedback: "Real concern. SOCs often have 24/7 coverage; ask about shift rotation when interviewing." },
+            { label: "No — I don't want to react, I want to build", feedback: "Useful self-knowledge. Engineering and Architecture might fit better." },
+          ],
+        },
+      },
+      {
+        title: "Penetration Tester",
+        body: "Day: get paid to break into systems legally, write reports about what you found, sometimes social engineering. Salary band: ~$70K–$110K entry, well into six figures with experience. Paths in: CTFs, OSCP certification, security research, sometimes from a developer or sysadmin background.",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — I love puzzles and reverse-engineering", feedback: "Strong signal. Build a CTF portfolio. The TryHackMe and HackTheBox platforms are common starting points." },
+            { label: "Maybe — I'd want to know if it's stressful", feedback: "Some pen testing is calm research; some is high-pressure on-site engagements. Varies by employer." },
+            { label: "No — I'd rather defend than attack", feedback: "Fair. Threat hunting (offensive mindset, defender role) might split the difference for you." },
+          ],
+        },
+      },
+      {
+        title: "GRC Analyst",
+        body: "Day: read regulations, translate them into company policies, audit whether controls actually exist, advise leadership on risk. Salary band: ~$60K–$95K entry. Paths in: writing/communications backgrounds, paralegal experience, audit, ISC2 CC + a GRC-leaning track like ISACA's CSX.",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — I'm a strong writer and I like translating tech", feedback: "Strong signal. GRC pays well and is less crowded than SOC-aspirant roles." },
+            { label: "Maybe — I want to know how technical it is", feedback: "GRC is less hands-on-keyboard than SOC, but you still need to understand the controls you're auditing. Some technical depth is expected." },
+            { label: "No — I want to be on the technical side", feedback: "Fair. Security engineering might be a better fit." },
+          ],
+        },
+      },
+      {
+        title: "Security Engineer",
+        body: "Day: design and deploy defenses — firewalls, identity systems, cloud security configurations, monitoring infrastructure. Salary band: ~$80K–$120K entry, often higher in cloud or major metros. Paths in: software engineering, network engineering, systems administration, cloud certifications (AWS Security Specialty, etc.).",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — I want to build the systems other people use", feedback: "Strong signal. Security engineering is one of the better-paid and faster-growing pillars." },
+            { label: "Maybe — I'd want to know about on-call", feedback: "Security engineering often has some on-call. Worth asking about." },
+            { label: "No — I prefer investigation to construction", feedback: "Fair. SOC or DFIR is probably a better fit." },
+          ],
+        },
+      },
+      {
+        title: "Digital Forensics & Incident Response (DFIR)",
+        body: "Day: get called in after a breach. Reconstruct what happened. Recover deleted files, analyze malware, write courtroom-grade reports. Salary band: ~$70K–$110K entry, much higher with consulting experience. Paths in: SOC analyst → DFIR, law enforcement, military intelligence, dedicated DFIR programs.",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — I want to handle real emergencies", feedback: "Strong signal. DFIR is intense but consistently in demand." },
+            { label: "Maybe — I'd want to know about work-life balance", feedback: "Real concern. Major incidents often involve long hours. Some firms manage this better than others." },
+            { label: "No — I'd rather prevent incidents than clean them up", feedback: "Fair. SOC and security engineering both lean toward prevention." },
+          ],
+        },
+      },
+      {
+        title: "Cloud Security Engineer",
+        body: "Day: configure and harden AWS / Azure / GCP environments, write infrastructure-as-code with security baked in, automate audits. Salary band: ~$90K–$140K entry, frequently higher. Paths in: cloud engineering, software development, infrastructure roles, AWS / Azure / GCP security certifications.",
+        choice: {
+          prompt: "Does this fit you?",
+          options: [
+            { label: "Yes — I want to work on modern infrastructure", feedback: "Strong signal. Cloud security is one of the highest-paid and fastest-growing specialties." },
+            { label: "Maybe — I'd want to know if I need coding experience", feedback: "Yes, some. Modern cloud security work usually involves infrastructure-as-code (Terraform, CloudFormation) and scripting." },
+            { label: "No — I want to work with on-premises networks", feedback: "Fair, though shrinking. Most companies are at least partly in the cloud now." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 12,
+    intro: "Six career snapshots. Match each story to the role they ended up in. The point isn't to memorize — it's to see that there are many real paths in.",
+    items: [
+      {
+        prompt: "Spent two years working IT help desk at a community college after high school. Got the Security+ on a study schedule of one chapter per week. Got hired as a Tier 1 analyst at a regional bank.",
+        options: [
+          { label: "SOC Analyst", correct: true, feedback: "Right. Help desk → Security+ → SOC is one of the most common paths into the field." },
+          { label: "Penetration Tester", correct: false, feedback: "Possible eventually, but the direct hire from help desk + Security+ is almost always a SOC role." },
+          { label: "Cloud Security Engineer", correct: false, feedback: "Cloud security usually wants cloud experience first — AWS or Azure work history." },
+        ],
+      },
+      {
+        prompt: "Studied English literature in college. Worked in legal aid for three years. Got the ISC2 CC and took a self-study GRC course. Hired as a junior risk analyst at a healthcare company.",
+        options: [
+          { label: "GRC Analyst", correct: true, feedback: "Right. The writing/legal background is exactly what GRC values. Communication is the differentiator." },
+          { label: "Security Engineer", correct: false, feedback: "Unlikely without a technical infrastructure background." },
+          { label: "DFIR Analyst", correct: false, feedback: "Would usually require more direct technical investigation experience first." },
+        ],
+      },
+      {
+        prompt: "Served four years in the Army's signal corps. Got a Top Secret clearance. Took the Cisco CyberOps Associate during the last six months of service. Hired by a federal contractor as a SOC analyst at $85K.",
+        options: [
+          { label: "SOC Analyst", correct: true, feedback: "Right. Military signal + clearance is a fast track into federal SOC work, often at higher salaries than civilian first jobs." },
+          { label: "Pen Tester", correct: false, feedback: "Possible long-term, but the first civilian role usually leans on the existing operational training." },
+          { label: "Compliance Auditor", correct: false, feedback: "Some go this route, but the operational background fits SOC better as a first move." },
+        ],
+      },
+      {
+        prompt: "Self-taught while working full-time at a coffee shop. Did 200+ HackTheBox challenges over a year. Wrote up the trickiest ones on a personal blog. Got the OSCP. Hired by a small pen-test firm.",
+        options: [
+          { label: "Penetration Tester", correct: true, feedback: "Right. HackTheBox + OSCP + write-ups is the textbook self-taught pen test path." },
+          { label: "Security Engineer", correct: false, feedback: "Possible, but the OSCP and CTF profile point strongly to offensive work." },
+          { label: "GRC Analyst", correct: false, feedback: "Not the natural fit — GRC values writing and process, not exploit-finding." },
+        ],
+      },
+      {
+        prompt: "Worked five years as a backend developer. Started getting interested in how their company's auth system worked. Took the AWS Security Specialty cert. Moved into a cloud security role inside the same company.",
+        options: [
+          { label: "Cloud Security Engineer", correct: true, feedback: "Right. Developer + AWS Security Specialty + internal move is a very common cloud security path." },
+          { label: "SOC Analyst", correct: false, feedback: "Underuses the engineering background — this person can build, not just monitor." },
+          { label: "DFIR Analyst", correct: false, feedback: "DFIR usually wants investigation experience, not pure development experience." },
+        ],
+      },
+      {
+        prompt: "Worked at a small MSP (managed service provider) doing everything — help desk, network admin, light security. Got pulled in to handle a ransomware incident at a client. Took specialized DFIR training. Hired by an incident response firm.",
+        options: [
+          { label: "DFIR Analyst", correct: true, feedback: "Right. Real incident exposure plus specialized training is the standard DFIR path." },
+          { label: "Pen Tester", correct: false, feedback: "Different mindset — DFIR is about reconstructing what happened, not breaking in." },
+          { label: "GRC Analyst", correct: false, feedback: "Not the natural fit given the hands-on incident background." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "My 12-month plan",
+    prompt: "Write down a real plan for the next year. Bring it back here and submit. The exercise is to write it down — research shows people who write down concrete plans are significantly more likely to follow them.",
+    instructions: [
+      "Pick your top 2 cyber roles to explore further (from the lesson or beyond it).",
+      "List 3 skills you already have that transfer (communication, attention to detail, math, teamwork, anything).",
+      "List 3 skills you need to build.",
+      "Write 3 specific actions you'll take in the next 90 days (start ISC2 CC, finish Cisco NetAcad Intro to Cybersecurity, build a home lab, do a CTF, etc.). Be specific — 'study more' doesn't count.",
+      "Name one person you'll talk to about this in the next 30 days. Anyone — facilitator, family member, someone working in tech.",
+    ],
+    placeholder: "Example: Top 2 roles: SOC analyst, cloud security engineer. Transferable skills: writing, pattern recognition, working under pressure (from sports). Skills to build: networking fundamentals, scripting, log analysis. 90-day actions: 1) finish ISC2 CC online course, 2) complete the Cisco NetAcad Introduction to Cybersecurity, 3) build a home lab with one VM running Wireshark. Person to talk to: my uncle who works in IT.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 6 — Cisco NetAcad Bridge
+// ────────────────────────────────────────────────────────────────────────────
+
+const NETACAD_BRIDGE: ModuleContent = {
+  slug: "cisco-netacad-link",
+  title: "Cisco NetAcad Bridge",
+  totalMinutes: 60,
+  hook: {
+    estMinutes: 4,
+    title: "From foundations to certification-ready",
+    paragraphs: [
+      "You've learned the foundations here. Now it's time to go deeper than any single platform can take you. Cisco offers free, industry-grade cybersecurity coursework through Cisco Networking Academy — the same coursework used by community colleges, four-year universities, and corporate training programs around the world.",
+      "The point of this module isn't to memorize Cisco's catalog. It's to get you actually enrolled, with a chosen course, before you leave the session.",
+    ],
+    closer: "By the end of this 60 minutes, you'll have a NetAcad account, a chosen first course, and a study plan.",
+  },
+  reading: {
+    estMinutes: 12,
+    sections: [
+      {
+        heading: "What Cisco NetAcad is",
+        paragraphs: [
+          "**Cisco Networking Academy** is a free education program run by Cisco. According to Cisco, it has served more than 17 million learners across more than 190 countries since it started.",
+          "The courses are not introductory marketing material — they are the same content that prepares students for real industry certifications. Several lead directly into Cisco's career-level certifications (CCST Cybersecurity, CyberOps Associate, CCNA), which are recognized by employers worldwide.",
+          "There is no cost. There is no admissions process. You sign up, pick a course, and start learning at your own pace.",
+        ],
+        callout: "Free, self-paced, industry-recognized. Almost no other career path offers this combination.",
+      },
+      {
+        heading: "Recommended starting sequence",
+        paragraphs: [
+          "**Introduction to Cybersecurity** is the right first course for almost everyone. About 15 hours total, no prerequisites. It covers the same broad terrain we've covered here, in more depth.",
+          "**Cybersecurity Essentials** is the next step — roughly 30 hours. It goes deeper on the technical side: encryption, networks, threats, defensive measures. Some of it will feel like review of what you've done in this track. That's a feature, not a bug — repetition is how concepts stick.",
+          "**CCST Cybersecurity** is a more substantial path — roughly 50 hours of coursework and lab work. It leads to the Cisco Certified Support Technician (CCST) Cybersecurity certification, which is an entry-level industry certification, distinct from the older 'CCNA Cyber Ops' track Cisco has been retiring.",
+          "If you're more network-curious than cybersecurity-curious, the **CCNA** path is the world's most-recognized entry-level networking credential. Plenty of cybersecurity professionals have a CCNA before they pivot fully into security.",
+        ],
+      },
+      {
+        heading: "How to actually get value from it",
+        paragraphs: [
+          "**Set a real schedule.** Two to three hours a week, on specific days, beats six hours every other Saturday. Tell someone — your facilitator, a friend, a family member — what your schedule is.",
+          "**Take notes alongside the content.** Even just a few bullet points per session. The act of writing helps you remember, and you'll thank yourself when you come back to study for a certification.",
+          "**Use the labs.** Cisco Packet Tracer is a free network simulator that comes with several of the courses. It lets you build virtual networks and experiment safely. Hands-on practice is what separates people who pass the cert from people who just watched the videos.",
+          "**Don't go alone if you don't have to.** The NetAcad community forums are active, and many cohort programs (including this one) pair learners up to keep each other accountable.",
+        ],
+        callout: "Two to three hours per week, with notes and hands-on practice, beats marathon sessions every time.",
+      },
+    ],
+    citations: [
+      "Cisco Networking Academy — https://www.netacad.com/",
+      "Cisco CCST Cybersecurity — https://www.cisco.com/site/us/en/learn/training-certifications/certifications/cybersecurity/ccst-cybersecurity/index.html",
+      "Cisco Packet Tracer — https://www.netacad.com/courses/packet-tracer",
+    ],
+  },
+  lesson: {
+    estMinutes: 17,
+    intro: "Walk through creating a NetAcad account and choosing your first course. By the end of these scenes, you should have an account and a course picked. Your facilitator can help if you get stuck.",
+    scenes: [
+      {
+        title: "Open netacad.com",
+        body: "Go to netacad.com in your browser. You'll see the Cisco Networking Academy landing page. Look for a button labeled 'Sign Up' or 'Get Started.'",
+        choice: {
+          prompt: "Picked the right button?",
+          options: [
+            { label: "Yes — I see the sign-up page", feedback: "Great. Move to the next step." },
+            { label: "I see a course catalog, not a sign-up button", feedback: "Try the top-right of the page — sign-up is usually there. If you're still stuck, your facilitator can walk through screen-sharing." },
+            { label: "I can't get to the site at all", feedback: "Check your connection. If the site is blocked on your school network, your facilitator can help work around that." },
+          ],
+        },
+      },
+      {
+        title: "Create an account",
+        body: "Cisco will ask for your name, email, and a password. You can sign up with a school email if you have one — it sometimes unlocks additional resources.",
+        choice: {
+          prompt: "Picking a password — what's the right move?",
+          options: [
+            { label: "A long unique passphrase saved in your password manager", feedback: "Right. You learned this in Module 2. Apply it here." },
+            { label: "Your usual personal password", feedback: "Don't. If that password is ever in a breach, this account goes too." },
+            { label: "The simplest password the system will accept", feedback: "Don't. This account will hold your certification progress — protect it." },
+          ],
+        },
+      },
+      {
+        title: "Browse the catalog",
+        body: "Once your account is active, you'll see a catalog with hundreds of courses. Most cybersecurity learners start with 'Introduction to Cybersecurity.' Use the search bar.",
+        choice: {
+          prompt: "How do you decide which course to enroll in?",
+          options: [
+            { label: "Pick the first one — it's all useful", feedback: "Not the worst approach, but better to pick deliberately." },
+            { label: "Match the course to where you are right now (probably 'Introduction to Cybersecurity' if it's your first one)", feedback: "Right. Start where you are, not where you want to be." },
+            { label: "Enroll in five at once to have options", feedback: "Common mistake. You'll finish zero. Pick one and finish it." },
+          ],
+        },
+      },
+      {
+        title: "Enroll",
+        body: "Click 'Enroll' on your chosen course. The platform will add it to your dashboard.",
+        choice: {
+          prompt: "What do you do first?",
+          options: [
+            { label: "Skim the syllabus and the time commitment", feedback: "Right. Knowing how long the course is helps you plan." },
+            { label: "Start the first lesson right now", feedback: "Also fine — but skim the syllabus first so you know what you signed up for." },
+            { label: "Close the tab and come back later", feedback: "Almost no one comes back. While you're here, commit to the first lesson now or this week." },
+          ],
+        },
+      },
+      {
+        title: "Set a schedule",
+        body: "Before you close the tab, pick the specific times in the next 7 days when you'll work on this course.",
+        choice: {
+          prompt: "What does a realistic schedule look like?",
+          options: [
+            { label: "Two 1-hour sessions per week, on specific days", feedback: "Right. Specific beats vague. 'Tuesday and Thursday after dinner' beats 'three hours sometime this week.'" },
+            { label: "All five hours on Saturday morning", feedback: "Possible but harder to sustain. Spaced repetition works better than cramming." },
+            { label: "Whenever I have time", feedback: "Almost certainly won't happen. Pick days and times now." },
+          ],
+        },
+      },
+      {
+        title: "Tell someone",
+        body: "Send a message — to your facilitator, a friend, anyone — saying what course you're starting and what your schedule is.",
+        choice: {
+          prompt: "Why bother telling someone?",
+          options: [
+            { label: "Accountability — you're significantly more likely to follow through", feedback: "Right. The research on this is strong. Saying it out loud changes the odds." },
+            { label: "It's a requirement of the module", feedback: "It's a recommendation, not a requirement. But it's a recommendation worth taking." },
+            { label: "It's not necessary if you're disciplined", feedback: "Even disciplined people benefit from external accountability. Tell someone." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 10,
+    intro: "Six 'plan your path' choices. Pick the one that fits your situation — there's no single right answer, but the feedback explains the trade-offs.",
+    items: [
+      {
+        prompt: "You have 2 hours per week. Pick your first NetAcad course.",
+        options: [
+          { label: "Introduction to Cybersecurity (~15 hours)", correct: true, feedback: "Right. At 2 hours/week, this is ~7-8 weeks — doable and builds momentum." },
+          { label: "CCST Cybersecurity (~50 hours)", correct: false, feedback: "At 2 hours/week, this would take 6 months. Possible, but better to build momentum with a shorter course first." },
+          { label: "CCNA (~100+ hours)", correct: false, feedback: "Way too much commitment as a first course. CCNA is a real career credential — earn it later." },
+        ],
+      },
+      {
+        prompt: "You have 6 hours per week and you've already done Introduction to Cybersecurity. What's next?",
+        options: [
+          { label: "Cybersecurity Essentials (~30 hours)", correct: true, feedback: "Right. The natural next step." },
+          { label: "Repeat Introduction to Cybersecurity", correct: false, feedback: "Repetition has value but you already have the foundation. Move forward." },
+          { label: "Skip straight to CCNA", correct: false, feedback: "Cybersecurity Essentials is the right bridge before more advanced certs." },
+        ],
+      },
+      {
+        prompt: "You're more interested in networking than security right now. What's the best path?",
+        options: [
+          { label: "Start with Introduction to Networks (CCNA path), then layer security on later", correct: true, feedback: "Right. A solid networking foundation makes everything in cybersecurity easier later." },
+          { label: "Skip networking and focus on cybersecurity courses", correct: false, feedback: "Risky. Almost every cybersecurity job requires solid networking fundamentals." },
+          { label: "Don't do NetAcad — wait for university", correct: false, feedback: "No reason to wait. Free coursework is available now." },
+        ],
+      },
+      {
+        prompt: "You want to know if your time will translate to a real credential. What's the most direct certification path?",
+        options: [
+          { label: "CCST Cybersecurity through NetAcad coursework + the exam", correct: true, feedback: "Right. CCST Cybersecurity is the most direct entry-level certification from NetAcad coursework." },
+          { label: "CCNA — apply for an entry job after", correct: false, feedback: "CCNA is excellent but it's networking-first. CCST Cybersecurity is more directly cyber." },
+          { label: "Skip certifications, just take courses", correct: false, feedback: "Coursework alone is great learning, but employers look for the credential. Take the exam." },
+        ],
+      },
+      {
+        prompt: "You're stuck on a hard concept (subnetting, encryption math, etc.). What's the right move?",
+        options: [
+          { label: "Post in the NetAcad forums or ask a peer in the cohort", correct: true, feedback: "Right. Communities exist specifically for this. Use them." },
+          { label: "Give up on the course", correct: false, feedback: "Don't. Stuck is normal. Asking is what gets you unstuck." },
+          { label: "Skip the section and hope it doesn't matter", correct: false, feedback: "It usually does matter, and gaps compound. Ask, don't skip." },
+        ],
+      },
+      {
+        prompt: "You're 60% through a course and losing motivation. What works best?",
+        options: [
+          { label: "Re-anchor to your 12-month plan and your accountability partner", correct: true, feedback: "Right. The dip in the middle is normal. The plan and the partner are exactly why you built them." },
+          { label: "Switch to a new course", correct: false, feedback: "Common trap. Finish what you started — momentum compounds." },
+          { label: "Take a 3-month break", correct: false, feedback: "Almost no one comes back. Cut the workload short-term if needed, but don't disappear." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "First lesson",
+    prompt: "Before our next session, complete the first lesson of your chosen NetAcad course. Submit your reflection here.",
+    instructions: [
+      "Which course did you enroll in?",
+      "What did the first lesson cover, in your own words (3-5 sentences)?",
+      "What was harder than you expected?",
+      "What was easier than you expected?",
+      "When are your next two scheduled study sessions?",
+    ],
+    placeholder: "Example: I enrolled in Introduction to Cybersecurity. First lesson covered different types of attackers and what motivates them — state actors, criminals, hacktivists, insiders. Harder than expected: the threat actor categories blur together; I'm still confused about hacktivists vs script kiddies. Easier than expected: the cyber-news quiz at the end. Next sessions: Tuesday 7-8 PM and Thursday 7-8 PM.",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module 7 — Cyber Capstone (90 min, no quiz — deliverable is the assessment)
+// ────────────────────────────────────────────────────────────────────────────
+
+const CYBER_CAPSTONE: ModuleContent = {
+  slug: "capstone-security-plan",
+  title: "Capstone — My Security Plan",
+  totalMinutes: 90,
+  skipQuiz: true,
+  hook: {
+    estMinutes: 5,
+    title: "Today, you're the consultant",
+    paragraphs: [
+      "Today you stop being a student. Today you're a consultant. A small business — a barbershop, a food truck, a community center — needs you. They don't have an IT department. They don't have a CISO. They have you, an hour, and a budget that's roughly zero.",
+      "What you produce today is portfolio-worthy. Real. Something you could bring to an internship interview, to a college application, or to a real local business that needs help.",
+    ],
+    closer: "By the end, you'll have a written security plan with concrete recommendations and a one-page executive summary.",
+  },
+  reading: {
+    estMinutes: 10,
+    sections: [
+      {
+        heading: "What SMB cybersecurity consulting looks like",
+        paragraphs: [
+          "Most small and medium-sized businesses (SMBs) don't have full-time security staff. They have an owner, a few employees, a point-of-sale system, a cloud accounting tool, maybe a website, and an instinct that they should be 'doing something' about security.",
+          "Real consultants who serve this market do a few things consistently: they ask about the business before they ask about the technology. They translate findings into plain language. They prioritize ruthlessly — three changes that will actually happen beats fifteen that won't.",
+          "Your work today follows that pattern. Pick a business, understand what they do and what they care about, identify the most likely risks, recommend a handful of high-impact, low-cost changes, and write it up.",
+        ],
+      },
+      {
+        heading: "What a good security plan looks like",
+        paragraphs: [
+          "A real SMB security plan is short. One executive page that the owner will actually read, plus a couple of supporting pages with detail. Long plans don't get implemented.",
+          "The structure that works: **business context** (what they do, what data they handle, who could hurt them and how), **top risks** (three to five, ranked), **recommendations** (concrete actions, with rough cost and effort estimates), **executive summary** (the one page).",
+          "Cite what you're recommending. If you say 'use a password manager,' name two real options. If you say 'enable MFA,' name where to enable it. Specificity is what separates a real plan from a generic one.",
+        ],
+        callout: "Three changes the owner will actually make beats fifteen that look good in a report.",
+      },
+    ],
+    citations: [
+      "CISA Cyber Essentials for Small Business — https://www.cisa.gov/cyber-essentials",
+      "FCC Small Biz Cyber Planner — https://www.fcc.gov/cyberplanner",
+      "NIST Small Business Cybersecurity Corner — https://www.nist.gov/itl/smallbusinesscyber",
+    ],
+  },
+  lesson: {
+    estMinutes: 15,
+    intro: "Read a sample security plan for a fictional barbershop. Notice what makes it useful: specific, prioritized, plain-language, cheap to implement.",
+    scenes: [
+      {
+        title: "The business",
+        body: "Fade & Co. is a four-chair barbershop. Two owners, two employees. They take walk-ins and appointments through an iPad-based booking system. Payments through a Square terminal. WhatsApp group with staff. They store no medical or legal records, but they have ~3,000 customer phone numbers and emails in their booking system.",
+        choice: {
+          prompt: "What's the most important thing to understand first?",
+          options: [
+            { label: "What systems hold customer data and who can access them", feedback: "Right. The plan is built around the data the business actually holds." },
+            { label: "Whether they use Mac or Windows", feedback: "Useful detail but not the first question. Data first." },
+            { label: "Their annual revenue", feedback: "Sometimes relevant for sizing, but not the first question." },
+          ],
+        },
+      },
+      {
+        title: "The top risks",
+        body: "Reviewing Fade & Co.'s setup, the consultant identifies the top three risks: (1) the iPad booking app is shared with no individual logins — anyone in the shop can read the full customer list; (2) staff WhatsApp group has personal phones with no MFA on the connected emails; (3) the Square account login is shared between owners.",
+        choice: {
+          prompt: "What ranks these correctly?",
+          options: [
+            { label: "Severity × likelihood — focus on what's most likely AND most damaging", feedback: "Right. A shared Square login is probably the highest risk because compromise means immediate financial exposure." },
+            { label: "Cost to fix — cheapest first", feedback: "A reasonable secondary sort, but not the primary one." },
+            { label: "Alphabetical order", feedback: "Don't." },
+          ],
+        },
+      },
+      {
+        title: "The recommendations",
+        body: "Three changes, each cheap. (1) Create individual Square logins per owner and enable MFA. (2) Enable MFA on the email connected to the booking system; consider Bitwarden for the staff. (3) Move the customer email list out of the booking app's CSV export into a managed list (Mailchimp, etc.) where access can be logged.",
+        choice: {
+          prompt: "Why are these three good recommendations?",
+          options: [
+            { label: "They're concrete, cheap, and address the top-ranked risks", feedback: "Right. The owner can see what to do and roughly what it costs." },
+            { label: "They sound impressive", feedback: "Impressing the client is the wrong goal. Helping them is the goal." },
+            { label: "They use industry jargon", feedback: "Jargon hides recommendations. Avoid it." },
+          ],
+        },
+      },
+      {
+        title: "The executive summary",
+        body: "One page. Three bullets at the top. Three numbered recommendations. A 'what to do this week' section. The total reading time should be 60 seconds.",
+        choice: {
+          prompt: "What's the test for whether the summary is good?",
+          options: [
+            { label: "The owner reads it once and knows what to do Monday morning", feedback: "Right. Action-readiness in 60 seconds is the bar." },
+            { label: "It's long enough to look thorough", feedback: "Length is not value. Concise is harder and more valuable." },
+            { label: "It uses technical terms", feedback: "Plain language is the strength of a good summary." },
+          ],
+        },
+      },
+    ],
+  },
+  practice: {
+    estMinutes: 35,
+    intro: "Now it's your turn. Pick a real or imagined small business. Build a security plan. There is no grading rubric here in the prototype — bring the draft to your facilitator for review. Save your progress as you go; the homework field below holds your full draft.",
+    items: [
+      {
+        prompt: "Choose your business. Which sounds most interesting to work on?",
+        options: [
+          { label: "A neighborhood barbershop or salon (4-8 employees, customer data, POS)", correct: true, feedback: "Strong choice. Real, common, manageable scope." },
+          { label: "A food truck (1-2 employees, mobile POS, social-media-driven sales)", correct: true, feedback: "Strong choice. Mobile + social media adds interesting wrinkles." },
+          { label: "A community nonprofit (volunteer-run, donor database, mailing list)", correct: true, feedback: "Strong choice. Donor data and grant compliance bring real considerations." },
+        ],
+      },
+      {
+        prompt: "Sketch the business: what do they do, what data do they hold, who could hurt them?",
+        options: [
+          { label: "I've thought about it and I'm ready to write", correct: true, feedback: "Good. Use the homework section to write up the business context." },
+          { label: "I need to think more about who could hurt them", correct: true, feedback: "Fair. Common threats for SMBs: phishing, ransomware, theft of customer or payment data, social-engineered fraud. Pick one or two relevant ones." },
+          { label: "I want to pick a different business", correct: true, feedback: "Go for it. There's no wrong answer here." },
+        ],
+      },
+      {
+        prompt: "List the top 3-5 risks. Rank them.",
+        options: [
+          { label: "Done — I have a ranked list", correct: true, feedback: "Good. Move to recommendations." },
+          { label: "I'm not sure how to rank — I have 5 risks but they all feel important", correct: true, feedback: "Sort by likely × impact. Likely × small impact ≠ unlikely × big impact. Decide which side to favor and explain it." },
+          { label: "I only have 2 risks — is that enough?", correct: true, feedback: "Three is a good target. If you only have two, push: what's the second-most-likely data leak, fraud, or business disruption?" },
+        ],
+      },
+      {
+        prompt: "Write 3 recommendations. Each one needs an action, a cost estimate, and an effort estimate.",
+        options: [
+          { label: "Done", correct: true, feedback: "Good. Now write the executive summary." },
+          { label: "I have 3 actions but no cost/effort estimates", correct: true, feedback: "Estimate. A password manager is ~$0-$3/user/month. MFA setup is ~1 hour. A new POS account is ~30 minutes. You don't need precision, you need order-of-magnitude." },
+          { label: "All my recommendations are 'add MFA'", correct: true, feedback: "MFA is real, but variety helps. What about backups? Staff training? Inventory of who has access to what?" },
+        ],
+      },
+      {
+        prompt: "Write the one-page executive summary in the homework field below.",
+        options: [
+          { label: "I'm ready to draft", correct: true, feedback: "Use this format in the homework field: (1) 3 bullets describing the business and what's at stake, (2) 3 numbered recommendations, (3) 'this week' action list of 1-3 things." },
+          { label: "I'm worried it's too short", correct: true, feedback: "Short is the goal. If the owner reads only the summary, they should know exactly what to do." },
+          { label: "I'm worried it's too long", correct: true, feedback: "Cut. Real consultants cut. One page is the target." },
+        ],
+      },
+    ],
+  },
+  homework: {
+    estMinutes: 10,
+    title: "Real-world application",
+    prompt: "This is both your capstone submission and your real-world homework. Submit the executive summary of your security plan here. As a bonus, find a real small business in your community (with the owner's permission), have a 15-minute conversation about how they handle data, and add 3 observations to your submission.",
+    instructions: [
+      "Paste your one-page executive summary: 3 bullets of business context, 3 numbered recommendations with action + cost + effort, 'this week' action list.",
+      "(Optional bonus) Find a small business owner you know. Ask them 3 questions: How do they take payments? Where do they store customer info? What would worry them about a data leak?",
+      "Add 3 observations from that conversation if you did it.",
+    ],
+    placeholder: "Example summary:\n\nBusiness: Tony's Tacos food truck. 1 owner, 1 employee. Square POS, ~600 customer phone numbers, Instagram and TikTok-driven sales.\n\nTop 3 risks: (1) Owner's Instagram is the de facto storefront — losing access = losing business. (2) Square account uses owner's personal email with no MFA. (3) Customer phone list is stored in a Notes app.\n\nRecommendations:\n1. Enable MFA on the Instagram account and the email behind it. Cost: $0. Effort: 30 min.\n2. Switch the Square account to a business email with MFA enabled. Cost: $0. Effort: 1 hour.\n3. Move the customer list out of Notes into a managed tool (Google Contacts or a free Mailchimp account). Cost: $0. Effort: 1 hour.\n\nThis week: turn on MFA on the Instagram and email accounts. Schedule the rest for next week.\n\nObservations from real conversation: ...",
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Export
+// ────────────────────────────────────────────────────────────────────────────
+
+export const CYBER_LAUNCH_CONTENT: Record<string, ModuleContent> = {
+  "cyber-foundations": CYBER_FOUNDATIONS,
+  "digital-safety-sim": DIGITAL_SAFETY,
+  "network-basics": NETWORK_BASICS,
+  "threat-detective": THREAT_DETECTIVE,
+  "career-map": CAREER_MAP,
+  "cisco-netacad-link": NETACAD_BRIDGE,
+  "capstone-security-plan": CYBER_CAPSTONE,
+};


### PR DESCRIPTION
## Summary

Restructures every Cyber Launch module from a ~15-minute slides-then-quiz into a real 60-minute pedagogical flow: **Hook → Reading → Lesson → Practice → Homework → Quiz**. Section-level progress is persisted so learners can leave and resume, and facilitators can see exactly where each learner is — including reading the homework they submitted.

### Architecture

- **`ModuleStructure`** — shared 6-stage shell with a progress bar across the top. Quiz unlocks only when the first five sections are complete. Each section persists completion to a new `PATCH /pathways/student/milestones/section` endpoint.
- **`cyberLaunchContent.ts`** — typed content for all 7 modules, separated from React so prose can be edited without touching JSX.
- **`StandaloneQuiz`** — small component that renders the per-module quiz bank and reports a 0-100 score.

### Schema (additive)

`PathwayMilestone` gains: `hookCompleted`, `readingCompleted`, `lessonCompleted`, `practiceCompleted`, `homeworkSubmitted`, `homeworkResponse` (TEXT), `quizCompleted`, `quizScore`, `timeSpentMinutes`. Migration is `ADD COLUMN IF NOT EXISTS`-style; safe on production.

### Backend

- `PATCH /pathways/student/milestones/section` — toggle a section's completion.
- `POST /pathways/student/milestones/homework` — save the learner's homework response.
- Existing facilitator learner-detail endpoint surfaces the new fields automatically.

### Content (real citations only)

Reading sections cite the BLS Occupational Outlook Handbook, NIST CyberSeek, ISC2's One Million Certified pledge, NIST SP 800-61 / 800-63B, Cisco Networking Academy, CISA, MITRE ATT&CK, Mozilla MDN, and Verizon's DBIR. Real-world incidents (Equifax 2017, Colonial Pipeline 2021, WannaCry 2017, Target 2013) are referenced as documented public events. Stories framed as 'Imagine…' / 'Picture…' are illustrative composites, not specific individuals.

### Module-by-module

| Module | Hook | Reading words | Lesson scenes | Practice items | Homework |
|---|---|---|---|---|---|
| Cyber Foundations | Equifax 2017 framing | ~900 | 6 SOC-day scenes | 6 career-match bios | "Cyber in your world" 1-week count |
| Digital Safety Sim | Phishing-text scenario | ~950 | 5 attack scenarios | 6 phishing-email red-flag exercises | "Account audit" of 5 accounts |
| Network Basics | TikTok packet journey | ~1000 | 7 trace-the-packet scenes | 6 network-event reads | "Map your home network" |
| Threat Detective | 3:47 AM SOC alert | ~950 | 6 investigation scenes | 10 alert-triage drills | "Nonprofit phishing tabletop" |
| Cyber Career Map | Self-taught path framing | ~1000 | 6 role cards w/ paths + salary | 6 real-path snapshots | "My 12-month plan" |
| Cisco NetAcad Bridge | Foundations → certification | ~700 | 6 signup walkthrough scenes | 6 plan-your-path choices | "Complete first NetAcad lesson" |
| Capstone — Security Plan | Consultant framing (90 min) | ~600 | 5 sample-plan-review scenes | 5 capstone scaffolds | One-page security plan deliverable |

Capstone skips the quiz section — its homework submission IS the assessment.

### Facilitator review UI

`LearnerDetail` now shows a 6-dot section-progress strip next to each milestone and expands homework submissions inline so Coach Davis can read Marcus's and Aisha's written work. Read-only for now; comments-on-homework is a future PR.

### What this PR does NOT do (deliberate cut lines)

- No facilitator comments-on-homework yet.
- `timeSpentMinutes` is accepted server-side; the frontend doesn't accumulate it yet.
- Modules 2–7 quiz prompts are English-only. Module 1 keeps its i18n wiring.
- Old slide content was removed (its substance now lives in the new hook/reading/lesson). Revert path is plain `git revert`.

## Test plan

- [ ] Railway deploy applies `20260514_add_milestone_section_progress` migration cleanly.
- [ ] Log in as `marcus@test.com` / `marcus123`. Open Cyber Foundations.
- [ ] 6-stage progress bar visible at top; Quiz stage shows a lock icon.
- [ ] Hook → Reading → Lesson → Practice → Homework all reachable in order; Reading shows citations.
- [ ] Submit homework; reload the page; submission is preserved (server-side).
- [ ] Quiz unlocks only after the first five sections are marked complete.
- [ ] Repeat across all 7 modules. Capstone has no Quiz; submitting the homework completes the module.
- [ ] Log in as `facilitator@test.com` / `pathway123`. Open Marcus's learner detail. Section-progress dots show on each module. Homework submissions expand inline.
- [ ] K-8 logins (`teacher@school.com`, `student@test.com`) still work — no regression on the K-8 side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)