### PR TITLE
feat: add registration entry points — unblock the top of the funnel

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -68,7 +68,8 @@ export type AnalyticsEvent =
       time_spent_seconds?: number;
       quiz_score?: number;
       grade_band?: string;
-    };
+    }
+  | { kind: "signup_role_selected"; role: "teacher" | "student" };
 
 let initialized = false;
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -346,7 +346,11 @@
     "selectHowToLogin": "Select how you'd like to login",
     "teacherLogin": "Teacher Login",
     "studentLogin": "Student Login",
-    "backToHome": "Back to Home"
+    "backToHome": "Back to Home",
+    "noAccount": "Don't have an account?",
+    "createAccount": "Create an account",
+    "signUpFree": "Sign up free",
+    "signupCtaSubtitle": "It's free \u2014 get started in under a minute."
   },
   "tutorial": {
     "welcome": "Welcome to BrightBoost!",
@@ -1677,5 +1681,21 @@
       "prompt3": "What STEM module unlocked that boost?",
       "prompt4": "What will you complete next to help your team?"
     }
+  },
+  "signupSelection": {
+    "title": "Create your account",
+    "subtitle": "Pick what fits you best.",
+    "teacherCard": {
+      "heading": "I'm a Teacher",
+      "blurb": "Bring K-8 STEM learning into your classroom.",
+      "cta": "Sign up as a Teacher"
+    },
+    "studentCard": {
+      "heading": "I'm a Student",
+      "blurb": "Play STEM missions and track your progress.",
+      "cta": "Sign up as a Student"
+    },
+    "haveAccount": "Already have an account?",
+    "logIn": "Log in"
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -178,6 +178,16 @@ const Index: React.FC = () => {
                   </Link>
                 </div>
 
+                <p className="mt-3 text-sm text-brightboost-navy">
+                  New to Bright Boost?{" "}
+                  <Link
+                    to="/signup"
+                    className="font-bold text-brightboost-blue underline underline-offset-2 hover:text-brightboost-blue/80"
+                  >
+                    Sign up free →
+                  </Link>
+                </p>
+
                 <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-sm">
                   {secondaryLinks.map((item) => (
                     <Link

--- a/src/pages/LoginSelection.tsx
+++ b/src/pages/LoginSelection.tsx
@@ -296,6 +296,24 @@ const LoginSelection: React.FC = () => {
         </form>
       </LoginSection>
 
+      {/* New users — make the signup path obvious */}
+      <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-center">
+        <p className="text-sm text-slate-700">
+          {t("auth.noAccount", { defaultValue: "Don't have an account?" })}
+        </p>
+        <Link
+          to="/signup"
+          className="mt-2 inline-flex items-center justify-center w-full px-4 py-3 min-h-[44px] rounded-lg bg-white border-2 border-indigo-500 text-indigo-700 font-semibold text-sm hover:bg-indigo-100 active:scale-[0.99] transition-all"
+        >
+          {t("auth.signUpFree", { defaultValue: "Sign up free" })}
+        </Link>
+        <p className="text-xs text-slate-500 mt-2">
+          {t("auth.signupCtaSubtitle", {
+            defaultValue: "It's free — get started in under a minute.",
+          })}
+        </p>
+      </div>
+
       <div className="text-center space-y-2">
         <p className="text-xs text-slate-400">
           {t("auth.teacherNote", { defaultValue: "Teacher?" })} <Link to="/teacher-login" className="text-indigo-600 hover:underline">Log in here</Link>

--- a/src/pages/SignupSelection.tsx
+++ b/src/pages/SignupSelection.tsx
@@ -1,51 +1,103 @@
+/**
+ * SignupSelection — role chooser for new users.
+ *
+ * Two distinct K-8 signup paths:
+ *   - Teacher → /teacher/signup (email + password, then create class)
+ *   - Student → /student/signup (email + password — students who only have a
+ *     class code use /class-login instead, no signup needed for them)
+ *
+ * Uses LoginCard for visual consistency with the rest of the auth flow.
+ * Fires `signup_role_selected` so the funnel shows where new users branch.
+ */
 import React from "react";
 import { Link } from "react-router-dom";
-import GameBackground from "../components/GameBackground";
-import LanguageToggle from "../components/LanguageToggle";
+import { useTranslation } from "react-i18next";
+import LoginCard from "@/components/auth/LoginCard";
+import { track } from "@/lib/analytics";
+
+interface RoleOption {
+  role: "teacher" | "student";
+  to: string;
+  emoji: string;
+  headingKey: string;
+  blurbKey: string;
+  ctaKey: string;
+  accent: string;
+}
+
+const OPTIONS: RoleOption[] = [
+  {
+    role: "teacher",
+    to: "/teacher/signup",
+    emoji: "👩‍🏫",
+    headingKey: "signupSelection.teacherCard.heading",
+    blurbKey: "signupSelection.teacherCard.blurb",
+    ctaKey: "signupSelection.teacherCard.cta",
+    accent: "from-sky-500 to-indigo-600",
+  },
+  {
+    role: "student",
+    to: "/student/signup",
+    emoji: "🎒",
+    headingKey: "signupSelection.studentCard.heading",
+    blurbKey: "signupSelection.studentCard.blurb",
+    ctaKey: "signupSelection.studentCard.cta",
+    accent: "from-purple-500 to-pink-500",
+  },
+];
 
 const SignupSelection: React.FC = () => {
+  const { t } = useTranslation();
+
   return (
-    <GameBackground>
-      <div className="flex flex-col items-center justify-center min-h-screen p-4 relative">
-        <div className="absolute top-4 right-4 z-20">
-          <LanguageToggle />
-        </div>
-        <div className="text-center mb-8">
-          <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-2">
-            Create an Account
-          </h1>
-          <p className="text-lg text-brightboost-navy">
-            Select your account type
-          </p>
-        </div>
-
-        <div className="game-card p-8 w-full max-w-md">
-          <div className="grid grid-cols-1 gap-4">
-            <Link
-              to="/teacher/signup"
-              className="button-shadow rounded-xl px-6 py-4 bg-brightboost-blue text-white font-bold text-center hover:bg-opacity-90 transition-all"
-            >
-              Teacher Signup
-            </Link>
-            <Link
-              to="/student/signup"
-              className="button-shadow rounded-xl px-6 py-4 bg-brightboost-yellow text-brightboost-navy font-bold text-center hover:bg-opacity-90 transition-all"
-            >
-              Student Signup
-            </Link>
-          </div>
-
-          <div className="mt-6 text-center">
-            <Link
-              to="/"
-              className="text-brightboost-blue font-bold hover:underline transition-colors"
-            >
-              Back to Home
-            </Link>
-          </div>
-        </div>
+    <LoginCard
+      icon="✨"
+      title={t("signupSelection.title")}
+      subtitle={t("signupSelection.subtitle")}
+    >
+      <div className="space-y-3">
+        {OPTIONS.map((opt) => (
+          <Link
+            key={opt.role}
+            to={opt.to}
+            onClick={() => track({ kind: "signup_role_selected", role: opt.role })}
+            className="block rounded-2xl border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md hover:border-indigo-300 active:scale-[0.99] transition-all group"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className={`shrink-0 w-12 h-12 rounded-xl bg-gradient-to-br ${opt.accent} flex items-center justify-center text-2xl shadow-sm`}
+                aria-hidden
+              >
+                {opt.emoji}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-base font-bold text-slate-900">
+                  {t(opt.headingKey)}
+                </p>
+                <p className="text-xs text-slate-500 mt-0.5 leading-snug">
+                  {t(opt.blurbKey)}
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-sm font-semibold text-indigo-600 group-hover:text-indigo-700">
+              {t(opt.ctaKey)} →
+            </p>
+          </Link>
+        ))}
       </div>
-    </GameBackground>
+
+      <div className="text-center">
+        <p className="text-sm text-slate-600">
+          {t("signupSelection.haveAccount")}{" "}
+          <Link
+            to="/student-login"
+            className="font-semibold text-indigo-600 hover:underline"
+          >
+            {t("signupSelection.logIn")}
+          </Link>
+        </p>
+      </div>
+    </LoginCard>
   );
 };
 

--- a/src/pages/TeacherLogin.tsx
+++ b/src/pages/TeacherLogin.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "../contexts/AuthContext";
 import { loginUser } from "../services/api";
 import LoginCard, { LoginInput, LoginButton, LoginSection } from "@/components/auth/LoginCard";
 
 const TeacherLogin: React.FC = () => {
+  const { t } = useTranslation();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -51,11 +53,26 @@ const TeacherLogin: React.FC = () => {
         </form>
       </LoginSection>
 
-      <div className="text-center space-y-2">
-        <Link to="/forgot-password" className="block text-sm text-indigo-600 hover:underline">Forgot password?</Link>
-        <p className="text-xs text-slate-400">
-          Don't have an account? <Link to="/teacher/signup" className="text-indigo-600 hover:underline">Sign up</Link>
+      {/* New users — make the signup path obvious */}
+      <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-center">
+        <p className="text-sm text-slate-700">
+          {t("auth.noAccount", { defaultValue: "Don't have an account?" })}
         </p>
+        <Link
+          to="/teacher/signup"
+          className="mt-2 inline-flex items-center justify-center w-full px-4 py-3 min-h-[44px] rounded-lg bg-white border-2 border-indigo-500 text-indigo-700 font-semibold text-sm hover:bg-indigo-100 active:scale-[0.99] transition-all"
+        >
+          {t("auth.signUpFree", { defaultValue: "Sign up free" })}
+        </Link>
+        <p className="text-xs text-slate-500 mt-2">
+          {t("auth.signupCtaSubtitle", {
+            defaultValue: "It's free — get started in under a minute.",
+          })}
+        </p>
+      </div>
+
+      <div className="text-center">
+        <Link to="/forgot-password" className="block text-sm text-indigo-600 hover:underline">Forgot password?</Link>
       </div>
     </LoginCard>
   );


### PR DESCRIPTION
## TL;DR — this unblocks the 1,000-account goal

The funnel was broken at the top: users could reach the login screen but had **no visible way to register**. The signup pages and routes already existed (the analytics PR confirmed they do); nothing linked to them from the login or landing screens. This PR adds those entry points and modernizes the role-selection page.

## Section 1 findings (what was wrong)

| Surface | State on main |
| --- | --- |
| `/` (Index hero) | "I'm a Teacher" / "I'm a Student!" buttons go to **login**, not signup. No separate "Create account" CTA. |
| `/student-login` (LoginSelection — the default for "I'm a Student!") | **Zero** signup links anywhere on the main view. Only email login + class code + "Teacher? Log in here" + Pathways. |
| `/teacher-login` | Has a `text-xs text-slate-400` "Don't have an account? Sign up" footnote — easy to miss. |
| `/login` | Redirects to `/student-login` → same dead end. |
| `/signup` → `SignupSelection` | Functional but dated; not linked from anywhere visible. |
| `/teacher/signup`, `/student/signup` | Work fine — analytics PR (#597) instrumented them already. |

**Routes were all registered.** Pages all existed. The bug was 100% missing entry points.

## What this PR changes

- **`LoginSelection.tsx`** — adds a prominent indigo-bordered "Create an account" CTA box with a full-width button → `/signup`. Visible in the main `/student-login` view (not buried in the Pathways cohort flow).
- **`TeacherLogin.tsx`** — replaces the tiny footnote with the same prominent CTA → `/teacher/signup`.
- **`Index.tsx`** — adds "New to Bright Boost? Sign up free →" right below the existing hero buttons. Keeps the existing buttons going to login (matches returning-user expectation) while giving new users a parallel path.
- **`SignupSelection.tsx`** — full rewrite to use `LoginCard` for visual consistency. Friendlier copy, emoji + gradient role cards, `min-h-[44px]` tap targets, mobile-first, "Already have an account? Log in" return link.
- **`src/lib/analytics.ts`** — new `signup_role_selected` event variant on the typed `AnalyticsEvent` union. Fires on each card click in SignupSelection so the funnel shows where new users branch.
- **`en/common.json`** — 4 new `auth.*` keys + `signupSelection.*` namespace.

## Auth-flow logic untouched

`AuthContext.login()`, JWT handling, password validation, and every backend route are unchanged. Seeded test accounts (`teacher@school.com`, `explorer@test.com`, etc.) log in exactly as before. This PR only adds presentation/markup and one new analytics event variant.

## Locale parity (intentional scope cut)

en gets the full new-key set. es/vi/zh-CN inherit via i18next `fallbackLng: "en"` — the UI works in every language immediately, just in English text where it isn't translated yet.

The es/vi/zh-CN files have a **pre-existing data issue** I discovered while trying to add keys: each contains duplicate top-level namespaces (e.g. `teacher` declared twice in `es/common.json`, lines 382 and 968). `JSON.parse` silently merges those (last-wins), so any round-trip rewrite generates a ~1000-line cosmetic diff. Fixing the duplicates is a separate concern (some could be intentional overrides) — left out of this PR to keep the diff focused on the funnel fix. Flagged here for a follow-up cleanup.

## The new user path

```
/  →  tap "Sign up free →"  OR  visit /signup directly
   →  SignupSelection (role chooser)
      →  "I'm a Teacher"  →  /teacher/signup  →  submit  →  /teacher/dashboard
      →  "I'm a Student"  →  /student/signup  →  submit  →  /student/dashboard

/student-login  OR  /teacher-login
   →  "Sign up free" CTA box  →  /signup or /teacher/signup
```

No more dead-end login walls.

## Friction audit on signup forms

`TeacherSignup` and `StudentSignup` already require only the minimum (name, email, password, confirm password, terms) — nothing extra to cut. Both already link back to their respective logins. Left untouched.

## Analytics

- `signup_role_selected` fires with `role: "teacher" | "student"` on each card tap (typed event, compiler enforces shape)
- `account_registered` continues to fire on successful signup (already instrumented by PR #597)
- The legacy `signup_clicked` event on the Index hero buttons stays — it's the right signal that someone CLICKED a teacher/student identity button, even if those still route to login

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean for new code
- [x] All new components use `min-h-[44px]` tap targets and `w-full` mobile buttons; `max-w-md` containers; mobile-first
- [ ] Manual: land on `/` → spot "Sign up free →" within 2 seconds
- [ ] Manual: `/signup` → click each card → lands on respective form → submit → logged in
- [ ] Manual: `/student-login` and `/teacher-login` → new CTA box is prominent
- [ ] Manual: existing seeded accounts (`teacher@school.com / password123`, `explorer@test.com / explore123`) still log in
- [ ] Manual: mobile viewport (375px) → no horizontal scroll, thumb-friendly

## Why this matters

Everything else in the summer plan — analytics, polish, champion onboarding — assumed users could register. They couldn't (or couldn't easily). This is the unblock-everything fix at the top of the funnel.

## Stats

6 files, +165 / -47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)