### PR TITLE
fix: restore Marcus partial progress + rename Hook → Why It Matters

### DIFF
--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -1617,28 +1617,55 @@ async function main() {
     });
   }
 
-  // Marcus's Cyber Launch milestones (partial progress)
+  // Marcus's Cyber Launch milestones (partial progress).
+  // Section-level fields, homework responses, and time spent are filled in so
+  // Coach Davis's facilitator view shows real-looking work, not empty rows.
+  // upsert update block re-applies these every seed run — important when the
+  // section-progress migration lands on top of existing rows.
+  const MARCUS_HOMEWORK = {
+    "cyber-foundations":
+      "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
+    "digital-safety-sim":
+      "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
+    "network-basics":
+      "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
+  };
   const marcusMilestones = [
-    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7 },
-    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5 },
-    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3 },
-    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1 },
+    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7, timeSpent: 62 },
+    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5, timeSpent: 58 },
+    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3, timeSpent: 65 },
+    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
   ];
 
   for (const m of marcusMilestones) {
+    const isDone = m.status === "completed";
+    const isInProgress = m.status === "in_progress";
+    const fullFields = {
+      status: m.status,
+      score: m.score,
+      completedAt: isDone ? new Date(Date.now() - m.daysAgo * 86400000) : null,
+      hookCompleted: isDone || isInProgress,
+      readingCompleted: isDone || isInProgress,
+      lessonCompleted: isDone || isInProgress,
+      practiceCompleted: isDone,
+      homeworkSubmitted: isDone,
+      homeworkResponse: isDone ? MARCUS_HOMEWORK[m.moduleSlug] ?? null : null,
+      quizCompleted: isDone,
+      quizScore: isDone ? m.score : null,
+      timeSpentMinutes: m.timeSpent,
+    };
     await prisma.pathwayMilestone.upsert({
       where: { userId_trackSlug_moduleSlug: { userId: marcus.id, trackSlug: "cyber-launch", moduleSlug: m.moduleSlug } },
       create: {
         userId: marcus.id,
         trackSlug: "cyber-launch",
         moduleSlug: m.moduleSlug,
-        status: m.status,
-        score: m.score,
-        completedAt: m.status === "completed" ? new Date(Date.now() - m.daysAgo * 86400000) : null,
+        ...fullFields,
       },
-      update: { status: m.status, score: m.score },
+      update: fullFields,
     });
   }
+  console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
 
   // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
   const endedCohort = await prisma.pathwayCohort.upsert({
@@ -1690,20 +1717,34 @@ async function main() {
       create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
       update: { status: "completed" },
     });
-    // Realistic completion milestones (each module completed during the Fall pilot)
+    // Realistic completion milestones (each module completed during the Fall pilot).
+    // Section-level fields filled in so the facilitator outcomes report shows
+    // 6-of-6 sections done per module, not "completed but 0 sections".
     for (let i = 0; i < moduleSlugs.length; i++) {
       const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+      const fullFields = {
+        status: "completed",
+        score: g.scores[i],
+        completedAt: completedDate,
+        hookCompleted: true,
+        readingCompleted: true,
+        lessonCompleted: true,
+        practiceCompleted: true,
+        homeworkSubmitted: true,
+        homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
+        quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
+        quizScore: moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
+        timeSpentMinutes: 55 + ((i * 7) % 20),
+      };
       await prisma.pathwayMilestone.upsert({
         where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
         create: {
           userId: gu.id,
           trackSlug: "cyber-launch",
           moduleSlug: moduleSlugs[i],
-          status: "completed",
-          score: g.scores[i],
-          completedAt: completedDate,
+          ...fullFields,
         },
-        update: { status: "completed", score: g.scores[i], completedAt: completedDate },
+        update: fullFields,
       });
     }
   }

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -1617,28 +1617,55 @@ async function main() {
     });
   }
 
-  // Marcus's Cyber Launch milestones (partial progress)
+  // Marcus's Cyber Launch milestones (partial progress).
+  // Section-level fields, homework responses, and time spent are filled in so
+  // Coach Davis's facilitator view shows real-looking work, not empty rows.
+  // upsert update block re-applies these every seed run — important when the
+  // section-progress migration lands on top of existing rows.
+  const MARCUS_HOMEWORK = {
+    "cyber-foundations":
+      "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
+    "digital-safety-sim":
+      "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
+    "network-basics":
+      "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
+  };
   const marcusMilestones = [
-    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7 },
-    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5 },
-    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3 },
-    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1 },
+    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7, timeSpent: 62 },
+    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5, timeSpent: 58 },
+    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3, timeSpent: 65 },
+    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
   ];
 
   for (const m of marcusMilestones) {
+    const isDone = m.status === "completed";
+    const isInProgress = m.status === "in_progress";
+    const fullFields = {
+      status: m.status,
+      score: m.score,
+      completedAt: isDone ? new Date(Date.now() - m.daysAgo * 86400000) : null,
+      hookCompleted: isDone || isInProgress,
+      readingCompleted: isDone || isInProgress,
+      lessonCompleted: isDone || isInProgress,
+      practiceCompleted: isDone,
+      homeworkSubmitted: isDone,
+      homeworkResponse: isDone ? MARCUS_HOMEWORK[m.moduleSlug] ?? null : null,
+      quizCompleted: isDone,
+      quizScore: isDone ? m.score : null,
+      timeSpentMinutes: m.timeSpent,
+    };
     await prisma.pathwayMilestone.upsert({
       where: { userId_trackSlug_moduleSlug: { userId: marcus.id, trackSlug: "cyber-launch", moduleSlug: m.moduleSlug } },
       create: {
         userId: marcus.id,
         trackSlug: "cyber-launch",
         moduleSlug: m.moduleSlug,
-        status: m.status,
-        score: m.score,
-        completedAt: m.status === "completed" ? new Date(Date.now() - m.daysAgo * 86400000) : null,
+        ...fullFields,
       },
-      update: { status: m.status, score: m.score },
+      update: fullFields,
     });
   }
+  console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
 
   // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
   const endedCohort = await prisma.pathwayCohort.upsert({
@@ -1690,20 +1717,34 @@ async function main() {
       create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
       update: { status: "completed" },
     });
-    // Realistic completion milestones (each module completed during the Fall pilot)
+    // Realistic completion milestones (each module completed during the Fall pilot).
+    // Section-level fields filled in so the facilitator outcomes report shows
+    // 6-of-6 sections done per module, not "completed but 0 sections".
     for (let i = 0; i < moduleSlugs.length; i++) {
       const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+      const fullFields = {
+        status: "completed",
+        score: g.scores[i],
+        completedAt: completedDate,
+        hookCompleted: true,
+        readingCompleted: true,
+        lessonCompleted: true,
+        practiceCompleted: true,
+        homeworkSubmitted: true,
+        homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
+        quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
+        quizScore: moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
+        timeSpentMinutes: 55 + ((i * 7) % 20),
+      };
       await prisma.pathwayMilestone.upsert({
         where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
         create: {
           userId: gu.id,
           trackSlug: "cyber-launch",
           moduleSlug: moduleSlugs[i],
-          status: "completed",
-          score: g.scores[i],
-          completedAt: completedDate,
+          ...fullFields,
         },
-        update: { status: "completed", score: g.scores[i], completedAt: completedDate },
+        update: fullFields,
       });
     }
   }

--- a/src/components/pathways/facilitator/data/worksheets.ts
+++ b/src/components/pathways/facilitator/data/worksheets.ts
@@ -640,7 +640,7 @@ export const WORKSHEETS: Worksheet[] = [
           <h2>Step 6 — Presentation Prep</h2>
           <p>You will present this in 3-5 minutes. Plan your structure.</p>
           <ol>
-            <li><strong>Hook</strong> (30 seconds) — Why should the business owner care? What's at stake?</li>
+            <li><strong>Opening</strong> (30 seconds) — Why should the business owner care? What's at stake?</li>
             <li><strong>Findings</strong> (90 seconds) — Top 3 risks, in plain language.</li>
             <li><strong>Recommendations</strong> (90 seconds) — What to do, in what order, what it costs.</li>
             <li><strong>Close</strong> (30 seconds) — One sentence on what success looks like in 30 days.</li>

--- a/src/components/pathways/facilitator/pages/LearnerDetail.tsx
+++ b/src/components/pathways/facilitator/pages/LearnerDetail.tsx
@@ -37,7 +37,7 @@ interface LearnerDetailData {
 }
 
 const SECTION_LABELS: Array<{ key: keyof Milestone; label: string }> = [
-  { key: "hookCompleted", label: "Hook" },
+  { key: "hookCompleted", label: "Why It Matters" },
   { key: "readingCompleted", label: "Read" },
   { key: "lessonCompleted", label: "Lesson" },
   { key: "practiceCompleted", label: "Practice" },

--- a/src/components/pathways/modules/ModuleStructure.tsx
+++ b/src/components/pathways/modules/ModuleStructure.tsx
@@ -34,8 +34,10 @@ const TRACK_SLUG = "cyber-launch";
 const SECTIONS = ["hook", "reading", "lesson", "practice", "homework", "quiz"] as const;
 export type SectionKey = (typeof SECTIONS)[number];
 
+// Internal `hook` keys remain for schema/API consistency, but the student
+// never sees that word — it's relabeled as "Why It Matters" everywhere.
 const SECTION_META: Record<SectionKey, { label: string; icon: typeof BookOpen }> = {
-  hook: { label: "Hook", icon: Sparkles },
+  hook: { label: "Why It Matters", icon: Sparkles },
   reading: { label: "Read", icon: BookOpen },
   lesson: { label: "Lesson", icon: PlayCircle },
   practice: { label: "Practice", icon: Lightbulb },

--- a/src/components/pathways/modules/cyberLaunchContent.ts
+++ b/src/components/pathways/modules/cyberLaunchContent.ts
@@ -5,6 +5,8 @@
  * experience built around a 6-section flow:
  *
  *   1. Hook      — short scene/story that frames why the module matters
+ *                  (rendered to the student as "Why It Matters" — the schema
+ *                  field stays `hookCompleted` for backward compatibility)
  *   2. Reading   — substantive written content with sections + citations
  *   3. Lesson    — interactive walkthrough or guided scenes
  *   4. Practice  — low-stakes attempts with immediate feedback


### PR DESCRIPTION
## Summary

Two demo-readiness fixes for the ETO meeting.

### 1. Marcus seed — section flags + homework responses

After the section-progress migration in #585, existing seed rows only wrote `status` + `score` + `completedAt`. The new section flags (`hookCompleted`, `readingCompleted`, etc.) defaulted to `false`, so Coach Davis's facilitator view of Marcus showed completed modules with zero section dots filled in.

This rewrites Marcus's milestone seed block to:
- Set all six section flags consistent with module status (completed → all true; in_progress → first three true).
- Set `timeSpentMinutes` to realistic per-module values (28–65 min).
- Attach realistic `homeworkResponse` text for each completed module — when Coach Davis expands a submission she'll see actual-looking learner work, not empty fields.
- Apply the same fields in both `create` and `update` so the seed self-heals on every redeploy.

Same treatment applied to the Fall 2025 pilot graduates so the outcomes report stays consistent.

### 2. "Hook" → "Why It Matters"

"Hook" is instructional-design jargon. Renamed everywhere it was student-visible:

- **ModuleStructure progress-bar chip** → "Why It Matters"
- **LearnerDetail section-dot tooltip** → "Why It Matters"
- **Capstone presentation worksheet** → "Opening (30 seconds)" (the word there referred to pitch structure, not module structure, but still student-visible)

Schema field names (`hookCompleted`, `hook` in API payloads) stay unchanged — backward compatible, internal-only.

Verification:
```
grep -rn '>Hook<|"Hook"|'\''Hook'\''' src/components/ --include='*.tsx' --include='*.ts'
```
returns **0 matches**.

## Test plan

- [ ] Railway deploy completes; seed runs and prints "Seeded Marcus partial Cyber Launch progress…"
- [ ] Log in as `marcus@test.com` / `marcus123` → `/pathways` shows 3/7 completed on Cyber Launch
- [ ] Cyber Foundations ✅ 85, Digital Safety Sim ✅ 90, Network Basics ✅ 78, Threat Detective 🔵 in progress
- [ ] Open any module — first section chip reads "Why It Matters", not "Hook"
- [ ] Log in as `facilitator@test.com` / `pathway123` → Marcus's learner detail shows full section dots on completed modules + expandable homework submissions with real-looking text
- [ ] Capstone worksheet (in Resources or printable view): step 6 reads "Opening (30 seconds)" not "Hook (30 seconds)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)