### PR TITLE
polish: registration flow — visual consistency, friendly copy, form UX, mobile + a11y

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1696,6 +1696,81 @@
       "cta": "Sign up as a Student"
     },
     "haveAccount": "Already have an account?",
-    "logIn": "Log in"
+    "logIn": "Log in",
+    "classCodeNote": "Have a class code from your teacher?",
+    "classCodeLink": "Join your class"
+  },
+  "teacherSignup": {
+    "pageTitle": "Sign up as a teacher",
+    "heading": "Let's get you set up",
+    "subtitle": "It only takes a minute. You'll be ready to invite your class right after.",
+    "fields": {
+      "name": "Your name",
+      "namePlaceholder": "Ms. Frizzle",
+      "email": "School email",
+      "emailPlaceholder": "you@school.edu",
+      "emailHelp": "We'll send class updates and account notifications here.",
+      "password": "Password",
+      "passwordPlaceholder": "At least 8 characters",
+      "confirmPassword": "Confirm password",
+      "confirmPasswordPlaceholder": "Type your password again"
+    },
+    "errors": {
+      "mismatch": "These don't match \u2014 try retyping.",
+      "emailInvalid": "That doesn't look like a valid email address.",
+      "passwordTooShort": "Use at least 8 characters.",
+      "generic": "We couldn't create your account. Please try again."
+    },
+    "terms": {
+      "prefix": "I agree to the",
+      "tos": "Terms of Service",
+      "and": "and",
+      "privacy": "Privacy Policy"
+    },
+    "submit": "Create my teacher account",
+    "submitting": "Creating your account\u2026",
+    "haveAccount": "Already have an account?",
+    "logIn": "Log in",
+    "trust": "We protect student data carefully. Email is for account-only use."
+  },
+  "studentSignup": {
+    "pageTitle": "Sign up as a student",
+    "heading": "Welcome to Bright Boost!",
+    "subtitle": "Let's set up your account so you can start playing.",
+    "fields": {
+      "name": "What's your name?",
+      "namePlaceholder": "First name is fine",
+      "email": "Email",
+      "emailPlaceholder": "you@example.com",
+      "emailHelp": "Ask a grown-up if you need help with this one.",
+      "password": "Make a password",
+      "passwordPlaceholder": "At least 8 characters",
+      "confirmPassword": "Type it again",
+      "confirmPasswordPlaceholder": "So we know you remember it"
+    },
+    "requirements": {
+      "length": "At least 8 characters",
+      "upper": "One BIG letter (A, B, C)",
+      "lower": "One small letter (a, b, c)",
+      "number": "One number (1, 2, 3)"
+    },
+    "errors": {
+      "mismatch": "Those don't match \u2014 try again.",
+      "emailInvalid": "That doesn't look like an email.",
+      "passwordTooShort": "Make it at least 8 characters.",
+      "generic": "We couldn't sign you up. Try again in a moment."
+    },
+    "terms": {
+      "prefix": "I agree to the",
+      "tos": "Terms of Service",
+      "and": "and",
+      "privacy": "Privacy Policy"
+    },
+    "submit": "Create my account",
+    "submitting": "Setting up your account\u2026",
+    "haveAccount": "Already have an account?",
+    "logIn": "Log in",
+    "haveCode": "Have a class code from your teacher?",
+    "joinClass": "Join your class"
   }
 }

--- a/src/pages/SignupSelection.tsx
+++ b/src/pages/SignupSelection.tsx
@@ -12,6 +12,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { KeyRound } from "lucide-react";
 import LoginCard from "@/components/auth/LoginCard";
 import { track } from "@/lib/analytics";
 
@@ -84,6 +85,23 @@ const SignupSelection: React.FC = () => {
             </p>
           </Link>
         ))}
+      </div>
+
+      {/* Class-code alternative — students with a code from their teacher
+          don't need a self-signup. Surfacing it here reduces confusion. */}
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 flex items-center gap-3">
+        <KeyRound className="w-4 h-4 text-emerald-700 shrink-0" aria-hidden />
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-slate-700">
+            {t("signupSelection.classCodeNote")}
+          </p>
+          <Link
+            to="/class-login"
+            className="text-sm font-semibold text-emerald-700 hover:underline"
+          >
+            {t("signupSelection.classCodeLink")} →
+          </Link>
+        </div>
       </div>
 
       <div className="text-center">

--- a/src/pages/StudentSignup.tsx
+++ b/src/pages/StudentSignup.tsx
@@ -1,54 +1,86 @@
 // src/pages/StudentSignup.tsx
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Check, Circle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Check, Circle, KeyRound, ShieldCheck } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { signupStudent } from "../services/api";
 import { track } from "../lib/analytics";
-import GameBackground from "../components/GameBackground";
-import BrightBoostRobot from "../components/BrightBoostRobot";
-import LanguageToggle from "../components/LanguageToggle";
+import LoginCard from "@/components/auth/LoginCard";
 import { Input } from "../components/ui/input";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
 import { Checkbox } from "../components/ui/checkbox";
 
+interface FieldErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  form?: string;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
 const StudentSignup: React.FC = () => {
+  const { t } = useTranslation();
+  const { login } = useAuth();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [error, setError] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [isPasswordFocused, setIsPasswordFocused] = useState(false);
   const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const { login } = useAuth();
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const previous = document.title;
+    document.title = `${t("studentSignup.pageTitle")} · Bright Boost`;
+    return () => {
+      document.title = previous;
+    };
+  }, [t]);
 
   const requirements = [
-    { re: /.{8,}/, label: "At least 8 characters long" },
-    { re: /[A-Z]/, label: "One BIG letter (like A, B, C)" },
-    { re: /[a-z]/, label: "One small letter (like a, b, c)" },
-    { re: /[0-9]/, label: "One number (like 1, 2, 3)" },
+    { re: /.{8,}/, label: t("studentSignup.requirements.length") },
+    { re: /[A-Z]/, label: t("studentSignup.requirements.upper") },
+    { re: /[a-z]/, label: t("studentSignup.requirements.lower") },
+    { re: /[0-9]/, label: t("studentSignup.requirements.number") },
   ];
+
+  const clearFieldError = (field: keyof FieldErrors) => {
+    if (errors[field]) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const validate = (): boolean => {
+    const next: FieldErrors = {};
+    if (!EMAIL_RE.test(email.trim())) {
+      next.email = t("studentSignup.errors.emailInvalid");
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      next.password = t("studentSignup.errors.passwordTooShort");
+    }
+    if (password !== confirmPassword) {
+      next.confirmPassword = t("studentSignup.errors.mismatch");
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError("");
-
-    // Validate passwords match
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
-
+    if (!validate()) return;
     setIsLoading(true);
-
     try {
-      // console.log('Attempting to sign up student:', { name, email, role: 'student' });
-      const response = await signupStudent(name, email, password);
-      // console.log('Signup successful:', response);
-
-      // Auto login after successful signup
+      const response = await signupStudent(name.trim(), email.trim(), password);
       if (response && response.token) {
         track({
           kind: "account_registered",
@@ -57,227 +89,227 @@ const StudentSignup: React.FC = () => {
         });
         login(response.token, response.user);
       } else {
-        console.error("Invalid response format:", response);
-        setError("Server returned an invalid response format");
+        setErrors({ form: t("studentSignup.errors.generic") });
       }
     } catch (err: unknown) {
-      console.error("Signup error:", err);
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Failed to sign up. Please try again.",
-      );
+      setErrors({
+        form:
+          err instanceof Error && err.message
+            ? err.message
+            : t("studentSignup.errors.generic"),
+      });
     } finally {
       setIsLoading(false);
     }
   };
 
-  const inputClassName =
-    "w-full px-4 py-2 bg-white border-2 border-brightboost-lightblue text-brightboost-navy rounded-lg focus:outline-none focus:ring-2 focus:ring-brightboost-blue focus:border-transparent transition-all";
-
   return (
-    <GameBackground>
-      <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
-        <div className="absolute top-4 right-4 z-20">
-          <LanguageToggle />
-        </div>
-        <div className="flex flex-col md:flex-row items-center justify-center gap-6 w-full max-w-4xl">
-          <div className="text-center md:text-left flex-1">
-            <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-4">
-              Join as a Student
-            </h1>
-            <p className="text-lg text-brightboost-navy mb-6">
-              Start your learning adventure today!
+    <LoginCard
+      icon="🎒"
+      title={t("studentSignup.heading")}
+      subtitle={t("studentSignup.subtitle")}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-xl border border-slate-200 bg-white shadow-sm p-5 space-y-4"
+        noValidate
+      >
+        {errors.form && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2"
+          >
+            {errors.form}
+          </div>
+        )}
+
+        <Input
+          label={t("studentSignup.fields.name")}
+          id="name"
+          name="name"
+          type="text"
+          autoComplete="given-name"
+          required
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            clearFieldError("name");
+          }}
+          placeholder={t("studentSignup.fields.namePlaceholder")}
+          error={errors.name}
+        />
+
+        <div>
+          <Input
+            label={t("studentSignup.fields.email")}
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              clearFieldError("email");
+            }}
+            placeholder={t("studentSignup.fields.emailPlaceholder")}
+            error={errors.email}
+          />
+          {!errors.email && (
+            <p className="mt-1 text-xs text-slate-500">
+              {t("studentSignup.fields.emailHelp")}
             </p>
-            <BrightBoostRobot className="hidden md:block" />
-          </div>
-
-          <div className="game-card p-6 flex-1 w-full max-w-md">
-            <BrightBoostRobot className="md:hidden mx-auto mb-6" size="sm" />
-
-            {error && (
-              <div
-                className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-4"
-                role="alert"
-                aria-live="polite"
-              >
-                {error}
-              </div>
-            )}
-
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label
-                  htmlFor="name"
-                  className="block text-sm font-medium text-brightboost-navy mb-1"
-                >
-                  Full Name
-                </label>
-                <Input
-                  id="name"
-                  type="text"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  required
-                  className={inputClassName}
-                  placeholder="Enter your full name"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-brightboost-navy mb-1"
-                >
-                  Email
-                </label>
-                <Input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  className={inputClassName}
-                  placeholder="Enter your email"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-brightboost-navy mb-1"
-                >
-                  Password
-                </label>
-                <PasswordInput
-                  id="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  onFocus={() => setIsPasswordFocused(true)}
-                  onBlur={() => setIsPasswordFocused(false)}
-                  required
-                  className={inputClassName}
-                  placeholder="Create a password"
-                  aria-describedby="password-requirements"
-                />
-                {(password.length > 0 || isPasswordFocused) && (
-                  <ul
-                    id="password-requirements"
-                    className="mt-2 space-y-1"
-                    aria-label="Password requirements"
-                    aria-live="polite"
-                  >
-                    {requirements.map((req, index) => {
-                      const isMet = req.re.test(password);
-                      return (
-                        <li
-                          key={index}
-                          className={`text-xs flex items-center gap-1.5 ${
-                            isMet ? "text-green-600" : "text-slate-500"
-                          }`}
-                        >
-                          {isMet ? (
-                            <Check className="w-3 h-3" aria-hidden="true" />
-                          ) : (
-                            <Circle
-                              className="w-3 h-3 text-slate-300"
-                              aria-hidden="true"
-                            />
-                          )}
-                          <span>{req.label}</span>
-                          <span className="sr-only">
-                            {isMet ? " - Completed" : " - Incomplete"}
-                          </span>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
-
-              <div>
-                <label
-                  htmlFor="confirmPassword"
-                  className="block text-sm font-medium text-brightboost-navy mb-1"
-                >
-                  Confirm Password
-                </label>
-                <PasswordInput
-                  id="confirmPassword"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  required
-                  className={inputClassName}
-                  placeholder="Confirm your password"
-                />
-              </div>
-
-              <div className="flex items-start gap-2">
-                <Checkbox
-                  id="agreeTerms"
-                  checked={agreedToTerms}
-                  onCheckedChange={(checked) =>
-                    setAgreedToTerms(checked === true)
-                  }
-                  className="mt-0.5"
-                />
-                <label
-                  htmlFor="agreeTerms"
-                  className="text-sm text-brightboost-navy leading-snug"
-                >
-                  I agree to the{" "}
-                  <Link
-                    to="/terms"
-                    className="text-brightboost-blue font-bold hover:underline"
-                    target="_blank"
-                  >
-                    Terms of Service
-                  </Link>{" "}
-                  and{" "}
-                  <Link
-                    to="/privacy"
-                    className="text-brightboost-blue font-bold hover:underline"
-                    target="_blank"
-                  >
-                    Privacy Policy
-                  </Link>
-                </label>
-              </div>
-
-              <Button
-                type="submit"
-                isLoading={isLoading}
-                disabled={!agreedToTerms}
-                loadingText="Signing up..."
-                className="button-shadow w-full py-3 px-4 rounded-xl text-brightboost-navy font-bold ui-lift bg-brightboost-yellow hover:bg-brightboost-yellow/90"
-              >
-                Sign Up
-              </Button>
-            </form>
-
-            <div className="mt-6 text-center">
-              <p className="text-sm text-brightboost-navy">
-                Already have an account?{" "}
-                <Link
-                  to="/student-login"
-                  className="text-brightboost-blue font-bold hover:underline transition-colors"
-                >
-                  Log in
-                </Link>
-              </p>
-              <p className="text-sm text-brightboost-navy mt-2">
-                <Link
-                  to="/"
-                  className="text-brightboost-blue font-bold hover:underline transition-colors"
-                >
-                  Back to Home
-                </Link>
-              </p>
-            </div>
-          </div>
+          )}
         </div>
+
+        <div>
+          <PasswordInput
+            label={t("studentSignup.fields.password")}
+            id="password"
+            name="new-password"
+            autoComplete="new-password"
+            required
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              clearFieldError("password");
+              if (errors.confirmPassword && e.target.value === confirmPassword) {
+                clearFieldError("confirmPassword");
+              }
+            }}
+            onFocus={() => setIsPasswordFocused(true)}
+            onBlur={() => setIsPasswordFocused(false)}
+            placeholder={t("studentSignup.fields.passwordPlaceholder")}
+            error={errors.password}
+            aria-describedby="password-requirements"
+          />
+          {(password.length > 0 || isPasswordFocused) && (
+            <ul
+              id="password-requirements"
+              className="mt-2 space-y-1"
+              aria-label="Password requirements"
+              aria-live="polite"
+            >
+              {requirements.map((req) => {
+                const isMet = req.re.test(password);
+                return (
+                  <li
+                    key={req.label}
+                    className={`text-xs flex items-center gap-1.5 ${
+                      isMet ? "text-emerald-600" : "text-slate-500"
+                    }`}
+                  >
+                    {isMet ? (
+                      <Check className="w-3 h-3" aria-hidden="true" />
+                    ) : (
+                      <Circle
+                        className="w-3 h-3 text-slate-300"
+                        aria-hidden="true"
+                      />
+                    )}
+                    <span>{req.label}</span>
+                    <span className="sr-only">
+                      {isMet ? " - Completed" : " - Incomplete"}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <PasswordInput
+          label={t("studentSignup.fields.confirmPassword")}
+          id="confirmPassword"
+          name="confirm-password"
+          autoComplete="new-password"
+          required
+          value={confirmPassword}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value);
+            clearFieldError("confirmPassword");
+          }}
+          placeholder={t("studentSignup.fields.confirmPasswordPlaceholder")}
+          error={errors.confirmPassword}
+        />
+
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="agreeTerms"
+            checked={agreedToTerms}
+            onCheckedChange={(checked) => setAgreedToTerms(checked === true)}
+            className="mt-0.5"
+          />
+          <label
+            htmlFor="agreeTerms"
+            className="text-xs text-slate-600 leading-snug"
+          >
+            {t("studentSignup.terms.prefix")}{" "}
+            <Link
+              to="/terms"
+              className="text-indigo-600 font-semibold hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("studentSignup.terms.tos")}
+            </Link>{" "}
+            {t("studentSignup.terms.and")}{" "}
+            <Link
+              to="/privacy"
+              className="text-indigo-600 font-semibold hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("studentSignup.terms.privacy")}
+            </Link>
+          </label>
+        </div>
+
+        <Button
+          type="submit"
+          isLoading={isLoading}
+          disabled={!agreedToTerms || isLoading}
+          loadingText={t("studentSignup.submitting")}
+          className="w-full py-3 min-h-[44px] rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-semibold text-sm transition-colors disabled:opacity-50"
+        >
+          {t("studentSignup.submit")}
+        </Button>
+
+        <p className="flex items-start gap-1.5 text-xs text-slate-500 pt-1">
+          <ShieldCheck className="w-3.5 h-3.5 mt-0.5 shrink-0 text-emerald-600" />
+          <span>{t("teacherSignup.trust")}</span>
+        </p>
+      </form>
+
+      {/* Class-code alternative — students with a code from their teacher
+          don't need a self-signup at all. */}
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+        <p className="text-xs text-slate-700">
+          {t("studentSignup.haveCode")}
+        </p>
+        <Link
+          to="/class-login"
+          className="mt-2 inline-flex items-center justify-center gap-1.5 w-full px-4 py-2.5 min-h-[44px] rounded-lg bg-white border border-emerald-400 text-emerald-700 font-semibold text-sm hover:bg-emerald-100 active:scale-[0.99] transition-all"
+        >
+          <KeyRound className="w-4 h-4" />
+          {t("studentSignup.joinClass")}
+        </Link>
       </div>
-    </GameBackground>
+
+      <div className="text-center">
+        <p className="text-sm text-slate-600">
+          {t("studentSignup.haveAccount")}{" "}
+          <Link
+            to="/student-login"
+            className="font-semibold text-indigo-600 hover:underline"
+          >
+            {t("studentSignup.logIn")}
+          </Link>
+        </p>
+      </div>
+    </LoginCard>
   );
 };
 

--- a/src/pages/TeacherSignup.tsx
+++ b/src/pages/TeacherSignup.tsx
@@ -1,43 +1,79 @@
 // src/pages/TeacherSignup.tsx
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { ShieldCheck } from "lucide-react";
 import { useAuth } from "../contexts/AuthContext";
 import { signupTeacher } from "../services/api";
 import { track } from "../lib/analytics";
-import GameBackground from "../components/GameBackground";
-import BrightBoostRobot from "../components/BrightBoostRobot";
-import LanguageToggle from "../components/LanguageToggle";
+import LoginCard from "@/components/auth/LoginCard";
 import { Input } from "../components/ui/input";
 import { PasswordInput } from "../components/ui/password-input";
 import { Button } from "../components/ui/button";
 import { Checkbox } from "../components/ui/checkbox";
 
+interface FieldErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  form?: string;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
 const TeacherSignup: React.FC = () => {
+  const { t } = useTranslation();
+  const { login } = useAuth();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [error, setError] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const { login } = useAuth();
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Set document title for browser tab + accessibility
+  useEffect(() => {
+    const previous = document.title;
+    document.title = `${t("teacherSignup.pageTitle")} · Bright Boost`;
+    return () => {
+      document.title = previous;
+    };
+  }, [t]);
+
+  const clearFieldError = (field: keyof FieldErrors) => {
+    if (errors[field]) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const validate = (): boolean => {
+    const next: FieldErrors = {};
+    if (!EMAIL_RE.test(email.trim())) {
+      next.email = t("teacherSignup.errors.emailInvalid");
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      next.password = t("teacherSignup.errors.passwordTooShort");
+    }
+    if (password !== confirmPassword) {
+      next.confirmPassword = t("teacherSignup.errors.mismatch");
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError("");
-
-    // Validate passwords match
-    if (password !== confirmPassword) {
-      setError("Passwords do not match");
-      return;
-    }
-
+    if (!validate()) return;
     setIsLoading(true);
-
     try {
-      const response = await signupTeacher(name, email, password);
-
-      // Auto login after successful signup
+      const response = await signupTeacher(name.trim(), email.trim(), password);
       if (response && response.token) {
         track({
           kind: "account_registered",
@@ -46,163 +82,175 @@ const TeacherSignup: React.FC = () => {
         });
         login(response.token, response.user);
       } else {
-        console.error("Invalid response format:", response);
-        setError("Server returned an invalid response format");
+        setErrors({ form: t("teacherSignup.errors.generic") });
       }
     } catch (err: unknown) {
-      console.error("Signup error:", err);
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Failed to sign up. Please try again.",
-      );
+      setErrors({
+        form:
+          err instanceof Error && err.message
+            ? err.message
+            : t("teacherSignup.errors.generic"),
+      });
     } finally {
       setIsLoading(false);
     }
   };
 
-  const inputClasses =
-    "bg-white border-2 border-brightboost-lightblue text-brightboost-navy rounded-lg focus:ring-brightboost-blue focus:border-transparent";
-
   return (
-    <GameBackground>
-      <div className="flex flex-col items-center justify-center min-h-screen p-4 relative z-10">
-        <div className="absolute top-4 right-4 z-20">
-          <LanguageToggle />
-        </div>
-        <div className="flex flex-col md:flex-row items-center justify-center gap-6 w-full max-w-4xl">
-          <div className="text-center md:text-left flex-1">
-            <h1 className="text-3xl md:text-4xl font-bold text-brightboost-navy mb-4">
-              Join as a Teacher
-            </h1>
-            <p className="text-lg text-brightboost-navy mb-6">
-              Share your knowledge and inspire the next generation
+    <LoginCard
+      icon="👩‍🏫"
+      title={t("teacherSignup.heading")}
+      subtitle={t("teacherSignup.subtitle")}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-xl border border-slate-200 bg-white shadow-sm p-5 space-y-4"
+        noValidate
+      >
+        {errors.form && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2"
+          >
+            {errors.form}
+          </div>
+        )}
+
+        <Input
+          label={t("teacherSignup.fields.name")}
+          id="name"
+          name="name"
+          type="text"
+          autoComplete="name"
+          required
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            clearFieldError("name");
+          }}
+          placeholder={t("teacherSignup.fields.namePlaceholder")}
+          error={errors.name}
+        />
+
+        <div>
+          <Input
+            label={t("teacherSignup.fields.email")}
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              clearFieldError("email");
+            }}
+            placeholder={t("teacherSignup.fields.emailPlaceholder")}
+            error={errors.email}
+          />
+          {!errors.email && (
+            <p className="mt-1 text-xs text-slate-500">
+              {t("teacherSignup.fields.emailHelp")}
             </p>
-            <BrightBoostRobot className="hidden md:block" />
-          </div>
-
-          <div className="game-card p-6 flex-1 w-full max-w-md">
-            <BrightBoostRobot className="md:hidden mx-auto mb-6" size="sm" />
-
-            {error && (
-              <div
-                className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-4"
-                role="alert"
-                aria-live="polite"
-              >
-                {error}
-              </div>
-            )}
-
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input
-                label="Full Name"
-                id="name"
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-                className={inputClasses}
-                placeholder="Enter your full name"
-              />
-
-              <Input
-                label="Email"
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className={inputClasses}
-                placeholder="Enter your email"
-              />
-
-              <PasswordInput
-                label="Password"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className={inputClasses}
-                placeholder="Create a password"
-              />
-
-              <PasswordInput
-                label="Confirm Password"
-                id="confirmPassword"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                className={inputClasses}
-                placeholder="Confirm your password"
-              />
-
-              <div className="flex items-start gap-2">
-                <Checkbox
-                  id="agreeTerms"
-                  checked={agreedToTerms}
-                  onCheckedChange={(checked) =>
-                    setAgreedToTerms(checked === true)
-                  }
-                  className="mt-0.5"
-                />
-                <label
-                  htmlFor="agreeTerms"
-                  className="text-sm text-brightboost-navy leading-snug"
-                >
-                  I agree to the{" "}
-                  <Link
-                    to="/terms"
-                    className="text-brightboost-blue font-bold hover:underline"
-                    target="_blank"
-                  >
-                    Terms of Service
-                  </Link>{" "}
-                  and{" "}
-                  <Link
-                    to="/privacy"
-                    className="text-brightboost-blue font-bold hover:underline"
-                    target="_blank"
-                  >
-                    Privacy Policy
-                  </Link>
-                </label>
-              </div>
-
-              <Button
-                type="submit"
-                isLoading={isLoading}
-                disabled={!agreedToTerms}
-                loadingText="Signing up..."
-                className="button-shadow w-full py-3 px-4 rounded-xl text-white font-bold ui-lift bg-brightboost-blue hover:bg-brightboost-blue/90"
-              >
-                Sign Up
-              </Button>
-            </form>
-
-            <div className="mt-6 text-center">
-              <p className="text-sm text-brightboost-navy">
-                Already have an account?{" "}
-                <Link
-                  to="/teacher-login"
-                  className="text-brightboost-blue font-bold hover:underline transition-colors"
-                >
-                  Log in
-                </Link>
-              </p>
-              <p className="text-sm text-brightboost-navy mt-2">
-                <Link
-                  to="/"
-                  className="text-brightboost-blue font-bold hover:underline transition-colors"
-                >
-                  Back to Home
-                </Link>
-              </p>
-            </div>
-          </div>
+          )}
         </div>
+
+        <PasswordInput
+          label={t("teacherSignup.fields.password")}
+          id="password"
+          name="new-password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            clearFieldError("password");
+            // Re-validate confirm field if user edited password after a mismatch
+            if (errors.confirmPassword && e.target.value === confirmPassword) {
+              clearFieldError("confirmPassword");
+            }
+          }}
+          placeholder={t("teacherSignup.fields.passwordPlaceholder")}
+          error={errors.password}
+        />
+
+        <PasswordInput
+          label={t("teacherSignup.fields.confirmPassword")}
+          id="confirmPassword"
+          name="confirm-password"
+          autoComplete="new-password"
+          required
+          value={confirmPassword}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value);
+            clearFieldError("confirmPassword");
+          }}
+          placeholder={t("teacherSignup.fields.confirmPasswordPlaceholder")}
+          error={errors.confirmPassword}
+        />
+
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="agreeTerms"
+            checked={agreedToTerms}
+            onCheckedChange={(checked) => setAgreedToTerms(checked === true)}
+            className="mt-0.5"
+          />
+          <label
+            htmlFor="agreeTerms"
+            className="text-xs text-slate-600 leading-snug"
+          >
+            {t("teacherSignup.terms.prefix")}{" "}
+            <Link
+              to="/terms"
+              className="text-indigo-600 font-semibold hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("teacherSignup.terms.tos")}
+            </Link>{" "}
+            {t("teacherSignup.terms.and")}{" "}
+            <Link
+              to="/privacy"
+              className="text-indigo-600 font-semibold hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t("teacherSignup.terms.privacy")}
+            </Link>
+          </label>
+        </div>
+
+        <Button
+          type="submit"
+          isLoading={isLoading}
+          disabled={!agreedToTerms || isLoading}
+          loadingText={t("teacherSignup.submitting")}
+          className="w-full py-3 min-h-[44px] rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-semibold text-sm transition-colors disabled:opacity-50"
+        >
+          {t("teacherSignup.submit")}
+        </Button>
+
+        <p className="flex items-start gap-1.5 text-xs text-slate-500 pt-1">
+          <ShieldCheck className="w-3.5 h-3.5 mt-0.5 shrink-0 text-emerald-600" />
+          <span>{t("teacherSignup.trust")}</span>
+        </p>
+      </form>
+
+      <div className="text-center">
+        <p className="text-sm text-slate-600">
+          {t("teacherSignup.haveAccount")}{" "}
+          <Link
+            to="/teacher-login"
+            className="font-semibold text-indigo-600 hover:underline"
+          >
+            {t("teacherSignup.logIn")}
+          </Link>
+        </p>
       </div>
-    </GameBackground>
+    </LoginCard>
   );
 };
 


### PR DESCRIPTION
## TL;DR

Funnel-top polish directly supporting the 1,000-account activation goal. The signup pages from PR #598's entry-points work were functional but visually inconsistent with the cleaner LoginCard pattern that the rest of the auth flow adopted. This pulls them into the same visual language and adds the form-UX details the old version was missing — without touching what the forms actually do.

## What's polished

### Visual consistency
- TeacherSignup + StudentSignup migrated to the **LoginCard** pattern (matches `/signup`, `/teacher-login`, `/student-login`). Same indigo accent, input shape, shadow/border tokens, max-width container.
- Dropped GameBackground and BrightBoostRobot from these screens — they pushed the form below the fold on mobile and competed with the CTA. The warmth now comes from the emoji-leading LoginCard header + microcopy, not background art.

### Copy & microcopy
| Before | After |
| --- | --- |
| "Join as a Teacher" | "Let's get you set up" |
| "Share your knowledge and inspire the next generation" | "It only takes a minute. You'll be ready to invite your class right after." |
| "Join as a Student" | "Welcome to Bright Boost!" |
| "Full Name" | "Your name" / "What's your name?" |
| "Email" | "School email" / "Email" + 1-line use-of-email reassurance |
| "Sign Up" | "Create my teacher account" / "Create my account" |
| "Signing up…" | "Creating your account…" / "Setting up your account…" |

### Form UX
- **Per-field inline errors** via the existing `Input` / `PasswordInput` `error` prop. Mismatched passwords light up the confirm field, not a global banner.
- Field errors **auto-clear as the user types**, with a smart re-validate so editing the password re-syncs the confirm field once the values match again.
- Client-side validation runs on submit (email shape, password length, password match) — users see issues without a server round-trip.
- `autoComplete` attributes everywhere: `name` / `given-name` / `email` / `new-password` / `confirm-password` (paired). Browser autofill + password managers now work.
- `inputMode="email"` surfaces the email keyboard on mobile.
- `noValidate` on the form so our friendly messages win over the browser's generic tooltip.
- `PasswordInput` already had show/hide toggle + Caps Lock detection + `aria-invalid` / `aria-describedby` — those are now correctly wired through every password field (they were only partially wired before).

### Trust signals
- Each form ends with a `ShieldCheck`-led line: **"We protect student data carefully. Email is for account-only use."** The right place for COPPA-conscious reassurance — at the point of decision, not behind a separate privacy click.
- Terms/Privacy links use `rel="noreferrer"` on the new-tab opens.

### Mobile + a11y
- Single-column LoginCard layout, `w-full` inputs and CTAs, every CTA meets the 44px minimum tap target (`min-h-[44px]`).
- `document.title` set via `useEffect` per signup screen so bookmarks + screen readers identify them correctly.
- Global form errors use `role="alert"` + `aria-live="polite"`; per-field errors flow through the existing `aria-invalid` + `aria-describedby` wiring.

### Bonus K-2 path (SignupSelection + StudentSignup)
- Both screens now surface an emerald-bordered **"Have a class code from your teacher? Join your class"** CTA → `/class-login`. K-2 students whose teachers created their accounts don't actually need a signup — they use the emoji-picker class-code flow. Surfacing the alternative here cuts the bounce we'd otherwise see from kids landing on the wrong page.

## What this PR does NOT change

- **Functionality is identical**: same `signupTeacher` / `signupStudent` calls, same `login()` handoff, same post-signup redirect (AuthContext routes by role).
- **`account_registered` analytics still fires** on success with the same `role` + `signup_method` properties — both client-side and the server-side mirror added in PR #597.
- **No new required fields** (still name + email + password + confirm + terms).
- **No password-policy changes** (still 8 chars + upper + lower + number).
- **No backend changes. No new routes.**

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean for new code
- [ ] `npm run dev` walk:
  - `/signup` → cards + new class-code alternative render; tapping a card fires `signup_role_selected`
  - `/teacher/signup` → friendly heading, password show/hide works, autofill suggests email
  - mismatched password → error lights up confirm field, clears on edit
  - submit valid form → loading state shows, lands on `/teacher/dashboard`
  - `/student/signup` → password requirement checklist still works, class-code alternative present
- [ ] Mobile viewport (375px): single column, no horizontal scroll, CTAs reachable above keyboard, `min-h-[44px]` everywhere
- [ ] Keyboard-only: tab through name → email → password → confirm → terms → submit; Enter submits
- [ ] Existing test accounts (`teacher@school.com / password123`, `explorer@test.com / explore123`) still log in unchanged

## i18n

en/common.json gains `teacherSignup.*` / `studentSignup.*` namespaces + 3 new `signupSelection.*` keys. es/vi/zh-CN inherit via i18next `fallbackLng: "en"` until translated — same approach as PR #598, since the non-en locale files still have pre-existing duplicate top-level keys (e.g. `teacher` declared twice in es) that make automated round-trip merges generate ~1000-line cosmetic diffs. Tracked as a follow-up cleanup.

## Stats

4 files, +562 / -389 (the page rewrites are big because the previous TeacherSignup / StudentSignup were full inline implementations — the polished versions delegate to LoginCard + Input / PasswordInput primitives so much of the diff is removed bespoke chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)