### PR TITLE
fix: PostHog analytics not firing — Dockerfile.frontend didn't forward VITE_POSTHOG_KEY into the build

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,9 +8,26 @@ COPY . .
 # Install dependencies
 RUN npm ci
 
-# Build frontend — VITE_API_BASE is the canonical API base URL
+# Build frontend.
+#
+# Vite inlines `VITE_*` env vars at BUILD TIME, not runtime — they have to be
+# present in this Docker build context, not just in the running container.
+# Railway passes service env vars through to build args when the ARG is
+# declared here with a matching name. Add a new VITE_ var? Add an ARG +
+# matching ENV line below AND set the value in Railway's service variables.
+#
+# Variables consumed by the bundle:
+#   VITE_API_BASE     — canonical API base URL ("/api" same-origin in prod)
+#   VITE_POSTHOG_KEY  — PostHog project key (phc_...). When unset, the
+#                       analytics shim silently no-ops.
+#   VITE_POSTHOG_HOST — PostHog region host (us.i.posthog.com or
+#                       eu.i.posthog.com). Mismatched region = lost events.
 ARG VITE_API_BASE=/api
 ENV VITE_API_BASE=$VITE_API_BASE
+ARG VITE_POSTHOG_KEY
+ENV VITE_POSTHOG_KEY=$VITE_POSTHOG_KEY
+ARG VITE_POSTHOG_HOST
+ENV VITE_POSTHOG_HOST=$VITE_POSTHOG_HOST
 RUN npm run build
 
 # Runner stage

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -25,7 +25,27 @@ POSTHOG_KEY=phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 POSTHOG_HOST=https://us.i.posthog.com
 ```
 
-When unset, both shims (`src/lib/analytics.ts` and `backend/src/services/analytics.ts`) silently no-op so local dev runs fine without the key. The first call logs a single info-level message so the absence is obvious.
+When unset, the backend shim (`backend/src/services/analytics.ts`) silently no-ops at runtime and prints one info log so the absence is obvious. The frontend shim (`src/lib/analytics.ts`) prints a **warning** with a Railway/Dockerfile pointer when the key is missing — silent prod failures are the #1 thing that hides itself.
+
+### Why the frontend env vars require a Docker rebuild
+
+Vite **inlines `VITE_*` variables at BUILD time, not runtime**. That means:
+
+1. The frontend env vars (`VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`) must be present when `npm run build` runs inside the Docker image — not just at container start.
+2. `Dockerfile.frontend` declares them as `ARG` so Railway forwards the service env vars into the build context. If you add a new `VITE_*` variable, add a matching `ARG` + `ENV` line in `Dockerfile.frontend`, OR Vite will substitute `undefined`.
+3. After changing a `VITE_*` env var on Railway, you must trigger a **clean rebuild** (the docker layer cache may otherwise keep an old bundle with the old/missing key).
+
+The backend Dockerfile reads `process.env.POSTHOG_KEY` at runtime, so backend env vars take effect on the next container start — no rebuild required.
+
+### Verifying the key reached the bundle
+
+```bash
+# Local build with a probe key, then grep the dist output:
+VITE_POSTHOG_KEY=phc_probe_xyz npm run build
+grep -rl "phc_probe_xyz" dist/   # should print at least one chunk path
+```
+
+If the grep finds nothing, the build isn't inlining the variable — check Dockerfile.frontend's ARG list and the Railway service variables.
 
 ## Privacy rules (COPPA-conscious)
 
@@ -142,6 +162,20 @@ gamesStarted:
 gamesCompleted:
 completionRate:
 ```
+
+## Triage runbook — "PostHog events aren't firing in production"
+
+Work through the layers in order — most of these failures fail silently, so don't trust any single signal.
+
+1. **Bundle inlining (most common).** Open DevTools → Console on the live site. If you see:
+   - `[analytics] DISABLED — VITE_POSTHOG_KEY is not present in the built bundle` → the key didn't make it into the build. Check `Dockerfile.frontend` declares `ARG VITE_POSTHOG_KEY` (and `_HOST`), confirm Railway's **frontend** service has the variable set (it must be a Railway **service** variable so it's available as a build arg), then trigger a clean rebuild from Railway (the docker layer cache may otherwise reuse the previous bundle).
+   - `[analytics] Initializing PostHog → https://us.i.posthog.com` followed by `[analytics] PostHog ready` → init is working; move to step 2.
+   - Initializing line but no "ready" line within a second → posthog-js failed to load. Network tab → look for blocked posthog.js requests (ad blockers / CSP / region typo).
+2. **Region/host.** PostHog projects are pinned to a region. US project ↔ `https://us.i.posthog.com`, EU project ↔ `https://eu.i.posthog.com`. Events sent to the wrong region succeed silently and vanish. Check the PostHog project URL (us.posthog.com vs eu.posthog.com).
+3. **Network.** Network tab → filter `posthog`. Fire an event (sign up, complete a module). Expected: POSTs returning 200. 401/403 = wrong project key. 4xx to a host you don't recognize = region/host wrong.
+4. **Project mismatch.** Confirm the PostHog project you're viewing matches the API key in Railway. Each PostHog project has its own `phc_*` key. The team has more than one PostHog project? Easy to look at the wrong one.
+5. **Idempotency trap for `game_completed`.** The server-side mirror fires once per `(studentId, activityId)`. Re-completing an already-completed activity skips the event — by design. Use a fresh activity on a fresh account for the test.
+6. **Backend events.** The backend reads `process.env.POSTHOG_KEY` at runtime, not build time — set it on the Railway **backend** service. Check backend logs for the `[analytics]` info line at startup. If you see `[analytics] No POSTHOG_KEY set …`, the backend env var is missing.
 
 ## Where the code lives
 

--- a/scripts/check-prisma-drift.sh
+++ b/scripts/check-prisma-drift.sh
@@ -24,16 +24,25 @@ if [ ! -f "$BACKEND_SCHEMA" ]; then
   exit 1
 fi
 
-# Strip comments, generator/datasource blocks, and blank lines to isolate models
+# Strip comments, generator/datasource blocks, and blank lines to isolate
+# model + enum content.
+#
+# The previous version only stripped full-line // comments anchored at
+# column 0. Inline comments (`field String  // "a" | "b"`) and indented
+# comment lines inside model bodies still flowed through and reported as
+# drift, which is what bit the schema sync after the gamification + CTF
+# work added a lot of `// enum-string` documentation to the root schema.
+# The expected behavior — and what the docblock has always claimed — is
+# that comments are not load-bearing for sync.
 strip_non_model() {
-  sed '/^\/\//d' "$1" \
-    | awk '
-      /^generator /  { skip=1 }
-      /^datasource / { skip=1 }
-      skip && /^}/   { skip=0; next }
-      skip           { next }
-                     { print }
-    ' \
+  awk '
+    /^generator /  { skip=1 }
+    /^datasource / { skip=1 }
+    skip && /^}/   { skip=0; next }
+    skip           { next }
+                   { print }
+  ' "$1" \
+    | sed -E 's|[[:space:]]*//.*$||' \
     | sed '/^[[:space:]]*$/d'
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -80,12 +80,24 @@ function disabled(): boolean {
 export function initAnalytics(): void {
   if (initialized) return;
   if (!POSTHOG_KEY) {
-    // Single info-level message so the absence is obvious in local dev.
-    console.info(
-      "[analytics] No PostHog key set — analytics disabled (this is fine in local dev)",
+    // Use warn (not info) so prod consoles surface the disabled state
+    // clearly — silent no-ops are the #1 PostHog-not-firing failure mode.
+    // The message names the env var so the cause is obvious to operators.
+    console.warn(
+      "[analytics] DISABLED — VITE_POSTHOG_KEY is not present in the built bundle. " +
+        "If you expect analytics to work here: confirm Railway has VITE_POSTHOG_KEY set " +
+        "on the FRONTEND service and that Dockerfile.frontend forwards it as a build ARG, " +
+        "then trigger a clean rebuild (Vite inlines VITE_* at build time, not runtime).",
     );
     return;
   }
+
+  // Surface a single distinguishable line at init so a prod operator can
+  // tell the difference between "no key" and "key present, loading":
+  //   - missing key: [analytics] DISABLED — ...
+  //   - present:     [analytics] Initializing PostHog → <host>
+  //   - loaded:      [analytics] PostHog ready (events will flow)
+  console.info(`[analytics] Initializing PostHog → ${POSTHOG_HOST}`);
 
   posthog.init(POSTHOG_KEY, {
     api_host: POSTHOG_HOST,
@@ -103,6 +115,7 @@ export function initAnalytics(): void {
     persistence: "localStorage",
     loaded: () => {
       initialized = true;
+      console.info("[analytics] PostHog ready (events will flow)");
     },
   });
 }


### PR DESCRIPTION
## Root cause

**Vite inlines `VITE_*` variables at BUILD time, not runtime.** `Dockerfile.frontend` only declared `ARG VITE_API_BASE` and forwarded that into the build `ENV`. **`VITE_POSTHOG_KEY` and `VITE_POSTHOG_HOST` were never passed into the Docker build context** — Railway's frontend service variables weren't reaching `npm run build` inside the image. Vite substituted `undefined` and the analytics shim correctly silenced every `track()` call.

The backend side reads `process.env.POSTHOG_KEY` at runtime from the container env, so backend events should already be firing (assuming `POSTHOG_KEY` is set on the **backend** Railway service). The frontend was the broken half.

## What this PR ships

**`Dockerfile.frontend`** — adds `ARG VITE_POSTHOG_KEY` + `ARG VITE_POSTHOG_HOST` and forwards each to `ENV` so Vite sees them during `npm run build`. Future `VITE_*` additions get caught by the explanatory comment block now above the ARG list.

**`src/lib/analytics.ts`** — silent failures were the #1 thing hiding this bug. Init now emits three distinguishable lines so a prod operator can tell exactly which layer failed:

| State | Console message |
| --- | --- |
| Key missing from bundle | `console.warn` — `[analytics] DISABLED — VITE_POSTHOG_KEY is not present in the built bundle. …` (names the env var + Dockerfile in the message) |
| Key present, contacting PostHog | `console.info` — `[analytics] Initializing PostHog → <host>` |
| PostHog `loaded` callback fired | `console.info` — `[analytics] PostHog ready (events will flow)` |

The `loaded` line only fires inside posthog's `loaded` callback, so its presence proves the key worked end-to-end — events will arrive.

**`scripts/check-prisma-drift.sh`** — the drift check has been failing on main since 2026-06-05, **gating CI from ever running `npm run build`**. The differences were 100% inline `//` comments and indented comment lines that the old `sed '/^\/\//d'` rule (anchored at column 0) didn't strip. Replaced with `sed -E 's|[[:space:]]*//.*$||'` which matches the docblock's claim that comments aren't load-bearing for sync. Drift check now passes; the build step can finally run in CI.

**`docs/analytics.md`** — new sections on the build-time inlining requirement, a verifying-the-key recipe (build with a probe value + grep `dist/`), and a six-layer **triage runbook** at the bottom for the next "events aren't firing" investigation.

## What the operator must do on Railway

This PR's code change alone won't make events flow — you also need to confirm Railway's config:

- [ ] **Frontend service**: `VITE_POSTHOG_KEY=phc_…` is set in the service variables. (Service vars are forwarded to build args when the ARG is declared in the Dockerfile — which this PR now does.)
- [ ] **Frontend service**: `VITE_POSTHOG_HOST` matches the PostHog project region — `https://us.i.posthog.com` for US, `https://eu.i.posthog.com` for EU. Wrong region = events succeed silently and vanish.
- [ ] **Backend service**: `POSTHOG_KEY=phc_…` set (no `VITE_` prefix — runtime env). Backend events take effect on the next container start; no rebuild required.
- [ ] **Backend service**: `POSTHOG_HOST` matches the same region as the frontend.
- [ ] **Trigger a clean rebuild of the frontend service** — Docker layer cache from the previous build will otherwise keep the un-inlined bundle even with the new Dockerfile.

After the rebuild, the prod browser console will show either `DISABLED + …` (config still wrong) or `Initializing → <host>` + `PostHog ready` within a second.

## How to verify the fix locally before the Railway redeploy

```bash
VITE_POSTHOG_KEY=phc_probe_xyz npm run build
grep -rl "phc_probe_xyz" dist/   # at least one chunk path should print
```

If `grep` finds nothing, Vite isn't inlining the variable — re-check the Dockerfile ARG list and the Railway service variables.

## CI status

The schema-drift fix unblocks CI. Before this PR, every push to main since 2026-06-05 hit the same gate, so the `Build application` step in CI has not actually run on any of the recent merges. That's a separate concern from PostHog (Railway has its own build), but worth knowing — CI hasn't been telling us if `npm run build` would succeed.

The `db-check` job's P3018 / `relation "Lesson" does not exist` failure is also still present, but that's a CI database state issue separate from both PostHog and the build chain. Flagged as a follow-up.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean for new code
- [x] `bash scripts/check-prisma-drift.sh` now passes
- [ ] After merge + Railway clean rebuild: prod console shows `Initializing → <host>` + `PostHog ready`
- [ ] PostHog Live Events shows new `account_registered` / `login` / `class_created` events within seconds of test actions
- [ ] If still empty: walk the triage runbook in `docs/analytics.md`

## Stats

4 files, +87 / -14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)