### PR TITLE
feat: K-8 analytics — PostHog integration, funnel instrumentation, admin scoreboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ SESSION_SECRET="local-dev-secret-change-in-production"
 # Incoming webhook URL for deploy, experiment, and milestone notifications.
 # SLACK_WEBHOOK_URL=
 
+# --- PostHog Analytics (optional — silently no-ops when unset) ---
+# Frontend (public project key, safe in the client bundle):
+# VITE_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# VITE_POSTHOG_HOST="https://us.i.posthog.com"
+# Backend (same project key; defaults to https://us.i.posthog.com):
+# POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# POSTHOG_HOST="https://us.i.posthog.com"
+
 # --- Email (optional for local dev) ---
 # SMTP_HOST=
 # SMTP_PORT=

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.0.2",
         "nodemailer": "^8.0.2",
+        "posthog-node": "^5.21.2",
         "prisma": "^6.19.1",
         "zod": "^3.23.8"
       },
@@ -530,6 +531,15 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
       }
     },
     "node_modules/@prisma/client": {
@@ -1578,6 +1588,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
@@ -2148,6 +2172,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "license": "MIT",
@@ -2459,6 +2489,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "license": "MIT"
@@ -2527,6 +2566,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/prisma": {
@@ -2759,6 +2810,27 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -3249,6 +3321,21 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.0.2",
     "nodemailer": "^8.0.2",
+    "posthog-node": "^5.21.2",
     "prisma": "^6.19.1",
     "zod": "^3.23.8"
   },

--- a/backend/src/routes/adminMetrics.ts
+++ b/backend/src/routes/adminMetrics.ts
@@ -1,0 +1,98 @@
+/**
+ * Admin scoreboard — GET /api/admin/metrics
+ *
+ * Computes the headline funnel numbers straight from the database. This is
+ * the source of truth for the team's weekly review — PostHog is for funnel
+ * exploration, this is for the trustworthy totals.
+ *
+ * Auth: admin role required (requireRole("admin")).
+ */
+import { Router, Request, Response } from "express";
+import prisma from "../utils/prisma";
+import { requireAuth, requireRole } from "../utils/auth";
+
+const router = Router();
+
+router.get(
+  "/admin/metrics",
+  requireAuth,
+  requireRole("admin"),
+  async (_req: Request, res: Response) => {
+    try {
+      const now = new Date();
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      // K-8-scope accounts. Pathways users (userType === 'pathways') are excluded
+      // — they have their own facilitator dashboard and roll up under a different
+      // funnel.
+      const k8Where = { userType: "k8" } as const;
+
+      const [
+        totalAccounts,
+        teachers,
+        students,
+        totalClasses,
+        totalEnrollments,
+        gamesStarted,
+        gamesCompleted,
+        signupsLast7Days,
+        signupsLast30Days,
+      ] = await Promise.all([
+        prisma.user.count({ where: k8Where }),
+        prisma.user.count({ where: { ...k8Where, role: "teacher" } }),
+        prisma.user.count({ where: { ...k8Where, role: "student" } }),
+        prisma.course.count(),
+        prisma.enrollment.count(),
+        // Progress records — IN_PROGRESS or COMPLETED — proxy "games started".
+        prisma.progress.count(),
+        prisma.progress.count({ where: { status: "COMPLETED" } }),
+        prisma.user.count({
+          where: { ...k8Where, createdAt: { gte: sevenDaysAgo } },
+        }),
+        prisma.user.count({
+          where: { ...k8Where, createdAt: { gte: thirtyDaysAgo } },
+        }),
+      ]);
+
+      const avgStudentsPerClass =
+        totalClasses > 0
+          ? Math.round((totalEnrollments / totalClasses) * 10) / 10
+          : 0;
+      const completionRate =
+        gamesStarted > 0
+          ? Math.round((gamesCompleted / gamesStarted) * 1000) / 10 // 1 decimal
+          : 0;
+
+      // "Active users in last 7d" = distinct students with any Progress.updatedAt
+      // in window. Login records aren't persisted in this schema, so progress
+      // activity is the best DB-side proxy. PostHog's `login` event is the
+      // direct measure if/when it's been instrumented for long enough.
+      const activeUsersLast7DaysRows = await prisma.progress.findMany({
+        where: { updatedAt: { gte: sevenDaysAgo } },
+        select: { studentId: true },
+        distinct: ["studentId"],
+      });
+      const activeUsersLast7Days = activeUsersLast7DaysRows.length;
+
+      res.json({
+        asOf: now.toISOString(),
+        totalAccounts,
+        accountsByRole: { teacher: teachers, student: students },
+        totalClasses,
+        avgStudentsPerClass,
+        gamesStarted,
+        gamesCompleted,
+        completionRate,
+        signupsLast7Days,
+        signupsLast30Days,
+        activeUsersLast7Days,
+      });
+    } catch (err) {
+      console.error("admin/metrics error:", err);
+      res.status(500).json({ error: "Failed to compute metrics" });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import bcrypt from "bcryptjs";
 import prisma from "../utils/prisma";
 import { authLimiter } from "../utils/security";
 import { logAudit } from "../utils/audit";
+import { trackServer } from "../services/analytics";
 import { generateToken } from "../utils/token";
 import { nameSchema, safeString, emailSchema } from "../validation/schemas";
 import { sendPasswordResetEmail } from "../utils/mail";
@@ -83,6 +84,11 @@ router.post(
         role: user.role,
       });
 
+      trackServer(user.id, "account_registered", {
+        role: "student",
+        signup_method: "email",
+      });
+
       const token = generateToken(user);
       const { password, ...userWithoutPassword } = user;
 
@@ -134,6 +140,11 @@ router.post(
       await logAudit("USER_SIGNUP", user.id, {
         email: user.email,
         role: user.role,
+      });
+
+      trackServer(user.id, "account_registered", {
+        role: "teacher",
+        signup_method: "email",
       });
 
       const token = generateToken(user);
@@ -205,6 +216,8 @@ router.post("/login", authLimiter, async (req: Request, res: Response) => {
 
     // 🛡️ Sentinel: Audit Log
     await logAudit("USER_LOGIN", user.id, { email: user.email, ip: req.ip });
+
+    trackServer(user.id, "login", { role: user.role });
 
     const token = generateToken(user);
     const { password, ...userWithoutPassword } = user;
@@ -310,6 +323,11 @@ router.post("/auth/register-pathways", async (req: Request, res: Response) => {
     });
 
     await logAudit("PATHWAYS_REGISTER", user.id, { email, cohortId: cohort.id });
+
+    trackServer(user.id, "account_registered", {
+      role: "student",
+      signup_method: "cohort_code",
+    });
 
     const token = generateToken(user);
     const { password, ...userWithoutPassword } = user;

--- a/backend/src/routes/courses.ts
+++ b/backend/src/routes/courses.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import bcrypt from "bcryptjs";
 import prisma from "../utils/prisma";
 import { requireAuth, requireRole } from "../utils/auth";
+import { trackServer } from "../services/analytics";
 import { z } from "zod";
 
 const router = Router();
@@ -84,6 +85,11 @@ router.post(
         gradeBand: parsed.data.gradeBand || "k2",
         defaultLanguage: parsed.data.defaultLanguage || "en",
       },
+    });
+
+    trackServer(req.user!.id, "class_created", {
+      class_id: course.id,
+      grade_band: course.gradeBand,
     });
 
     res.status(201).json({
@@ -248,6 +254,11 @@ router.post(
         studentId: req.user!.id,
         courseId: course.id,
       },
+    });
+
+    trackServer(req.user!.id, "student_joined_class", {
+      class_id: course.id,
+      join_method: "class_code",
     });
 
     res.status(201).json({

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -23,6 +23,7 @@ import {
   slugSchema,
 } from "../validation/schemas";
 import { upsertCheckpoint, getAggregatedProgress } from "../services/progress";
+import { trackServer } from "../services/analytics";
 import { GameError } from "../utils/errors";
 
 const router = Router();
@@ -183,6 +184,17 @@ router.post(
         },
       });
     }
+
+    // Server-side mirror of game_completed — fires once per (student, activity)
+    // because we only reach this branch on first-time completion (idempotent
+    // re-completions short-circuit earlier).
+    trackServer(studentId, "game_completed", {
+      module_slug: moduleSlug,
+      activity_id: activityId,
+      game_id: result?.gameKey || activityId,
+      score: result?.score,
+      time_spent_seconds: timeSpentS || 0,
+    });
 
     // 3. Apply Rewards & Check Unlocks
     let avatarAfter: any = avatarBefore;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -28,11 +28,13 @@ import feedbackRouter from "./routes/feedback";
 import benchmarkRouter from "./routes/benchmarks";
 import homeAccessRouter from "./routes/homeAccess";
 import experimentsRouter from "./routes/experiments";
+import adminMetricsRouter from "./routes/adminMetrics";
 // TEMPORARY — remove after Slack webhook verification is confirmed working.
 import slackTestRouter from "./routes/slack-test";
 import { devRoleShim, authenticateToken } from "./utils/auth";
 import { preventHpp, nocache } from "./utils/security";
 import { notifySlack } from "./utils/slack";
+import { shutdownAnalytics } from "./services/analytics";
 
 const app = express();
 
@@ -209,6 +211,7 @@ app.use("/api", feedbackRouter);
 app.use("/api", benchmarkRouter);
 app.use("/api", homeAccessRouter);
 app.use("/api", experimentsRouter);
+app.use("/api", adminMetricsRouter);
 
 app.get("/health", (_req: Request, res: Response) =>
   res.status(200).json({ status: "ok" }),
@@ -266,6 +269,15 @@ process.on("uncaughtException", (err) => {
   console.error("Uncaught Exception:", err);
   process.exit(1);
 });
+
+// Flush queued PostHog events on graceful shutdown so trailing captures land.
+async function gracefulShutdown(signal: string) {
+  console.log(`[server] ${signal} received — flushing analytics`);
+  await shutdownAnalytics();
+  process.exit(0);
+}
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 if (process.env.NODE_ENV !== "test") {

--- a/backend/src/services/analytics.ts
+++ b/backend/src/services/analytics.ts
@@ -1,0 +1,68 @@
+/**
+ * Backend analytics shim — PostHog Node SDK wrapper.
+ *
+ * The server-side mirror of high-value funnel events lives here. The client
+ * may drop events when a tab closes mid-flow; the server is the source of
+ * truth for the scoreboard.
+ *
+ * If POSTHOG_KEY is unset, every call here silently no-ops so dev/test runs
+ * cleanly without a key. Don't crash on a missing key.
+ *
+ * PRIVACY: same rules as src/lib/analytics.ts — distinctId is the DB user id,
+ * properties are IDs and enums only. Never persist email, name, or free-text
+ * content to PostHog.
+ */
+import { PostHog } from "posthog-node";
+
+const POSTHOG_KEY = process.env.POSTHOG_KEY;
+const POSTHOG_HOST = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
+
+let client: PostHog | null = null;
+let warnedMissingKey = false;
+
+export function getAnalyticsClient(): PostHog | null {
+  if (!POSTHOG_KEY) {
+    if (!warnedMissingKey) {
+      console.info(
+        "[analytics] No POSTHOG_KEY set — server-side analytics disabled (fine in local dev)",
+      );
+      warnedMissingKey = true;
+    }
+    return null;
+  }
+  if (!client) {
+    client = new PostHog(POSTHOG_KEY, { host: POSTHOG_HOST });
+  }
+  return client;
+}
+
+/**
+ * Fire-and-forget event capture. Wraps every call in a try/catch so a
+ * misconfigured PostHog never breaks a real request handler.
+ */
+export function trackServer(
+  userId: string,
+  event: string,
+  properties: Record<string, unknown> = {},
+): void {
+  const ph = getAnalyticsClient();
+  if (!ph) return;
+  try {
+    ph.capture({ distinctId: userId, event, properties });
+  } catch (err) {
+    console.warn("[analytics] capture failed:", err);
+  }
+}
+
+/**
+ * Flush queued events. Call on graceful shutdown so trailing captures land
+ * in PostHog before the process exits.
+ */
+export async function shutdownAnalytics(): Promise<void> {
+  if (!client) return;
+  try {
+    await client.shutdown();
+  } catch (err) {
+    console.warn("[analytics] shutdown failed:", err);
+  }
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,160 @@
+# Bright Boost Analytics
+
+Funnel instrumentation, scoreboard, and tooling notes for the K-8 product.
+
+## Tooling
+
+| What | Where | Used for |
+| --- | --- | --- |
+| **PostHog Cloud** | https://us.i.posthog.com | product analytics, funnels, retention cohorts, session replay, feature flags |
+| **Internal scoreboard** | `/admin/metrics` | DB-source-of-truth totals (admin role required) |
+
+PostHog is the exploration tool — slice events by property, build funnels, run experiments. The scoreboard is the trustworthy headline number ("how many teachers signed up?") because it counts from Postgres directly.
+
+## Environment variables
+
+Set in Railway for production; copy to `.env` locally if you want events to flow during dev.
+
+```
+# Frontend (public — safe to ship in the bundle)
+VITE_POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+
+# Backend (same key)
+POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+POSTHOG_HOST=https://us.i.posthog.com
+```
+
+When unset, both shims (`src/lib/analytics.ts` and `backend/src/services/analytics.ts`) silently no-op so local dev runs fine without the key. The first call logs a single info-level message so the absence is obvious.
+
+## Privacy rules (COPPA-conscious)
+
+This is a children's product. **These rules are non-negotiable:**
+
+- `distinct_id` is ALWAYS the DB user id (`User.id`). Never email, name, or any PII.
+- Session recordings mask all input values (`maskAllInputs: true`) and all rendered text (`maskTextSelector: '*'`). Replays show interaction shape, not content.
+- Never track free-text content (homework answers, names typed into fields, messages).
+- Track behavior (counts, timings, IDs, enum values) — not content.
+- When adding a new event, pass IDs and enums, not personal data.
+
+The comment block at the top of `src/lib/analytics.ts` enforces the same rules in-code so interns adding events will see them.
+
+## Event taxonomy
+
+| Event | When | Properties | Surface |
+| --- | --- | --- | --- |
+| `account_registered` | Signup success (email or cohort code) | `role`, `signup_method` | client + server |
+| `login` | Auth success (any method) | `role` | client + server |
+| `class_created` | Teacher creates a class | `class_id`, `grade_band` | client + server |
+| `student_joined_class` | Student joins via class code | `class_id`, `join_method` | client + server |
+| `game_started` | Activity/game opens | `game_id`, `module_slug`, `activity_id`, `grade_band` | client only |
+| `game_completed` | Activity/game finishes (first time per student) | `game_id`, `module_slug`, `activity_id`, `score`, `time_spent_seconds`, `grade_band` | client + server |
+
+`grade_band` values: `k2`, `g3_5`, `g6_8` (whatever the student's class is set to).
+
+### Client-only vs. client+server
+
+Game start is **client-only** by design — it fires when the activity component mounts, which is too early to bother the server with a dedicated event (we don't have an "I opened a game" route, only "I completed it"). Funnel analysis still works: PostHog deduplicates per `distinct_id`.
+
+Everything that maps to a database write is mirrored server-side. The server is the source of truth — if the kid closes their tab right before the network request completes, the server-side capture still goes out (it runs in the same request handler that wrote to Postgres).
+
+## The scoreboard
+
+Endpoint: `GET /api/admin/metrics` — requires `admin` role.
+
+Returns:
+
+```ts
+{
+  asOf: string;                            // ISO timestamp
+  totalAccounts: number;                   // K-8 only (userType === 'k8')
+  accountsByRole: { teacher: number; student: number };
+  totalClasses: number;
+  avgStudentsPerClass: number;             // 1 decimal
+  gamesStarted: number;                    // Progress rows
+  gamesCompleted: number;                  // Progress rows with status COMPLETED
+  completionRate: number;                  // % with 1 decimal
+  signupsLast7Days: number;
+  signupsLast30Days: number;
+  activeUsersLast7Days: number;            // Distinct students with any Progress.updatedAt in window
+}
+```
+
+The page lives at `/admin/metrics`. It's intentionally plain — function over form, no decorative chrome. It links out to PostHog for funnel exploration.
+
+### Why some metrics live in PostHog instead
+
+| Metric | Where | Why |
+| --- | --- | --- |
+| Signup → first game rate | PostHog funnel | needs sequential event ordering per user |
+| Teacher → class created rate | PostHog funnel | same |
+| Week-2 retention | PostHog cohort | retention math is what PostHog is built for |
+| Most-played games | PostHog breakdown | `game_started` × `game_id` is a one-click chart in PostHog |
+| Headline totals | scoreboard | DB is authoritative for "how many *exist*" |
+
+## PostHog UI setup (manual)
+
+These steps happen in the PostHog dashboard, not in code. Do them once per environment.
+
+1. **Create insights**:
+   - Funnel: `account_registered` → `game_started` (conversion %). Break down by `role`.
+   - Funnel (teachers): `account_registered` (`role=teacher`) → `class_created` → `student_joined_class`.
+   - Trend: `game_started` count by `game_id` (most-played).
+   - Trend: completion rate = `game_completed` / `game_started`.
+2. **Retention cohort**: weekly retention on `login`.
+3. **Dashboard**: pin all of the above on a single "K-8 Funnel" dashboard so reviewers see them at a glance.
+4. **Session replay**: keep on. Confirm the masking config in `src/lib/analytics.ts` is taking effect by skimming a recording — all text and inputs should be solid blocks.
+
+## Adding a new event
+
+1. Pick the moment. Fire at the *exact* moment of the action — don't fire on render.
+2. Add the event to the `AnalyticsEvent` discriminated union in `src/lib/analytics.ts` so the compiler catches typos.
+3. Call `track({ kind: "your_event", ...props })`.
+4. If it's scoreboard-critical (i.e. corresponds to a DB write that drives a funnel KPI), also call `trackServer(userId, "your_event", { ... })` in the route handler.
+5. Update the **Event taxonomy** table above.
+6. Pass only IDs, enums, counts, timings. **Never** email, name, or free-text content.
+
+## Verifying locally
+
+```bash
+# Without a key — should print a single info message, no errors
+unset VITE_POSTHOG_KEY POSTHOG_KEY
+npm run dev
+
+# With a key — events should appear in PostHog Live Events within seconds
+echo 'VITE_POSTHOG_KEY=phc_xxx' >> .env.local
+npm run dev
+# Register a test account, start a game, watch PostHog
+```
+
+## Baseline
+
+Capture the headline numbers the day analytics go live. Future progress is measured against this row.
+
+> **Baseline (TODO once deployed)**: pull `/api/admin/metrics` on the day this PR lands. Write the row here.
+
+```
+Date:              YYYY-MM-DD
+totalAccounts:
+teachers / students:
+totalClasses:
+gamesStarted:
+gamesCompleted:
+completionRate:
+```
+
+## Where the code lives
+
+| Concern | File |
+| --- | --- |
+| Frontend shim (init, identify, track, reset) | `src/lib/analytics.ts` |
+| Frontend init call | `src/main.tsx` |
+| Login + logout identification | `src/contexts/AuthContext.tsx` |
+| Signup events | `src/pages/TeacherSignup.tsx`, `src/pages/StudentSignup.tsx`, `src/pages/LoginSelection.tsx` |
+| Class lifecycle | `src/pages/TeacherClasses.tsx`, `src/pages/JoinClass.tsx` |
+| Game lifecycle | `src/pages/ActivityPlayer.tsx` |
+| Backend shim | `backend/src/services/analytics.ts` |
+| Server-side mirror calls | `backend/src/routes/auth.ts`, `backend/src/routes/courses.ts`, `backend/src/routes/progress.ts` |
+| Scoreboard endpoint | `backend/src/routes/adminMetrics.ts` |
+| Scoreboard page | `src/pages/AdminMetrics.tsx` (route in `src/App.tsx`) |
+| Graceful shutdown flush | `backend/src/server.ts` (`SIGTERM`/`SIGINT`) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "lovable-tagger": "^1.1.7",
         "lucide-react": "^0.525.0",
         "next-themes": "^0.4.6",
+        "posthog-js": "^1.379.3",
         "react": "^18.3.1",
         "react-day-picker": "^9.7.0",
         "react-dom": "^18.3.1",
@@ -2912,6 +2913,21 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.30.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.30.6.tgz",
+      "integrity": "sha512-9X9IUm4Iw9M+nxWOou8LdsvUCyAhDNwzYchMZOcOUVu+CY2oq19GJHC7fZ7UERoUppKVbgWQD51NlfFMHkjGKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.379.3"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.379.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.379.3.tgz",
+      "integrity": "sha512-xx5GLkb/S/eSSQ0H0hnkn1BT7ZG1ZVetQ8/G/h8B5XyOM5prR96a/bgkcIbnK25GFSYyIMNx0X3syvBCYorkUA==",
       "license": "MIT"
     },
     "node_modules/@prisma/client": {
@@ -6524,6 +6540,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -8781,6 +8804,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -9421,6 +9455,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-prop": {
@@ -10725,6 +10768,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -14571,6 +14620,32 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.379.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.379.3.tgz",
+      "integrity": "sha512-Ej0Z6ZdaG8c0NoHtY0k1xiV/ws2WooX44Yr1GcuPU82uee+r6EuWf6fBsp9EDc5F/6MHe0RRpZG0YbLqM3TLTg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "1.30.6",
+        "@posthog/types": "1.379.3",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -14766,6 +14841,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -18244,6 +18325,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lovable-tagger": "^1.1.7",
     "lucide-react": "^0.525.0",
     "next-themes": "^0.4.6",
+    "posthog-js": "^1.379.3",
     "react": "^18.3.1",
     "react-day-picker": "^9.7.0",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import ForReviewers from "./pages/ForReviewers";
 import StudentBenchmark from "./pages/StudentBenchmark";
 import StudentSettings from "./pages/StudentSettings";
 import ExperimentDashboard from "./components/admin/ExperimentDashboard";
+import AdminMetrics from "./pages/AdminMetrics";
 
 // Pathways (secondary-age program layer)
 import PathwaysLayout from "./components/pathways/PathwaysLayout";
@@ -182,6 +183,16 @@ function App() {
                 element={
                   <ProtectedRoute requiredRole="teacher">
                     <ExperimentDashboard />
+                  </ProtectedRoute>
+                }
+              />
+
+              {/* Admin: K-8 scoreboard — admin role only */}
+              <Route
+                path="/admin/metrics"
+                element={
+                  <ProtectedRoute requiredRole="admin">
+                    <AdminMetrics />
                   </ProtectedRoute>
                 }
               />

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,12 @@ import React, {
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { join } from "../services/api";
+import {
+  identifyUser,
+  resetAnalytics,
+  track,
+  type AnalyticsRole,
+} from "../lib/analytics";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? "/api";
 
@@ -40,6 +46,16 @@ interface AuthContextType {
 export const AuthContext = createContext<AuthContextType | undefined>(
   undefined,
 );
+
+function normalizeAnalyticsRole(role: string): AnalyticsRole {
+  const r = role.toLowerCase();
+  if (r === "teacher") return "teacher";
+  if (r === "student") return "student";
+  if (r === "parent") return "parent";
+  if (r === "admin") return "admin";
+  // Default conservatively rather than leaking an unknown role label.
+  return "student";
+}
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -92,6 +108,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     if (token) localStorage.setItem("bb_access_token", token);
     localStorage.setItem("user", JSON.stringify(userData));
 
+    // Analytics: identify + fire `login` for every successful auth (signup
+    // pages also call this; they additionally fire `account_registered`).
+    const role = normalizeAnalyticsRole(userData.role);
+    identifyUser(userData.id, role);
+    track({ kind: "login", role });
+
     setToken(token || null);
     setUser(userData);
     setNextPath(next);
@@ -120,6 +142,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     localStorage.removeItem("user");
     setToken(null);
     setUser(null);
+    resetAnalytics();
     navigate("/");
   }, [navigate]);
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,35 @@
+/**
+ * Frontend analytics shim — backed by PostHog when VITE_POSTHOG_KEY is set,
+ * otherwise a silent no-op so local dev runs cleanly without a key.
+ *
+ * ANALYTICS PRIVACY RULES (K-8 product — COPPA-conscious)
+ * - distinct_id is ALWAYS the database user ID, never email/name/PII
+ * - Session recordings mask all inputs and text
+ * - Never track free-text content (homework, names, messages)
+ * - Track behavior (events, counts, timings), not content
+ * - When adding events, pass IDs and enums, not personal data
+ *
+ * Two call styles coexist:
+ *   - track({ kind: "homepage_viewed" })            // typed discriminated union
+ *   - trackEvent("custom_funnel_event", { ... })   // free-form (rare; prefer typed)
+ *
+ * The typed API is preferred for everything that the funnel cares about so
+ * the compiler catches typos in event names.
+ */
+import posthog from "posthog-js";
+
+const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
+const POSTHOG_HOST =
+  (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ||
+  "https://us.i.posthog.com";
+
+export type AnalyticsRole = "teacher" | "student" | "parent" | "admin";
+export type GradeBand = "k2" | "g3_5" | "g6_8";
+export type SignupMethod = "email" | "class_code" | "cohort_code";
+export type JoinMethod = "class_code" | "cohort_code";
+
 export type AnalyticsEvent =
+  // Legacy homepage / marketing events (pre-existing, no-op before PostHog)
   | { kind: "quest_start"; questId: string }
   | { kind: "quest_complete"; questId: string; attempts: number }
   | { kind: "quiz_answer"; questionId: string; isCorrect: boolean }
@@ -11,6 +42,104 @@ export type AnalyticsEvent =
   | { kind: "parent_page_clicked" }
   | { kind: "organization_page_clicked" }
   | { kind: "free_plan_clicked"; plan: string }
-  | { kind: "feedback_submitted"; audience: "teacher" | "student" | "parent" | "org" };
+  | { kind: "feedback_submitted"; audience: "teacher" | "student" | "parent" | "org" }
+  // Funnel events (see docs/analytics.md)
+  | { kind: "account_registered"; role: AnalyticsRole; signup_method: SignupMethod }
+  | { kind: "login"; role: AnalyticsRole }
+  | { kind: "class_created"; class_id: string; grade_band?: string }
+  | {
+      kind: "student_joined_class";
+      class_id: string;
+      join_method: JoinMethod;
+    }
+  | {
+      kind: "game_started";
+      game_id: string;
+      module_slug?: string;
+      activity_id?: string;
+      grade_band?: string;
+    }
+  | {
+      kind: "game_completed";
+      game_id: string;
+      module_slug?: string;
+      activity_id?: string;
+      score?: number;
+      time_spent_seconds?: number;
+      quiz_score?: number;
+      grade_band?: string;
+    };
 
-export function track(_event: AnalyticsEvent): void {}
+let initialized = false;
+
+function disabled(): boolean {
+  return !POSTHOG_KEY || !initialized;
+}
+
+export function initAnalytics(): void {
+  if (initialized) return;
+  if (!POSTHOG_KEY) {
+    // Single info-level message so the absence is obvious in local dev.
+    console.info(
+      "[analytics] No PostHog key set — analytics disabled (this is fine in local dev)",
+    );
+    return;
+  }
+
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    // We track explicit funnel events ourselves, not every DOM interaction.
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+    // Session replay is on, but the masking config below keeps it safe for
+    // a children's product — no input values, no rendered text.
+    disable_session_recording: false,
+    session_recording: {
+      maskAllInputs: true,
+      maskTextSelector: "*",
+    },
+    persistence: "localStorage",
+    loaded: () => {
+      initialized = true;
+    },
+  });
+}
+
+/** Bind subsequent events to a real user. Use the DB user id, never email. */
+export function identifyUser(
+  userId: string,
+  role: AnalyticsRole,
+  props: Record<string, unknown> = {},
+): void {
+  if (disabled()) return;
+  posthog.identify(userId, { role, ...props });
+}
+
+/** Clear the identified user on logout. */
+export function resetAnalytics(): void {
+  if (disabled()) return;
+  posthog.reset();
+}
+
+/**
+ * Track a typed analytics event. Use this for everything the funnel needs
+ * to count — the discriminated union forces consistent event naming.
+ */
+export function track(event: AnalyticsEvent): void {
+  if (disabled()) return;
+  const { kind, ...props } = event;
+  posthog.capture(kind, props);
+}
+
+/**
+ * Free-form event escape hatch. Prefer `track()` with a typed event. Use
+ * this only for one-offs that don't deserve their own union member.
+ */
+export function trackEvent(
+  event: string,
+  props: Record<string, unknown> = {},
+): void {
+  if (disabled()) return;
+  posthog.capture(event, props);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { initAnalytics } from "./lib/analytics";
+
+initAnalytics();
 
 const renderApp = () => {
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/ActivityPlayer.tsx
+++ b/src/pages/ActivityPlayer.tsx
@@ -27,6 +27,7 @@ import {
   resolveText,
   resolveChoiceList,
 } from "@/utils/localizedContent";
+import { track } from "@/lib/analytics";
 import ActivityHeader from "@/components/activities/ActivityHeader";
 import { ACTIVITY_VISUAL_TOKENS } from "@/theme/activityVisualTokens";
 import { ImageKey } from "@/theme/activityIllustrations";
@@ -179,6 +180,13 @@ export default function ActivityPlayer() {
         setActivity(found);
         const parsed = safeJsonParse(found.content || "");
         setContent(parsed);
+        track({
+          kind: "game_started",
+          game_id: parsed?.gameKey || String(found.id),
+          module_slug: String(slug),
+          activity_id: String(found.id),
+          grade_band: gradeBand,
+        });
         // reset INFO local state
         setSlideIndex(0);
         setMode("story");
@@ -217,13 +225,23 @@ export default function ActivityPlayer() {
     roundsCompleted?: number;
   }) => {
     if (!slug || !lessonId || !activityId) return;
+    const timeSpentS = getTimeSpentS();
     try {
       const res = await api.completeActivity({
         moduleSlug: slug,
         lessonId: String(lessonId),
         activityId: String(activityId),
-        timeSpentS: getTimeSpentS(),
+        timeSpentS,
         result,
+      });
+      track({
+        kind: "game_completed",
+        game_id: result?.gameKey || content?.gameKey || String(activityId),
+        module_slug: String(slug),
+        activity_id: String(activityId),
+        score: result?.score,
+        time_spent_seconds: timeSpentS,
+        grade_band: gradeBand,
       });
       setCompletionData(res);
       toast({

--- a/src/pages/AdminMetrics.tsx
+++ b/src/pages/AdminMetrics.tsx
@@ -1,0 +1,223 @@
+/**
+ * Admin scoreboard — /admin/metrics
+ *
+ * Internal-only view of the headline K-8 funnel numbers. The team reviews
+ * these every Friday. Function over form: big numbers, no decorative chrome.
+ *
+ * Backed by GET /api/admin/metrics (DB-side source of truth). Funnel rates
+ * and retention live in PostHog — this page links out for those.
+ *
+ * Auth: admin role enforced by ProtectedRoute + backend requireRole("admin").
+ */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useApi } from "@/services/api";
+
+interface MetricsResponse {
+  asOf: string;
+  totalAccounts: number;
+  accountsByRole: { teacher: number; student: number };
+  totalClasses: number;
+  avgStudentsPerClass: number;
+  gamesStarted: number;
+  gamesCompleted: number;
+  completionRate: number;
+  signupsLast7Days: number;
+  signupsLast30Days: number;
+  activeUsersLast7Days: number;
+}
+
+interface KpiCard {
+  label: string;
+  value: string | number;
+  target?: string;
+  hint?: string;
+}
+
+function formatNumber(n: number): string {
+  return new Intl.NumberFormat("en-US").format(n);
+}
+
+export default function AdminMetrics() {
+  const api = useApi();
+  const [data, setData] = useState<MetricsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = (await api.get("/admin/metrics")) as MetricsResponse;
+      setData(res);
+    } catch (err: any) {
+      setError(err?.message || "Failed to load metrics");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (loading && !data) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center text-slate-500">
+        Loading scoreboard…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-slate-50 p-8">
+        <div className="max-w-2xl mx-auto rounded-lg border border-red-200 bg-red-50 p-6">
+          <h1 className="text-lg font-bold text-red-800">
+            Couldn't load metrics
+          </h1>
+          <p className="text-sm text-red-700 mt-1">{error}</p>
+          <button
+            onClick={load}
+            className="mt-3 inline-flex items-center gap-1.5 px-3 py-2 rounded bg-red-600 text-white text-sm font-semibold hover:bg-red-700"
+          >
+            <RefreshCw className="w-3.5 h-3.5" /> Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const cards: KpiCard[] = [
+    {
+      label: "Total accounts",
+      value: formatNumber(data.totalAccounts),
+      target: "Goal: 1,000",
+      hint: `${data.accountsByRole.teacher} teachers · ${data.accountsByRole.student} students`,
+    },
+    {
+      label: "Signups (last 7 days)",
+      value: formatNumber(data.signupsLast7Days),
+      hint: `${data.signupsLast30Days} in the last 30 days`,
+    },
+    {
+      label: "Active users (last 7d)",
+      value: formatNumber(data.activeUsersLast7Days),
+      hint: "Distinct students with progress activity",
+    },
+    {
+      label: "Classes created",
+      value: formatNumber(data.totalClasses),
+      hint: `Avg ${data.avgStudentsPerClass} students/class · target 15+`,
+    },
+    {
+      label: "Games started",
+      value: formatNumber(data.gamesStarted),
+    },
+    {
+      label: "Games completed",
+      value: formatNumber(data.gamesCompleted),
+      hint: `Completion rate ${data.completionRate}% · target >50%`,
+    },
+  ];
+
+  const asOf = new Date(data.asOf);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+        <header className="flex flex-wrap items-baseline justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">
+              Scoreboard — K-8 Funnel
+            </h1>
+            <p className="text-xs text-slate-500 mt-1">
+              DB source of truth · as of {asOf.toLocaleString()}
+            </p>
+          </div>
+          <button
+            onClick={load}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-slate-300 bg-white hover:bg-slate-100 text-sm text-slate-700"
+          >
+            <RefreshCw className="w-3.5 h-3.5" /> Refresh
+          </button>
+        </header>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {cards.map((c) => (
+            <div
+              key={c.label}
+              className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
+            >
+              <p className="text-xs uppercase tracking-wider text-slate-500 font-semibold">
+                {c.label}
+              </p>
+              <p className="text-3xl font-bold text-slate-900 font-mono mt-2">
+                {c.value}
+              </p>
+              {c.target && (
+                <p className="text-xs text-slate-500 mt-1">{c.target}</p>
+              )}
+              {c.hint && (
+                <p className="text-xs text-slate-600 mt-1">{c.hint}</p>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-5">
+          <h2 className="text-sm font-semibold text-slate-900 mb-2">
+            Look in PostHog for
+          </h2>
+          <p className="text-xs text-slate-500 mb-3">
+            Funnels, retention, and per-cohort breakdowns live in PostHog —
+            this page intentionally shows DB totals only. See{" "}
+            <Link to="/admin/experiments" className="text-blue-700 underline">
+              /admin/experiments
+            </Link>{" "}
+            for active A/B tests.
+          </p>
+          <ul className="space-y-2 text-sm text-slate-700">
+            <li className="flex items-baseline gap-2">
+              <ExternalLink className="w-3.5 h-3.5 mt-0.5 text-slate-400 shrink-0" />
+              <span>
+                <strong>Signup → first game</strong>: funnel from
+                {" "}<code>account_registered</code> → <code>game_started</code> (target &gt;70%).
+              </span>
+            </li>
+            <li className="flex items-baseline gap-2">
+              <ExternalLink className="w-3.5 h-3.5 mt-0.5 text-slate-400 shrink-0" />
+              <span>
+                <strong>Teacher → class created → first student</strong>:
+                funnel from <code>account_registered</code> (role=teacher) →
+                {" "}<code>class_created</code> → <code>student_joined_class</code>.
+              </span>
+            </li>
+            <li className="flex items-baseline gap-2">
+              <ExternalLink className="w-3.5 h-3.5 mt-0.5 text-slate-400 shrink-0" />
+              <span>
+                <strong>Week-2 retention</strong>: weekly retention cohort on
+                {" "}<code>login</code> (target &gt;40%).
+              </span>
+            </li>
+            <li className="flex items-baseline gap-2">
+              <ExternalLink className="w-3.5 h-3.5 mt-0.5 text-slate-400 shrink-0" />
+              <span>
+                <strong>Most-played games</strong>:{" "}
+                <code>game_started</code> broken down by <code>game_id</code>.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        <p className="text-xs text-slate-400">
+          Adding new metrics? See <code>docs/analytics.md</code>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/JoinClass.tsx
+++ b/src/pages/JoinClass.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useApi } from "../services/api";
 import { Users, ArrowRight } from "lucide-react";
 import PulseSurveyDialog from "@/components/student/PulseSurveyDialog";
+import { track } from "../lib/analytics";
 
 const JoinClass: React.FC = () => {
   const { t } = useTranslation();
@@ -27,6 +28,11 @@ const JoinClass: React.FC = () => {
     try {
       const result = await api.post("/student/join-course", {
         joinCode: joinCode.trim().toUpperCase(),
+      });
+      track({
+        kind: "student_joined_class",
+        class_id: result.courseId as string,
+        join_method: "class_code",
       });
       setSuccess(t("joinClass.success", { name: result.courseName }));
       setJoinedCourseId(result.courseId as string);

--- a/src/pages/LoginSelection.tsx
+++ b/src/pages/LoginSelection.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { Mail, KeyRound, Loader2, UserPlus } from "lucide-react";
 import LoginCard, { LoginInput, LoginButton, LoginSection, LoginDivider } from "@/components/auth/LoginCard";
+import { track } from "@/lib/analytics";
 
 const API = "/api";
 
@@ -119,6 +120,13 @@ const LoginSelection: React.FC = () => {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Registration failed");
+      // Pathways students sign up via a cohort code, not email; the role is
+      // always 'student' for this flow.
+      track({
+        kind: "account_registered",
+        role: "student",
+        signup_method: "cohort_code",
+      });
       login(data.token, data.user, "/pathways");
     } catch (err: any) {
       setRegError(err.message || "Registration failed");

--- a/src/pages/StudentSignup.tsx
+++ b/src/pages/StudentSignup.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Check, Circle } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { signupStudent } from "../services/api";
+import { track } from "../lib/analytics";
 import GameBackground from "../components/GameBackground";
 import BrightBoostRobot from "../components/BrightBoostRobot";
 import LanguageToggle from "../components/LanguageToggle";
@@ -49,6 +50,11 @@ const StudentSignup: React.FC = () => {
 
       // Auto login after successful signup
       if (response && response.token) {
+        track({
+          kind: "account_registered",
+          role: "student",
+          signup_method: "email",
+        });
         login(response.token, response.user);
       } else {
         console.error("Invalid response format:", response);

--- a/src/pages/TeacherClasses.tsx
+++ b/src/pages/TeacherClasses.tsx
@@ -4,6 +4,7 @@ import BrightBoostRobot from "../components/BrightBoostRobot";
 import { Plus, Users, Copy, Check, Zap, Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useApi, ApiError } from "../services/api";
+import { track } from "../lib/analytics";
 import {
   Dialog,
   DialogContent,
@@ -66,6 +67,11 @@ const ClassesPage: React.FC = () => {
     try {
       const course = await api.post("/teacher/courses", {
         name: newName.trim(),
+      });
+      track({
+        kind: "class_created",
+        class_id: course.id,
+        grade_band: course.gradeBand,
       });
       setCourses((prev) => [course, ...prev]);
       setNewName("");

--- a/src/pages/TeacherSignup.tsx
+++ b/src/pages/TeacherSignup.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { signupTeacher } from "../services/api";
+import { track } from "../lib/analytics";
 import GameBackground from "../components/GameBackground";
 import BrightBoostRobot from "../components/BrightBoostRobot";
 import LanguageToggle from "../components/LanguageToggle";
@@ -38,6 +39,11 @@ const TeacherSignup: React.FC = () => {
 
       // Auto login after successful signup
       if (response && response.token) {
+        track({
+          kind: "account_registered",
+          role: "teacher",
+          signup_method: "email",
+        });
         login(response.token, response.user);
       } else {
         console.error("Invalid response format:", response);


### PR DESCRIPTION
## Summary

Pre-intern infrastructure PR. When summer interns arrive June 15, the funnel data is already flowing — they can make data-driven decisions from day one instead of writing instrumentation from scratch.

- **PostHog integration** (frontend + backend) with COPPA-conscious privacy defaults — distinct_id is the DB user id, session recordings mask all inputs and text, no free-text content tracked anywhere. Silent no-op when keys are unset so local dev runs cleanly.
- **6 funnel events** instrumented client-side, 5 of them mirrored server-side as the source of truth: `account_registered`, `login`, `class_created`, `student_joined_class`, `game_started` (client only), `game_completed`.
- **Admin scoreboard** at `/admin/metrics` (admin role) — DB-source-of-truth headline numbers: accounts, classes, games started/completed, 7/30-day signups, 7-day active users. Funnel rates and retention intentionally live in PostHog (which is built for that math); the page links out for those.
- **`docs/analytics.md`** documents the runtime, env vars, privacy rules, complete event taxonomy, the client-vs-server tracking rationale, the manual PostHog UI insights to create, a baseline-capture template, and a code-location index. Written so an intern can extend the taxonomy without losing the rails.

## Events instrumented

| Event | Where (client) | Where (server) |
| --- | --- | --- |
| `account_registered` | TeacherSignup, StudentSignup, LoginSelection.handlePathwaysRegister | auth.ts × 3 signup routes |
| `login` | AuthContext.login (covers every auth path) | auth.ts POST /login |
| `class_created` | TeacherClasses.handleCreate | courses.ts POST /teacher/courses |
| `student_joined_class` | JoinClass.handleJoin | courses.ts POST /student/join-course |
| `game_started` | ActivityPlayer (activity load) | — |
| `game_completed` | ActivityPlayer.handleComplete | progress.ts POST /progress/complete-activity (first-time only — idempotent re-completions short-circuit) |

All client events go through the typed `track({ kind: ... })` API in `src/lib/analytics.ts` — the discriminated union catches event-name typos at compile time. Server mirrors use the simpler `trackServer(userId, event, props)` call from `backend/src/services/analytics.ts`.

## Privacy posture (COPPA-conscious — children's product)

- `distinct_id` is ALWAYS the DB user id, never email/name/PII
- Session recordings: `maskAllInputs: true`, `maskTextSelector: "*"` (solid blocks)
- Properties pass IDs and enums only — never free-text content
- Header comments in both `src/lib/analytics.ts` and `backend/src/services/analytics.ts` enforce these rules for future contributors

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean for new code (pre-existing `ControlInstructions` casing collision in git index is unrelated; was already failing on main)
- [x] `cd backend && npx tsc --noEmit` — clean
- [x] Without `VITE_POSTHOG_KEY` / `POSTHOG_KEY` set: app/server run, single info log, every track call silently no-ops
- [ ] With keys set in `.env.local`: register a test account → events visible in PostHog Live Events within seconds
- [ ] As admin, navigate to `/admin/metrics` — cards render with current DB totals
- [ ] As non-admin, `/admin/metrics` redirects (ProtectedRoute) and `/api/admin/metrics` returns 403

## Manual PostHog UI setup (post-merge, documented in `docs/analytics.md`)

1. Create funnels: signup → first game; teacher → class_created → first student_joined_class
2. Create completion-rate trend: `game_completed / game_started`
3. Create weekly retention cohort on `login`
4. Pin all four onto a "K-8 Funnel" dashboard
5. Skim a session replay to confirm masking is taking effect

## Required for prod events to flow

Set in Railway (both services):

```
VITE_POSTHOG_KEY=phc_...
VITE_POSTHOG_HOST=https://us.i.posthog.com
POSTHOG_KEY=phc_...
POSTHOG_HOST=https://us.i.posthog.com
```

App works fine without them — no crashes, just no analytics.

## Baseline capture

Run `GET /api/admin/metrics` (or the snippet in `docs/analytics.md` Section "Baseline") the day this merges and write the row into the doc. That's the starting line interns measure against.

## Stats

23 files, +1005 / -3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)