### PR TITLE
fix: diagnostic findings — Marcus demo reset + daily goal level wiring + intro reseed

### DIFF
--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -1637,6 +1637,16 @@ async function main() {
     { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
   ];
 
+  // Clear any drifted Cyber Launch milestone state before re-seeding the
+  // canonical 4 rows. Without this, live demo usage that touches modules
+  // outside the seed array accumulates rows that the upsert-only loop
+  // never cleans up — Marcus drifted from "3 done + 1 in flight" to
+  // "1 done + 5 in flight" over the past two weeks. (See diagnostic
+  // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
+  await prisma.pathwayMilestone.deleteMany({
+    where: { userId: marcus.id, trackSlug: "cyber-launch" },
+  });
+
   for (const m of marcusMilestones) {
     const isDone = m.status === "completed";
     const isInProgress = m.status === "in_progress";
@@ -1654,15 +1664,13 @@ async function main() {
       quizScore: isDone ? m.score : null,
       timeSpentMinutes: m.timeSpent,
     };
-    await prisma.pathwayMilestone.upsert({
-      where: { userId_trackSlug_moduleSlug: { userId: marcus.id, trackSlug: "cyber-launch", moduleSlug: m.moduleSlug } },
-      create: {
+    await prisma.pathwayMilestone.create({
+      data: {
         userId: marcus.id,
         trackSlug: "cyber-launch",
         moduleSlug: m.moduleSlug,
         ...fullFields,
       },
-      update: fullFields,
     });
   }
   console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
@@ -1784,6 +1792,10 @@ async function main() {
       missionStatement:
         "I want to build a real career in cybersecurity and help my community stay safe online.",
       dailyGoalLevel: "medium",
+      // Demo intent: every fresh demo should see the toolbox intro fire on
+      // first CTF visit. Live sessions used to leave this `true`, breaking
+      // the demo story on the next showing. (Diagnostic finding L3.)
+      toolboxIntroSeen: false,
     },
     {
       email: "facilitator@test.com",
@@ -1791,6 +1803,7 @@ async function main() {
       missionStatement:
         "I want to help my students see themselves in this work and build real pathways forward.",
       dailyGoalLevel: "heavy",
+      toolboxIntroSeen: false,
     },
   ];
 
@@ -1807,6 +1820,7 @@ async function main() {
       skillsTourSkipped: false,
       missionStatement: data.missionStatement,
       dailyGoalLevel: data.dailyGoalLevel,
+      toolboxIntroSeen: data.toolboxIntroSeen,
       completedAt: new Date(),
     };
     await prisma.pathwayOnboarding.upsert({
@@ -1835,6 +1849,66 @@ async function main() {
     });
   }
   console.log("  Awarded Getting Started badge to demo accounts");
+
+  // ─── Daily goals for today (demo accounts) ──────────────────────────────
+  // Without a row for "today", the home page goal card briefly renders an
+  // empty/skeleton state until the lazy server-side creation fires. Pre-
+  // seeding here means demos always open to a fully-rendered goal card.
+  // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
+  // should hit the lazy creation path so we can show that flow.
+  //
+  // NOTE: this mirrors getDailyGoalTargets() in
+  // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
+  // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
+  // off them at runtime to credit progress.
+  function getDailyGoalTargets(level) {
+    const effective = level || "medium";
+    if (effective === "light") {
+      return [
+        { slug: "complete_section", label: "Complete 1 section", target: 1 },
+        { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+      ];
+    }
+    if (effective === "heavy") {
+      return [
+        { slug: "complete_section", label: "Complete 2 sections", target: 2 },
+        { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
+        { slug: "try_lab_or_quiz", label: "Try 1 lab or challenge", target: 1 },
+      ];
+    }
+    return [
+      { slug: "complete_section", label: "Complete 1 section", target: 1 },
+      { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
+      { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
+    ];
+  }
+
+  const todayUtc = new Date();
+  todayUtc.setUTCHours(0, 0, 0, 0);
+
+  for (const data of onboardingDemoData) {
+    const user = await prisma.user.findUnique({ where: { email: data.email } });
+    if (!user) continue;
+    const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
+      ...t,
+      current: 0,
+      completed: false,
+    }));
+    await prisma.pathwayDailyGoal.upsert({
+      where: { userId_date: { userId: user.id, date: todayUtc } },
+      // Don't clobber progress someone already accrued today; just ensure
+      // a row exists with the right shape.
+      update: {},
+      create: {
+        userId: user.id,
+        date: todayUtc,
+        goals,
+        allComplete: false,
+        bonusAwarded: false,
+      },
+    });
+  }
+  console.log("  Seeded daily goals for demo accounts (today, by goal level)");
   } catch (e) {
     console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
   }

--- a/backend/src/services/gamification.ts
+++ b/backend/src/services/gamification.ts
@@ -560,11 +560,49 @@ export interface DailyGoalItem {
   completed: boolean;
 }
 
-const DEFAULT_GOALS: DailyGoalItem[] = [
-  { slug: "complete_section", label: "Complete 1 section", target: 1, current: 0, completed: false },
-  { slug: "earn_xp", label: "Earn 50 XP", target: 50, current: 0, completed: false },
-  { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1, current: 0, completed: false },
-];
+export type DailyGoalLevel = "light" | "medium" | "heavy";
+
+/**
+ * Returns the target shape for a given daily-goal preference. Light has
+ * 2 goals (lower XP, no lab), medium has 3 (the original defaults), heavy
+ * has 3 with higher targets (2 sections, 100 XP).
+ *
+ * NOTE: keep the slugs stable (`complete_section`, `earn_xp`,
+ * `try_lab_or_quiz`) — `updateDailyGoalProgress` matches on those slugs
+ * to credit progress. Labels can vary per level.
+ *
+ * NOTE: prisma/seed.cjs mirrors this function. If you change the shapes
+ * here, mirror the change there too (small enough to duplicate).
+ */
+export function getDailyGoalTargets(
+  level: DailyGoalLevel | null | undefined,
+): Array<Omit<DailyGoalItem, "current" | "completed">> {
+  const effective: DailyGoalLevel = level ?? "medium";
+  if (effective === "light") {
+    return [
+      { slug: "complete_section", label: "Complete 1 section", target: 1 },
+      { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+    ];
+  }
+  if (effective === "heavy") {
+    return [
+      { slug: "complete_section", label: "Complete 2 sections", target: 2 },
+      { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
+      { slug: "try_lab_or_quiz", label: "Try 1 lab or challenge", target: 1 },
+    ];
+  }
+  return [
+    { slug: "complete_section", label: "Complete 1 section", target: 1 },
+    { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
+    { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
+  ];
+}
+
+function expandTargets(
+  targets: ReturnType<typeof getDailyGoalTargets>,
+): DailyGoalItem[] {
+  return targets.map((t) => ({ ...t, current: 0, completed: false }));
+}
 
 export async function getOrCreateDailyGoals(userId: string) {
   const today = toUtcDate(new Date());
@@ -572,11 +610,23 @@ export async function getOrCreateDailyGoals(userId: string) {
     where: { userId_date: { userId, date: today } },
   });
   if (found) return found;
+
+  // Honour the student's Cyber Skills 101 daily-goal preference if it's
+  // been set. Missing onboarding row or `null` level falls through to
+  // medium (the historical default).
+  const onboarding = await prisma.pathwayOnboarding.findUnique({
+    where: { userId },
+    select: { dailyGoalLevel: true },
+  });
+  const targets = getDailyGoalTargets(
+    onboarding?.dailyGoalLevel as DailyGoalLevel | null,
+  );
+
   return prisma.pathwayDailyGoal.create({
     data: {
       userId,
       date: today,
-      goals: DEFAULT_GOALS as unknown as Prisma.InputJsonValue,
+      goals: expandTargets(targets) as unknown as Prisma.InputJsonValue,
     },
   });
 }

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -1637,6 +1637,16 @@ async function main() {
     { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
   ];
 
+  // Clear any drifted Cyber Launch milestone state before re-seeding the
+  // canonical 4 rows. Without this, live demo usage that touches modules
+  // outside the seed array accumulates rows that the upsert-only loop
+  // never cleans up — Marcus drifted from "3 done + 1 in flight" to
+  // "1 done + 5 in flight" over the past two weeks. (See diagnostic
+  // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
+  await prisma.pathwayMilestone.deleteMany({
+    where: { userId: marcus.id, trackSlug: "cyber-launch" },
+  });
+
   for (const m of marcusMilestones) {
     const isDone = m.status === "completed";
     const isInProgress = m.status === "in_progress";
@@ -1654,15 +1664,13 @@ async function main() {
       quizScore: isDone ? m.score : null,
       timeSpentMinutes: m.timeSpent,
     };
-    await prisma.pathwayMilestone.upsert({
-      where: { userId_trackSlug_moduleSlug: { userId: marcus.id, trackSlug: "cyber-launch", moduleSlug: m.moduleSlug } },
-      create: {
+    await prisma.pathwayMilestone.create({
+      data: {
         userId: marcus.id,
         trackSlug: "cyber-launch",
         moduleSlug: m.moduleSlug,
         ...fullFields,
       },
-      update: fullFields,
     });
   }
   console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
@@ -1784,6 +1792,10 @@ async function main() {
       missionStatement:
         "I want to build a real career in cybersecurity and help my community stay safe online.",
       dailyGoalLevel: "medium",
+      // Demo intent: every fresh demo should see the toolbox intro fire on
+      // first CTF visit. Live sessions used to leave this `true`, breaking
+      // the demo story on the next showing. (Diagnostic finding L3.)
+      toolboxIntroSeen: false,
     },
     {
       email: "facilitator@test.com",
@@ -1791,6 +1803,7 @@ async function main() {
       missionStatement:
         "I want to help my students see themselves in this work and build real pathways forward.",
       dailyGoalLevel: "heavy",
+      toolboxIntroSeen: false,
     },
   ];
 
@@ -1807,6 +1820,7 @@ async function main() {
       skillsTourSkipped: false,
       missionStatement: data.missionStatement,
       dailyGoalLevel: data.dailyGoalLevel,
+      toolboxIntroSeen: data.toolboxIntroSeen,
       completedAt: new Date(),
     };
     await prisma.pathwayOnboarding.upsert({
@@ -1835,6 +1849,66 @@ async function main() {
     });
   }
   console.log("  Awarded Getting Started badge to demo accounts");
+
+  // ─── Daily goals for today (demo accounts) ──────────────────────────────
+  // Without a row for "today", the home page goal card briefly renders an
+  // empty/skeleton state until the lazy server-side creation fires. Pre-
+  // seeding here means demos always open to a fully-rendered goal card.
+  // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
+  // should hit the lazy creation path so we can show that flow.
+  //
+  // NOTE: this mirrors getDailyGoalTargets() in
+  // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
+  // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
+  // off them at runtime to credit progress.
+  function getDailyGoalTargets(level) {
+    const effective = level || "medium";
+    if (effective === "light") {
+      return [
+        { slug: "complete_section", label: "Complete 1 section", target: 1 },
+        { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+      ];
+    }
+    if (effective === "heavy") {
+      return [
+        { slug: "complete_section", label: "Complete 2 sections", target: 2 },
+        { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
+        { slug: "try_lab_or_quiz", label: "Try 1 lab or challenge", target: 1 },
+      ];
+    }
+    return [
+      { slug: "complete_section", label: "Complete 1 section", target: 1 },
+      { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
+      { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
+    ];
+  }
+
+  const todayUtc = new Date();
+  todayUtc.setUTCHours(0, 0, 0, 0);
+
+  for (const data of onboardingDemoData) {
+    const user = await prisma.user.findUnique({ where: { email: data.email } });
+    if (!user) continue;
+    const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
+      ...t,
+      current: 0,
+      completed: false,
+    }));
+    await prisma.pathwayDailyGoal.upsert({
+      where: { userId_date: { userId: user.id, date: todayUtc } },
+      // Don't clobber progress someone already accrued today; just ensure
+      // a row exists with the right shape.
+      update: {},
+      create: {
+        userId: user.id,
+        date: todayUtc,
+        goals,
+        allComplete: false,
+        bonusAwarded: false,
+      },
+    });
+  }
+  console.log("  Seeded daily goals for demo accounts (today, by goal level)");
   } catch (e) {
     console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
   }


### PR DESCRIPTION
## Summary

Four-item surgical PR for the actionable findings from the 2026-05-24
Pathways stack diagnostic at commit `7d4a0aa`. Demo-impact and a small
piece of dead-code wiring. ~80 lines per file, no schema changes.

- **M4** — Reset Marcus's milestones to the documented demo state
- **L1** — Seed today's daily goals for Marcus + Coach Davis
- **L2** — Wire `PathwayOnboarding.dailyGoalLevel` into goal generation
- **L3** — Set `toolboxIntroSeen: false` in demo onboarding payloads

Skipped (per audit recommendation): M1, M2 (cosmetic file/endpoint
renames), M3, and the 5 low items not listed above.

## What changed

| File | What |
|---|---|
| `backend/src/services/gamification.ts` | New `getDailyGoalTargets(level)` helper. `getOrCreateDailyGoals` now reads `PathwayOnboarding.dailyGoalLevel` before creating today's row. Slugs stay stable so `updateDailyGoalProgress` keeps crediting correctly. |
| `prisma/seed.cjs` | `deleteMany` Marcus's Cyber Launch milestones before re-seeding the canonical 4. Adds `toolboxIntroSeen: false` to demo onboarding payloads. Seeds today's `PathwayDailyGoal` for Marcus + Coach Davis using the level-appropriate targets. |
| `backend/prisma/seed.cjs` | Mirror of root seed. |

### Goal-level shapes

| Level | Goals |
|---|---|
| `light`  | Complete 1 section · Earn 30 XP (2 goals) |
| `medium` | Complete 1 section · Earn 50 XP · Try 1 lab or quiz (3 goals — historical default) |
| `heavy`  | Complete 2 sections · Earn 100 XP · Try 1 lab or challenge (3 goals, higher) |

## Test plan

- [x] `npm run lint` clean
- [x] Backend `tsc --noEmit` clean
- [x] Both seed files syntax-check (`node --check`)
- [x] `diff prisma/seed.cjs backend/prisma/seed.cjs` returns nothing
- [ ] Post-deploy: Marcus's milestones are exactly 4 (3 completed, 1 in
  progress), `toolboxIntroSeen` is `false`, daily-goal row for today
  exists with 3 entries (medium targets)
- [ ] Post-deploy: Coach Davis has a daily-goal row for today with 3
  entries (heavy targets, 2 sections + 100 XP + 1 lab/challenge)
- [ ] Aisha still has no daily-goal row pre-seeded (fresh-user demo
  preserved); her row is created lazily on first home-page visit

## Idempotency

All four operations are safe to run multiple times:

- The `deleteMany` is scoped to `userId: marcus.id, trackSlug: "cyber-launch"`
- The onboarding upsert overwrites identical fields with identical
  values
- The daily-goal upsert uses `update: {}` so it never clobbers
  in-flight progress for "today"
- The badge upsert is unchanged from prior PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)