### PR TITLE
feat: CTF toolbox sidebar + difficulty rebalance + first-time intro

### DIFF
--- a/backend/prisma/migrations/20260521_add_toolbox_intro_seen/migration.sql
+++ b/backend/prisma/migrations/20260521_add_toolbox_intro_seen/migration.sql
@@ -1,0 +1,6 @@
+-- Phase 2.2 — track whether each student has seen the CTF toolbox intro
+-- screen. Idempotent: ALTER TABLE ADD COLUMN IF NOT EXISTS skips if the
+-- column already exists, so re-running on any environment is safe.
+
+ALTER TABLE "PathwayOnboarding"
+  ADD COLUMN IF NOT EXISTS "toolboxIntroSeen" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -912,6 +912,8 @@ model PathwayOnboarding {
 
   avatarSlug        String?
 
+  toolboxIntroSeen  Boolean  @default(false)
+
   user User @relation(fields: [userId], references: [id])
 }
 

--- a/backend/src/data/ctfChallenges.ts
+++ b/backend/src/data/ctfChallenges.ts
@@ -40,7 +40,7 @@ export const CTF_CHALLENGES_SERVER: CtfServerChallenge[] = [
     category: "cryptography",
     difficulty: "easy",
     flag: "ifireversethesewordsthentheflagisstoredcode",
-    xpReward: 10,
+    xpReward: 5,
     hints: [
       "Try reading the message right to left.",
       "Reverse the entire string character by character.",
@@ -50,9 +50,9 @@ export const CTF_CHALLENGES_SERVER: CtfServerChallenge[] = [
   {
     slug: "base64-buddy",
     category: "cryptography",
-    difficulty: "medium",
+    difficulty: "easy",
     flag: "theflagissilverlining",
-    xpReward: 25,
+    xpReward: 10,
     hints: [
       "This is base64-encoded text. Most browsers can decode it via DevTools.",
       "Open browser DevTools console and try: atob('VGhlZmxhZ2lzc2lsdmVybGluaW5n')",
@@ -62,13 +62,25 @@ export const CTF_CHALLENGES_SERVER: CtfServerChallenge[] = [
   {
     slug: "hex-hunt",
     category: "cryptography",
-    difficulty: "medium",
+    difficulty: "easy",
     flag: "the flag is cipherspace.",
-    xpReward: 25,
+    xpReward: 10,
     hints: [
       "Hex pairs (two characters at a time) represent ASCII codes.",
       "Try a hex-to-ASCII converter. Browser DevTools: parseInt('74', 16) = 116, then String.fromCharCode(116) = 't'.",
       "The decoded text begins with 'the flag is…'",
+    ],
+  },
+  {
+    slug: "layered-mystery",
+    category: "cryptography",
+    difficulty: "hard",
+    flag: "theflagisdeeplyhidden",
+    xpReward: 50,
+    hints: [
+      "Start by base64-decoding the message. The result will still look scrambled.",
+      "Then reverse the string. It'll look like a single Caesar cipher.",
+      "Finally, Caesar-decode with the toolbox set to shift = 7.",
     ],
   },
   {
@@ -147,9 +159,9 @@ export const CTF_CHALLENGES_SERVER: CtfServerChallenge[] = [
   {
     slug: "form-field-sleuth",
     category: "web",
-    difficulty: "hard",
+    difficulty: "medium",
     flag: "hidden_field_treasure",
-    xpReward: 50,
+    xpReward: 25,
     hints: [
       "Look for input fields with type='hidden'.",
       "There are two hidden fields. One is for CSRF protection; the other contains the flag.",
@@ -281,9 +293,9 @@ export const CTF_CHALLENGES_SERVER: CtfServerChallenge[] = [
   {
     slug: "firewall-find",
     category: "networks",
-    difficulty: "medium",
+    difficulty: "easy",
     flag: "10.0.5.0/24",
-    xpReward: 25,
+    xpReward: 10,
     hints: [
       "Look for ALLOW rules with port 22 (SSH).",
       "Rule 1 specifies the source subnet for SSH access.",

--- a/backend/src/routes/pathways.ts
+++ b/backend/src/routes/pathways.ts
@@ -1122,6 +1122,7 @@ const onboardingPatchSchema = z.object({
   missionStatement: z.string().max(280).optional(),
   dailyGoalLevel: z.enum(["light", "medium", "heavy"]).optional(),
   avatarSlug: z.string().min(1).max(32).optional(),
+  toolboxIntroSeen: z.boolean().optional(),
   completed: z.boolean().optional(),
 });
 

--- a/prisma/migrations/20260521_add_toolbox_intro_seen/migration.sql
+++ b/prisma/migrations/20260521_add_toolbox_intro_seen/migration.sql
@@ -1,0 +1,6 @@
+-- Phase 2.2 — track whether each student has seen the CTF toolbox intro
+-- screen. Idempotent: ALTER TABLE ADD COLUMN IF NOT EXISTS skips if the
+-- column already exists, so re-running on any environment is safe.
+
+ALTER TABLE "PathwayOnboarding"
+  ADD COLUMN IF NOT EXISTS "toolboxIntroSeen" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -947,6 +947,11 @@ model PathwayOnboarding {
 
   avatarSlug        String?  // "explorer" | "analyst" | "guardian" | ...
 
+  // Phase 2.2 — set to true after the student sees the CTF toolbox intro
+  // screen. Lets us show the one-time tour the first time someone opens
+  // a challenge.
+  toolboxIntroSeen  Boolean  @default(false)
+
   user User @relation(fields: [userId], references: [id])
 }
 

--- a/src/components/pathways/challenges/ChallengePage.tsx
+++ b/src/components/pathways/challenges/ChallengePage.tsx
@@ -20,6 +20,7 @@ import {
   Clock,
   ListChecks,
   Users,
+  HelpCircle,
 } from "lucide-react";
 import {
   getChallengeBySlug,
@@ -30,8 +31,11 @@ import {
 import EthicsFraming from "../labs/EthicsFraming";
 import { useCelebrate } from "../gamification/CelebrationContext";
 import { useChallenges } from "./useChallenges";
+import { useOnboarding } from "../onboarding/useOnboarding";
 import Toolbox from "./Toolbox";
 import ScratchPad from "./ScratchPad";
+import MobileToolbox from "./MobileToolbox";
+import ToolboxIntro from "./ToolboxIntro";
 
 const DIFFICULTY_BG: Record<CtfDifficulty, string> = {
   easy: "bg-emerald-600",
@@ -70,6 +74,7 @@ export default function ChallengePage() {
   const challenge = useMemo(() => (slug ? getChallengeBySlug(slug) : undefined), [slug]);
   const { progress, refresh } = useChallenges();
   const { celebrate } = useCelebrate();
+  const { state: onboarding, patch: patchOnboarding } = useOnboarding();
 
   const [ethicsAcked, setEthicsAcked] = useState(false);
   const [submittedFlag, setSubmittedFlag] = useState("");
@@ -80,6 +85,29 @@ export default function ChallengePage() {
   const [hintError, setHintError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [teamMode, setTeamMode] = useState<"solo" | "team">("solo");
+  // Toolbox intro: shown automatically the first time the student finishes
+  // ethics framing, and re-openable via the help icon on the Toolbox header.
+  const [toolboxIntroOpen, setToolboxIntroOpen] = useState(false);
+  const [toolboxIntroForcedOpen, setToolboxIntroForcedOpen] = useState(false);
+
+  // Open the toolbox intro after ethics is acked, but only if the user
+  // hasn't seen it before. `toolboxIntroSeen` lives on PathwayOnboarding.
+  useEffect(() => {
+    if (!ethicsAcked) return;
+    if (onboarding && onboarding.toolboxIntroSeen === false) {
+      setToolboxIntroOpen(true);
+    }
+  }, [ethicsAcked, onboarding]);
+
+  const dismissToolboxIntro = async () => {
+    setToolboxIntroOpen(false);
+    setToolboxIntroForcedOpen(false);
+    // Persist the first-time dismissal so it doesn't reappear next visit.
+    // No-op when the user opened it via the help icon (already seen).
+    if (onboarding && onboarding.toolboxIntroSeen === false) {
+      await patchOnboarding({ toolboxIntroSeen: true });
+    }
+  };
 
   // Pre-fill any hints the student has already revealed (via highest
   // hintsUsed for this slug on the server).
@@ -206,7 +234,9 @@ export default function ChallengePage() {
   };
 
   return (
-    <div className="space-y-5 max-w-3xl mx-auto">
+    <div className="flex flex-col lg:flex-row gap-6 max-w-7xl mx-auto">
+      {/* MAIN COLUMN — challenge content */}
+      <div className="flex-1 min-w-0 space-y-5">
       {/* Header */}
       <div>
         <Link
@@ -297,10 +327,6 @@ export default function ChallengePage() {
         </h2>
         <p className="text-sm text-slate-800 dark:text-slate-200">{challenge.prompt}</p>
       </div>
-
-      {/* Toolbox — category-appropriate calculators and references.
-          Collapsed by default so it doesn't steal focus from the scenario. */}
-      <Toolbox category={challenge.category} />
 
       {/* Materials */}
       <div className="space-y-3">
@@ -413,9 +439,47 @@ export default function ChallengePage() {
         )}
       </div>
 
-      {/* Scratch pad — auto-saves to sessionStorage per challenge slug.
-          Sits at the bottom so students can take notes throughout. */}
-      <ScratchPad challengeSlug={challenge.slug} />
+      </div>{/* /MAIN COLUMN */}
+
+      {/* RIGHT SIDEBAR — sticky on desktop, hidden on mobile (drawer below).
+          Internal overflow so the sidebar itself scrolls when tools +
+          scratch pad exceed the viewport height. */}
+      <aside className="hidden lg:block w-80 flex-shrink-0">
+        <div className="sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto space-y-4 pr-1">
+          <Toolbox
+            category={challenge.category}
+            defaultExpanded
+            headerSlot={
+              <button
+                type="button"
+                onClick={() => {
+                  setToolboxIntroForcedOpen(true);
+                  setToolboxIntroOpen(true);
+                }}
+                aria-label="What is the toolbox?"
+                className="p-1 -m-1 text-indigo-700 dark:text-indigo-300 hover:text-indigo-900 dark:hover:text-indigo-100"
+              >
+                <HelpCircle className="w-4 h-4" />
+              </button>
+            }
+          />
+          <ScratchPad challengeSlug={challenge.slug} defaultExpanded />
+        </div>
+      </aside>
+
+      {/* MOBILE — floating button + bottom-sheet drawer. Hidden on lg+. */}
+      <MobileToolbox
+        category={challenge.category}
+        challengeSlug={challenge.slug}
+      />
+
+      {/* One-time intro on first CTF visit; re-openable via help icon */}
+      {toolboxIntroOpen && (
+        <ToolboxIntro
+          showClose={toolboxIntroForcedOpen}
+          onAcknowledge={() => void dismissToolboxIntro()}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/pathways/challenges/ChallengesPage.tsx
+++ b/src/components/pathways/challenges/ChallengesPage.tsx
@@ -7,7 +7,7 @@
  * if we want a strict ladder later, the `Lock` import is ready.
  */
 import { Link } from "react-router-dom";
-import { Flag, Trophy, Lock } from "lucide-react";
+import { Flag, Trophy, Lock, Wrench } from "lucide-react";
 import { CATEGORIES, type CtfDifficulty } from "@/constants/ctfChallenges";
 import { useChallenges, type DisplayChallenge } from "./useChallenges";
 
@@ -64,6 +64,63 @@ export default function ChallengesPage() {
           <span className="inline-flex items-center gap-1.5">
             <Trophy className="w-4 h-4" /> {progress?.totalAttempts ?? 0} attempts
           </span>
+        </div>
+      </div>
+
+      {/* How challenges work — brief intro above the category ladders.
+          Helps first-time visitors understand the toolbox + scratch pad
+          are part of the experience, not optional extras. */}
+      <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/50 p-4 sm:p-5">
+        <div className="flex items-start gap-3">
+          <div className="bg-indigo-600 rounded-lg p-2 shrink-0">
+            <Wrench className="w-5 h-5 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-semibold text-slate-900 dark:text-slate-100">
+              How CTF Challenges Work
+            </h3>
+            <p className="text-slate-700 dark:text-slate-300 text-sm mt-1 leading-relaxed">
+              Each challenge gives you a puzzle and a set of tools to solve
+              it. The skill isn't memorizing — it's pattern recognition and
+              tool selection. Use the toolbox (right side on desktop, 🔧
+              button on mobile), take notes in the scratch pad, and reveal
+              hints if you get stuck.
+            </p>
+            <details className="mt-3 group">
+              <summary className="text-sm text-indigo-700 dark:text-indigo-300 cursor-pointer hover:text-indigo-900 dark:hover:text-indigo-200 list-none">
+                <span className="inline-flex items-center gap-1">
+                  Where to start
+                  <span className="group-open:rotate-90 transition-transform">
+                    →
+                  </span>
+                </span>
+              </summary>
+              <div className="text-sm text-slate-600 dark:text-slate-400 mt-2 space-y-1.5">
+                <p>
+                  ·{" "}
+                  <strong className="text-slate-800 dark:text-slate-200">
+                    New to CTFs?
+                  </strong>{" "}
+                  Start with any Easy challenge in Cryptography or Web.
+                </p>
+                <p>
+                  ·{" "}
+                  <strong className="text-slate-800 dark:text-slate-200">
+                    Want a challenge?
+                  </strong>{" "}
+                  Try a Hard one after solving three or four Easys.
+                </p>
+                <p>
+                  ·{" "}
+                  <strong className="text-slate-800 dark:text-slate-200">
+                    Going for badges?
+                  </strong>{" "}
+                  Solve one challenge in each category to earn Cyber
+                  Generalist.
+                </p>
+              </div>
+            </details>
+          </div>
         </div>
       </div>
 

--- a/src/components/pathways/challenges/MobileToolbox.tsx
+++ b/src/components/pathways/challenges/MobileToolbox.tsx
@@ -1,0 +1,120 @@
+/**
+ * MobileToolbox — bottom-anchored drawer that gives mobile students
+ * access to the Toolbox and Scratch Pad without taking screen space
+ * from the challenge content.
+ *
+ * Hidden at lg+ (the desktop sidebar handles those viewports). On
+ * smaller screens, the floating "Tools" button sits above the Pathways
+ * bottom nav. Tapping opens a 80vh bottom sheet with two tabs.
+ */
+import { useEffect, useState } from "react";
+import { Wrench, Edit3, X } from "lucide-react";
+import type { CtfCategory } from "@/constants/ctfChallenges";
+import Toolbox from "./Toolbox";
+import ScratchPad from "./ScratchPad";
+
+interface MobileToolboxProps {
+  category: CtfCategory;
+  challengeSlug: string;
+}
+
+export default function MobileToolbox({
+  category,
+  challengeSlug,
+}: MobileToolboxProps) {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<"tools" | "scratch">("tools");
+
+  // Close on Escape so it behaves like a modal even when the FAB has focus.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      {/* Floating button — `bottom-20` keeps it above the Pathways bottom
+          nav (~64px). Hidden on lg+ where the sidebar is visible. */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open challenge tools"
+        className="lg:hidden fixed bottom-20 right-4 z-40 bg-indigo-600 hover:bg-indigo-700 active:scale-95 text-white rounded-full shadow-lg pl-3 pr-4 py-3 flex items-center gap-2 transition-transform"
+      >
+        <Wrench className="w-5 h-5" />
+        <span className="text-sm font-semibold">Tools</span>
+      </button>
+
+      {/* Bottom sheet */}
+      {open && (
+        <div
+          className="lg:hidden fixed inset-0 z-50 flex items-end bg-black/60 backdrop-blur-sm"
+          onClick={() => setOpen(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Challenge tools"
+        >
+          <div
+            className="bg-white dark:bg-slate-900 w-full max-h-[80vh] rounded-t-2xl overflow-hidden flex flex-col border-t border-slate-200 dark:border-slate-700"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Drag handle */}
+            <div className="flex justify-center py-2 shrink-0">
+              <div className="w-12 h-1 bg-slate-300 dark:bg-slate-600 rounded-full" />
+            </div>
+
+            {/* Tabs */}
+            <div className="flex border-b border-slate-200 dark:border-slate-700 shrink-0">
+              <button
+                type="button"
+                onClick={() => setView("tools")}
+                className={`flex-1 py-3 inline-flex items-center justify-center gap-1.5 font-semibold text-sm transition-colors ${
+                  view === "tools"
+                    ? "text-indigo-700 dark:text-indigo-300 border-b-2 border-indigo-500"
+                    : "text-slate-500 dark:text-slate-400 border-b-2 border-transparent"
+                }`}
+              >
+                <Wrench className="w-4 h-4" /> Toolbox
+              </button>
+              <button
+                type="button"
+                onClick={() => setView("scratch")}
+                className={`flex-1 py-3 inline-flex items-center justify-center gap-1.5 font-semibold text-sm transition-colors ${
+                  view === "scratch"
+                    ? "text-indigo-700 dark:text-indigo-300 border-b-2 border-indigo-500"
+                    : "text-slate-500 dark:text-slate-400 border-b-2 border-transparent"
+                }`}
+              >
+                <Edit3 className="w-4 h-4" /> Scratch Pad
+              </button>
+            </div>
+
+            {/* Content (scrolls internally if tools exceed the sheet) */}
+            <div className="flex-1 overflow-y-auto p-3 sm:p-4">
+              {view === "tools" && <Toolbox category={category} hideHeader />}
+              {view === "scratch" && (
+                <ScratchPad
+                  challengeSlug={challengeSlug}
+                  hideHeader
+                />
+              )}
+            </div>
+
+            {/* Close affordance — separate from the swipe-down area */}
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="px-4 py-3 inline-flex items-center justify-center gap-2 bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 font-medium border-t border-slate-200 dark:border-slate-700 shrink-0"
+            >
+              <X className="w-4 h-4" /> Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/pathways/challenges/ScratchPad.tsx
+++ b/src/components/pathways/challenges/ScratchPad.tsx
@@ -14,12 +14,20 @@ import { Edit3, ChevronDown, ChevronUp } from "lucide-react";
 
 interface ScratchPadProps {
   challengeSlug: string;
+  defaultExpanded?: boolean;
+  /** If true, omit the collapsible header chrome. Used inside the mobile
+   *  drawer where the drawer's tab provides the wrapper. */
+  hideHeader?: boolean;
 }
 
-export default function ScratchPad({ challengeSlug }: ScratchPadProps) {
+export default function ScratchPad({
+  challengeSlug,
+  defaultExpanded = true,
+  hideHeader = false,
+}: ScratchPadProps) {
   const storageKey = `ctf-scratch-${challengeSlug}`;
   const [content, setContent] = useState("");
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   // Hydrate from sessionStorage when the slug changes.
   useEffect(() => {
@@ -40,6 +48,25 @@ export default function ScratchPad({ challengeSlug }: ScratchPadProps) {
          lives in component state for the lifetime of the page. */
     }
   };
+
+  const body = (
+    <>
+      <textarea
+        value={content}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder="Work it out here. Notes, attempts, decoded letters, anything…"
+        spellCheck={false}
+        className="w-full min-h-[150px] p-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 font-mono text-sm resize-y focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+      />
+      <p className="text-[10px] text-slate-500 dark:text-slate-500 mt-2">
+        Saved locally in your browser — clears when you close the tab.
+      </p>
+    </>
+  );
+
+  if (hideHeader) {
+    return <div>{body}</div>;
+  }
 
   return (
     <div className="bg-white dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
@@ -65,20 +92,7 @@ export default function ScratchPad({ challengeSlug }: ScratchPadProps) {
         )}
       </button>
 
-      {expanded && (
-        <div className="px-3 sm:px-4 pb-3 sm:pb-4">
-          <textarea
-            value={content}
-            onChange={(e) => handleChange(e.target.value)}
-            placeholder="Work it out here. Notes, attempts, decoded letters, anything…"
-            spellCheck={false}
-            className="w-full min-h-[150px] p-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 font-mono text-sm resize-y focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-          />
-          <p className="text-[10px] text-slate-500 dark:text-slate-500 mt-2">
-            Saved locally in your browser — clears when you close the tab.
-          </p>
-        </div>
-      )}
+      {expanded && <div className="px-3 sm:px-4 pb-3 sm:pb-4">{body}</div>}
     </div>
   );
 }

--- a/src/components/pathways/challenges/Toolbox.tsx
+++ b/src/components/pathways/challenges/Toolbox.tsx
@@ -23,20 +23,47 @@ import type { CtfCategory } from "@/constants/ctfChallenges";
 
 interface ToolboxProps {
   category: CtfCategory;
+  /** Initial expand state for the collapsible chrome. Ignored when hideHeader=true. */
+  defaultExpanded?: boolean;
+  /** If true, render only the tools — no header, no collapse. Used inside the
+   *  mobile drawer where the drawer tabs already provide the collapse UX. */
+  hideHeader?: boolean;
+  /** Optional click target rendered next to the header (e.g. "What is the toolbox?"). */
+  headerSlot?: React.ReactNode;
 }
 
-export default function Toolbox({ category }: ToolboxProps) {
-  const [expanded, setExpanded] = useState(false);
+function CategoryTools({ category }: { category: CtfCategory }) {
+  if (category === "cryptography") return <CryptographyTools />;
+  if (category === "web") return <WebTools />;
+  if (category === "forensics") return <ForensicsTools />;
+  return <NetworkTools />;
+}
+
+export default function Toolbox({
+  category,
+  defaultExpanded = false,
+  hideHeader = false,
+  headerSlot,
+}: ToolboxProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (hideHeader) {
+    return (
+      <div className="space-y-3 sm:space-y-4">
+        <CategoryTools category={category} />
+      </div>
+    );
+  }
 
   return (
     <div className="bg-indigo-50/60 dark:bg-indigo-950/30 border border-indigo-200 dark:border-indigo-800/50 rounded-xl overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        aria-expanded={expanded}
-        className="w-full flex items-center justify-between p-3 sm:p-4 text-left hover:bg-indigo-100/60 dark:hover:bg-indigo-900/40"
-      >
-        <div className="flex items-center gap-2 min-w-0">
+      <div className="flex items-center justify-between p-3 sm:p-4">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          className="flex items-center gap-2 min-w-0 flex-1 text-left hover:opacity-80"
+        >
           <Wrench className="w-4 h-4 text-indigo-700 dark:text-indigo-300 shrink-0" />
           <span className="font-semibold text-slate-900 dark:text-slate-100">
             Toolbox
@@ -44,20 +71,18 @@ export default function Toolbox({ category }: ToolboxProps) {
           <span className="text-xs text-indigo-700/80 dark:text-indigo-300/70 hidden sm:inline">
             tools for this challenge
           </span>
-        </div>
-        {expanded ? (
-          <ChevronUp className="w-4 h-4 text-indigo-700 dark:text-indigo-300" />
-        ) : (
-          <ChevronDown className="w-4 h-4 text-indigo-700 dark:text-indigo-300" />
-        )}
-      </button>
+          {expanded ? (
+            <ChevronUp className="ml-auto w-4 h-4 text-indigo-700 dark:text-indigo-300" />
+          ) : (
+            <ChevronDown className="ml-auto w-4 h-4 text-indigo-700 dark:text-indigo-300" />
+          )}
+        </button>
+        {headerSlot && <div className="ml-2 shrink-0">{headerSlot}</div>}
+      </div>
 
       {expanded && (
         <div className="p-3 sm:p-4 pt-0 space-y-3 sm:space-y-4">
-          {category === "cryptography" && <CryptographyTools />}
-          {category === "web" && <WebTools />}
-          {category === "forensics" && <ForensicsTools />}
-          {category === "networks" && <NetworkTools />}
+          <CategoryTools category={category} />
         </div>
       )}
     </div>

--- a/src/components/pathways/challenges/ToolboxIntro.tsx
+++ b/src/components/pathways/challenges/ToolboxIntro.tsx
@@ -1,0 +1,139 @@
+/**
+ * ToolboxIntro — one-time overlay shown the first time a student opens a
+ * CTF challenge. Frames the toolbox + scratch pad + hints so they don't
+ * think they're supposed to do everything in their head.
+ *
+ * Dismissal flips PathwayOnboarding.toolboxIntroSeen so future visits skip
+ * it. Re-openable via the help icon on the Toolbox header.
+ */
+import { Wrench, Edit3, Lightbulb, X } from "lucide-react";
+
+interface ToolboxIntroProps {
+  onAcknowledge: () => void;
+  /** When true, shows a small × close button (used when the intro is
+   *  re-opened from the help icon and the user is just browsing the
+   *  reference rather than completing first-run). */
+  showClose?: boolean;
+}
+
+export default function ToolboxIntro({
+  onAcknowledge,
+  showClose,
+}: ToolboxIntroProps) {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 shadow-xl">
+        <div className="flex items-start justify-between px-5 sm:px-6 py-4 border-b border-slate-200 dark:border-slate-800">
+          <h2 className="text-lg sm:text-xl font-bold text-slate-900 dark:text-slate-100">
+            Meet Your Toolbox
+          </h2>
+          {showClose && (
+            <button
+              type="button"
+              onClick={onAcknowledge}
+              aria-label="Close"
+              className="p-1 -m-1 text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+
+        <div className="px-5 sm:px-6 py-5 space-y-4 text-sm leading-relaxed text-slate-800 dark:text-slate-200">
+          <p>
+            Real cybersecurity professionals don't memorize ciphers or compute
+            hex by hand. They use tools — and so will you.
+          </p>
+
+          <IntroBlock
+            Icon={Wrench}
+            tint="indigo"
+            title="Toolbox"
+            body={
+              <>
+                Every challenge has tools designed for it — cipher decoders,
+                hex converters, port references, network calculators, and
+                more. They live in a panel on the right (on mobile, tap the{" "}
+                <span className="inline-flex items-center gap-0.5 align-baseline">
+                  <Wrench className="w-3 h-3" /> Tools
+                </span>{" "}
+                button in the bottom corner).
+              </>
+            }
+          />
+
+          <IntroBlock
+            Icon={Edit3}
+            tint="emerald"
+            title="Scratch Pad"
+            body="A notepad for your work. Notes, attempts, partial answers — anything. Auto-saves while you work. It sits right below the Toolbox."
+          />
+
+          <IntroBlock
+            Icon={Lightbulb}
+            tint="amber"
+            title="Hints"
+            body="Stuck? Every challenge has 3 progressive hints. Using them doesn't cost you any XP — it just helps your facilitator see where group instruction might help."
+          />
+
+          <p className="text-center text-slate-600 dark:text-slate-400 italic text-xs sm:text-sm pt-2">
+            The challenge isn't to do everything in your head.
+            <br />
+            The challenge is to recognize problems and use the right tool.
+          </p>
+        </div>
+
+        <div className="px-5 sm:px-6 py-4 border-t border-slate-200 dark:border-slate-800">
+          <button
+            type="button"
+            onClick={onAcknowledge}
+            className="w-full px-5 py-3 min-h-[44px] rounded-lg bg-indigo-600 hover:bg-indigo-700 active:scale-[0.98] text-white text-sm font-semibold transition-all"
+          >
+            Got it — let's solve some puzzles
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type Tint = "indigo" | "emerald" | "amber";
+
+function IntroBlock({
+  Icon,
+  tint,
+  title,
+  body,
+}: {
+  Icon: typeof Wrench;
+  tint: Tint;
+  title: string;
+  body: React.ReactNode;
+}) {
+  const ring = {
+    indigo:
+      "bg-indigo-50 dark:bg-indigo-950/30 border-indigo-200 dark:border-indigo-800/50",
+    emerald:
+      "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800/50",
+    amber:
+      "bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50",
+  }[tint];
+  const iconColor = {
+    indigo: "text-indigo-700 dark:text-indigo-300",
+    emerald: "text-emerald-700 dark:text-emerald-400",
+    amber: "text-amber-700 dark:text-amber-400",
+  }[tint];
+  return (
+    <div className={`rounded-xl border p-3 sm:p-4 ${ring}`}>
+      <p className="flex items-center gap-2 mb-1">
+        <Icon className={`w-4 h-4 ${iconColor}`} />
+        <span className="font-semibold text-slate-900 dark:text-slate-100">
+          {title}
+        </span>
+      </p>
+      <div className="text-xs sm:text-sm text-slate-700 dark:text-slate-300">
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pathways/onboarding/useOnboarding.ts
+++ b/src/components/pathways/onboarding/useOnboarding.ts
@@ -18,6 +18,7 @@ export interface OnboardingState {
   missionStatement: string | null;
   dailyGoalLevel: "light" | "medium" | "heavy" | null;
   avatarSlug: string | null;
+  toolboxIntroSeen?: boolean;
 }
 
 export interface OnboardingPatch {
@@ -27,6 +28,7 @@ export interface OnboardingPatch {
   missionStatement?: string;
   dailyGoalLevel?: "light" | "medium" | "heavy";
   avatarSlug?: string;
+  toolboxIntroSeen?: boolean;
   completed?: boolean;
 }
 

--- a/src/constants/ctfChallenges.ts
+++ b/src/constants/ctfChallenges.ts
@@ -99,13 +99,13 @@ export const CRYPTOGRAPHY_CHALLENGES: CtfChallenge[] = [
     ],
     skills: ["observation", "string manipulation"],
     estimatedMinutes: 3,
-    xpReward: 10,
+    xpReward: 5,
     beforeYouStart: ["Ability to read text carefully"],
   },
   {
     slug: "base64-buddy",
     category: "cryptography",
-    difficulty: "medium",
+    difficulty: "easy",
     title: "Base64 Buddy",
     description:
       "Base64 is everywhere on the web — emails, images, tokens. Time to decode some.",
@@ -128,7 +128,7 @@ export const CRYPTOGRAPHY_CHALLENGES: CtfChallenge[] = [
     ],
     skills: ["encoding awareness", "browser DevTools"],
     estimatedMinutes: 8,
-    xpReward: 25,
+    xpReward: 10,
     beforeYouStart: [
       "Knowing how to open browser DevTools (F12 in most browsers)",
     ],
@@ -136,7 +136,7 @@ export const CRYPTOGRAPHY_CHALLENGES: CtfChallenge[] = [
   {
     slug: "hex-hunt",
     category: "cryptography",
-    difficulty: "medium",
+    difficulty: "easy",
     title: "Hex Hunt",
     description:
       "Hexadecimal is how computers represent data. Today, you're the human decoder.",
@@ -159,9 +159,46 @@ export const CRYPTOGRAPHY_CHALLENGES: CtfChallenge[] = [
     ],
     skills: ["hex understanding", "ASCII"],
     estimatedMinutes: 10,
-    xpReward: 25,
+    xpReward: 10,
     beforeYouStart: [
       "Understanding that computers store text as numbers (ASCII codes)",
+    ],
+  },
+  {
+    slug: "layered-mystery",
+    category: "cryptography",
+    difficulty: "hard",
+    title: "Layered Mystery",
+    description: "Sometimes secrets hide behind multiple walls.",
+    scenario:
+      "A message was wrapped in three layers of encoding before being passed on. Peel them off one at a time using the toolbox.",
+    prompt:
+      "Decode this message. The flag is the final readable text. You'll need to chain three tools.",
+    materials: [
+      {
+        type: "code",
+        content: "dWxra3BvZnN3bGxrenBuaHNtbG9h",
+        caption: "Triple-encoded message",
+      },
+      {
+        type: "text",
+        content:
+          "The sender applied these steps in order to ENCODE:\n  1. Caesar cipher (shift +7)\n  2. Reverse the string\n  3. Base64 encode\n\nTo DECODE, undo them in reverse: base64 first, then reverse, then Caesar shift back by 7.",
+      },
+    ],
+    flag: "theflagisdeeplyhidden",
+    flagFormat: "all lowercase, no spaces",
+    hints: [
+      "Start by base64-decoding the message. The result will still look scrambled.",
+      "Then reverse the string. It'll look like a single Caesar cipher.",
+      "Finally, Caesar-decode with the toolbox set to shift = 7.",
+    ],
+    skills: ["multi-step decoding", "tool chaining"],
+    estimatedMinutes: 15,
+    xpReward: 50,
+    beforeYouStart: [
+      "Comfort with the Base64, Reverse, and Caesar tools individually",
+      "Patience to undo encodings in the right order",
     ],
   },
   {
@@ -380,7 +417,7 @@ URL pattern: https://example.com/files/[directory]/[file]`,
   {
     slug: "form-field-sleuth",
     category: "web",
-    difficulty: "hard",
+    difficulty: "medium",
     title: "Form Field Sleuth",
     description:
       "Forms have visible fields and invisible ones. The flag is in the latter.",
@@ -416,7 +453,7 @@ URL pattern: https://example.com/files/[directory]/[file]`,
     ],
     skills: ["form inspection", "HTML", "hidden field discovery"],
     estimatedMinutes: 8,
-    xpReward: 50,
+    xpReward: 25,
     beforeYouStart: [
       "Understanding HTML forms have input fields with names and values",
     ],
@@ -846,7 +883,7 @@ mysteriousdomain.example.        NS     ns1.example.com.`,
   {
     slug: "firewall-find",
     category: "networks",
-    difficulty: "medium",
+    difficulty: "easy",
     title: "Firewall Find",
     description:
       "Firewall rules decide what gets through. Reading them well is half the battle.",
@@ -877,7 +914,7 @@ mysteriousdomain.example.        NS     ns1.example.com.`,
     ],
     skills: ["firewall rules", "CIDR notation", "rule order"],
     estimatedMinutes: 8,
-    xpReward: 25,
+    xpReward: 10,
     beforeYouStart: [
       "Knowing what a subnet looks like in CIDR notation (e.g., 10.0.0.0/24)",
     ],


### PR DESCRIPTION
## Summary

Three connected CTF UX improvements:

1. **Toolbox + ScratchPad to a sticky right sidebar** (desktop) /
   bottom-sheet drawer (mobile). Frees vertical space, keeps tools
   one click away while scrolling the challenge.
2. **Difficulty rebalance**. With tools shipped in 7719e48, several
   challenges became one-click solves. Difficulty now reflects what
   you have to FIGURE OUT, not what you have to COMPUTE.
3. **First-time toolbox intro overlay** after EthicsFraming on the
   first CTF visit. Re-openable via a help icon on the Toolbox.
   Tracked via `PathwayOnboarding.toolboxIntroSeen` (new field).

## Layout restructure

`ChallengePage.tsx` becomes a flex container:
- Main column: header → before-you-start → scenario → mission →
  materials → hints → flag submission. `max-w-7xl` wrapper, main
  column stays `min-w-0` so long code blocks wrap.
- Right `<aside>`: `w-80`, hidden below `lg`. Sticky `top-4` with
  internal `overflow-y-auto` capped at `calc(100vh-2rem)`, so the
  sidebar scrolls on its own when tools + scratch pad exceed the
  viewport.
- Mobile drawer: new `MobileToolbox` component renders a pill above
  the bottom nav (`bottom-20`) opening a 80vh bottom sheet with
  Toolbox / Scratch Pad tabs. Closes on outside tap, Escape, or the
  Close button.
- `Toolbox` and `ScratchPad` gained `defaultExpanded` and `hideHeader`
  props so they render with chrome in the sidebar and as bare content
  inside the drawer.

## Difficulty + XP changes

| Challenge | Before | After | Why |
|---|---|---|---|
| Backwards Mind | easy / 10 | easy / 5 | Reverse tool = literal one click |
| Base64 Buddy | medium / 25 | easy / 10 | Tool decodes entirely |
| Hex Hunt | medium / 25 | easy / 10 | Tool decodes entirely |
| Form Field Sleuth | hard / 50 | medium / 25 | HTML inspect is medium-tier |
| Firewall Find | medium / 25 | easy / 10 | Reading rule 1 is easy |

Plus one new **genuine-hard** challenge that requires *chaining* three
tools, not using any single one:

**Layered Mystery** (cryptography / hard / 50 XP). Ciphertext
`dWxra3BvZnN3bGxrenBuaHNtbG9h`. Encode pipeline: Caesar +7 →
reverse → base64. Verified end-to-end against the canonical flag
`theflagisdeeplyhidden` via Node script.

Both the frontend catalog and the backend validation mirror were
updated together.

## First-time intro

- Migration `20260521_add_toolbox_intro_seen` (both root and backend
  mirrors): `ADD COLUMN IF NOT EXISTS "toolboxIntroSeen" BOOLEAN NOT
  NULL DEFAULT false`. Idempotent.
- Backend `PATCH /onboarding/me` zod schema accepts the new field.
- New `ToolboxIntro` overlay fires after EthicsFraming when
  `onboarding.toolboxIntroSeen === false`. Dismissal PATCHes
  `toolboxIntroSeen: true` so it never reappears for that user.
- `Toolbox` accepts a `headerSlot` and we wire a `HelpCircle` button
  there to re-open the intro as a close-able modal.
- New "How CTF Challenges Work" card on the `/pathways/challenges`
  landing page above the category ladders, with a "Where to start"
  details disclosure (new-to-CTFs / want-a-challenge /
  going-for-badges).

## Test plan

- [ ] Desktop ≥1024px: sidebar visible, sticky as you scroll, tools
  usable while reading the scenario
- [ ] Mobile <1024px: sidebar hidden, floating Tools pill above the
  bottom nav, drawer opens with two tabs
- [ ] Hint button works (carry-over from #593)
- [ ] First-time CTF visitor: EthicsFraming → ToolboxIntro →
  challenge UI. Second visit: straight to the challenge.
- [ ] Help icon on Toolbox re-opens intro with a close ×
- [ ] Layered Mystery: paste ciphertext into Base64 tool → reverse →
  Caesar shift 7 → submit `theflagisdeeplyhidden` → solve
- [ ] Difficulty chips on the ladder reflect new values
- [ ] `npm run lint` clean (verified)
- [ ] Backend `tsc --noEmit` clean (verified)
- [ ] Frontend `tsc --noEmit` clean for CTF / onboarding code (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)