### PR TITLE
fix: landing page Early Access Goal section — mobile overlap, card content, CTA

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -212,8 +212,8 @@ const Index: React.FC = () => {
 
           <section id="early-access" aria-labelledby="early-access-heading" className="mx-auto max-w-6xl px-4 py-14">
             <h2 id="early-access-heading" className="text-2xl font-extrabold text-brightboost-navy">Early Access Goal</h2>
-            <Card className="mt-4 rounded-[18px] border-2 border-white/80 bg-white/85">
-              <CardContent className="pt-1 text-brightboost-navy font-semibold">
+            <Card className="mt-4 rounded-[18px] border-2 border-[#46B1E6]/20">
+              <CardContent className="text-brightboost-navy font-semibold">
                 Join our first 1,000 users
               </CardContent>
             </Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -144,10 +144,16 @@ const Index: React.FC = () => {
           <section
             id="hero"
             aria-labelledby="hero-heading"
-            className="mx-auto max-w-6xl px-4 py-10 md:py-12 md:min-h-[500px] min-h-[620px] max-h-[660px] md:max-h-[540px]"
+            // No max-height here: the mobile single-column stack (pill +
+            // heading + copy + CTAs + signup line + secondary links +
+            // early-access pill + mascot) is taller than any fixed clamp,
+            // and overflow:visible made the excess render ON TOP of the
+            // next section. Content sizes itself; md:min-h keeps the
+            // desktop hero from looking shallow.
+            className="mx-auto max-w-6xl px-4 py-10 md:py-12 md:min-h-[500px]"
             style={{ background: "linear-gradient(180deg,#BFE5F7 0%,#DCEEFB 55%,#EAF6FD 100%)" }}
           >
-            <div className="grid md:grid-cols-2 gap-6 items-center h-full">
+            <div className="grid md:grid-cols-2 gap-6 items-center">
               <div>
                 <p className="inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs uppercase tracking-[0.15em] bg-white text-brightboost-navy font-bold">
                   <span className="w-2 h-2 rounded-full bg-brightboost-green" aria-hidden="true" />
@@ -213,8 +219,23 @@ const Index: React.FC = () => {
           <section id="early-access" aria-labelledby="early-access-heading" className="mx-auto max-w-6xl px-4 py-14">
             <h2 id="early-access-heading" className="text-2xl font-extrabold text-brightboost-navy">Early Access Goal</h2>
             <Card className="mt-4 rounded-[18px] border-2 border-[#46B1E6]/20">
-              <CardContent className="text-brightboost-navy font-semibold">
-                Join our first 1,000 users
+              <CardContent>
+                <p className="inline-flex items-center gap-2 rounded-full bg-[#69D681]/20 px-3 py-1 text-xs font-bold text-brightboost-navy">
+                  🌱 Early access
+                </p>
+                <p className="mt-3 text-lg font-extrabold text-brightboost-navy">
+                  Join our first 1,000 users
+                </p>
+                <p className="mt-1 text-sm font-medium text-brightboost-navy/80 max-w-xl">
+                  Free for teachers, students, and families — help shape Bright
+                  Boost while your class gets early access to every game.
+                </p>
+                <Link
+                  to="/signup"
+                  className="mt-4 inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-[12px] font-extrabold bg-brightboost-navy text-white text-sm hover:brightness-110 active:translate-y-[2px] button-shadow"
+                >
+                  Sign up free →
+                </Link>
               </CardContent>
             </Card>
           </section>


### PR DESCRIPTION
## Context

This is the **public marketing landing page on mobile** — the first thing a teacher sees on their phone when a colleague shares the link. Top of the organic acquisition funnel for the 1,000-account goal. An iPhone screenshot of brightboost.org showed the Early Access Goal section visually broken: the hero's early-access pill and secondary links rendering ON TOP of the section heading, and the goal card as a near-empty white box.

## Root cause (the overlap)

The hero section had **`min-h-[620px] max-h-[660px]`** on mobile. The single-column mobile stack — badge pill + 3-line heading + paragraph + two CTA buttons + the "Sign up free" line (added in PR #598) + three secondary links + early-access pill + the 250px MascotHeroVisual — totals **~950px**. CSS overflow is visible by default, so everything past 660px **rendered on top of the next section**. That's the collision in the screenshot: the hero's overflow (pill + Give Feedback / Support Bright Boost / Explore Pathways links) landing on the "Early Access Goal" heading.

PR #598's extra hero line is likely what pushed the overflow into visible breakage — the clamp was always fragile; the line made it break.

## Fixes (3 commits on this branch)

1. **Card visibility** (first commit): `bg-white/85 border-white/80` were both translucent white against a white page background — card had no visible boundary. Now `border-[#46B1E6]/20` with solid white bg, matching the Free Access Plans cards below.
2. **The overlap** (this commit): removed the mobile `min-h`/`max-h` clamps and the desktop `md:max-h-[540px]`. Max-heights on text content are inherently fragile — one added line re-breaks the page. Content sizes itself; `md:min-h-[500px]` stays (min-heights can't cause overlap) so desktop keeps its visual floor. Dropped the now-purposeless `h-full` on the hero grid.
3. **Card content**: was a one-line near-empty box. Now: 🌱 Early access badge chip → "Join our first 1,000 users" headline → one motivating sentence → **"Sign up free →" CTA** (min 44px tap target) into `/signup`, the role-chooser from PR #598. The section now funnels directly into registration.

## Where the Give Feedback / Support / Explore Pathways links ended up

They stay exactly where they belong — **inside the hero**. They were never part of the Early Access section; they were hero content overflowing past the clamp into it. With the clamp gone they sit within the hero's existing spacing.

## Analytics

No new event names. The hero "Sign up free" link is untracked by existing convention, and `/signup` fires `signup_role_selected` on the next step — that's the funnel branch signal. The card CTA follows the same pattern.

## Verification

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean for new code
- [x] `npm run build` **succeeds** when combined with PR #601's casing fix (verified by borrowing that branch's `shared/games` files locally, building green in 11.8s, then reverting the borrow — this PR stays scoped to `Index.tsx`)
- [ ] **Needs browser check** (can't drive DevTools from this environment): 320px / 375px — no overlap, hero flows into Early Access section cleanly; 768px / 1280px — desktop unchanged (only the brittle max-height was removed; `md:min-h` retained)
- [ ] Tap card CTA → lands on `/signup` role chooser

## Deferred (spotted nearby, not fixed here)

- `MascotHeroVisual` hides two floating badges below `md` (`hidden md:block`) — fine, but the mobile mascot circle (250px) makes the mobile hero quite tall; if mobile bounce is a concern, a future pass could shrink it below `sm`.
- The hero CTA buttons "I'm a Teacher" / "I'm a Student!" can wrap to two rows at 320px — acceptable but worth a look in a hero-focused pass.
- `npm run build` on Mac/Windows still requires PR #601's casing fix to land first.

## Stats

1 file, +25 / −4 across the branch (3 commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)