### PR TITLE
feat: /try instant playable demo — public zero-signup game + conversion funnel

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -69,8 +69,22 @@ The comment block at the top of `src/lib/analytics.ts` enforces the same rules i
 | `student_joined_class` | Student joins via class code | `class_id`, `join_method` | client + server |
 | `game_started` | Activity/game opens | `game_id`, `module_slug`, `activity_id`, `grade_band` | client only |
 | `game_completed` | Activity/game finishes (first time per student) | `game_id`, `module_slug`, `activity_id`, `score`, `time_spent_seconds`, `grade_band` | client + server |
+| `demo_page_viewed` | Public `/try` route mounts | `source` | client only |
+| `demo_game_started` | First interaction inside the demo game area (the Start Mission tap in practice) | `game_id` | client only |
+| `demo_game_completed` | Demo game finished (GameShell results → Finish) | `game_id`, `score`, `stars`, `time_spent_seconds` | client only |
+| `demo_replayed` | "Play again" on the demo conversion screen (GameShell-internal replays on its results screen are not observable without modifying GameShell — known undercount, sessions still visible in PostHog) | `game_id` | client only |
+| `demo_signup_cta_clicked` | Conversion CTA tapped on `/try` | `placement` (`results` \| `hero_teacher_whisper`) | client only |
 
 `grade_band` values: `k2`, `g3_5`, `g6_8` (whatever the student's class is set to).
+
+### Demo-funnel privacy note
+
+`/try` visitors are anonymous by design — no `identifyUser()` call fires on
+the demo path. PostHog assigns an anonymous ID and automatically stitches
+the demo session to the real identity if the visitor later signs up (when
+`identifyUser()` fires post-registration). That's what makes the
+demo → signup funnel measurable end-to-end without collecting anything
+about the visitor.
 
 ### Client-only vs. client+server
 
@@ -121,6 +135,11 @@ These steps happen in the PostHog dashboard, not in code. Do them once per envir
    - Funnel (teachers): `account_registered` (`role=teacher`) → `class_created` → `student_joined_class`.
    - Trend: `game_started` count by `game_id` (most-played).
    - Trend: completion rate = `game_completed` / `game_started`.
+   - **Demo funnel (the homepage growth lever):** `demo_page_viewed` →
+     `demo_game_started` → `demo_game_completed` → `demo_signup_cta_clicked`
+     → `account_registered`. The headline acquisition number is
+     `$pageview` (on `/`) → `account_registered`; this funnel diagnoses
+     WHERE the demo path leaks.
 2. **Retention cohort**: weekly retention on `login`.
 3. **Dashboard**: pin all of the above on a single "K-8 Funnel" dashboard so reviewers see them at a glance.
 4. **Session replay**: keep on. Confirm the masking config in `src/lib/analytics.ts` is taking effect by skimming a recording — all text and inputs should be solid blocks.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import StudentClassLogin from "./pages/StudentClassLogin";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import ForReviewers from "./pages/ForReviewers";
+import TryDemo from "./pages/TryDemo";
 import StudentBenchmark from "./pages/StudentBenchmark";
 import StudentSettings from "./pages/StudentSettings";
 import ExperimentDashboard from "./components/admin/ExperimentDashboard";
@@ -117,6 +118,10 @@ function App() {
               <Route path="/forgot-password" element={<ForgotPassword />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/showcase" element={<ShowcaseMode isPublic />} />
+              {/* Public zero-signup playable demo — the homepage growth
+                  lever from docs/audits/k8-engagement-audit.md Part 3.
+                  Must stay outside any auth-gated layout. */}
+              <Route path="/try" element={<TryDemo />} />
               <Route path="/for-reviewers" element={<ForReviewers />} />
               <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="/terms" element={<TermsOfService />} />

--- a/src/components/games/TankTrekGame.tsx
+++ b/src/components/games/TankTrekGame.tsx
@@ -45,7 +45,9 @@ interface ChapterDef {
   levels: TankTrekLevel[];
 }
 
-interface TankTrekConfig {
+// Exported so external mounts (e.g. the public /try demo) can type their
+// hardcoded level configs against the real contract.
+export interface TankTrekConfig {
   gameKey: "tank_trek";
   chapters: ChapterDef[];
 }

--- a/src/hooks/usePersonalBest.ts
+++ b/src/hooks/usePersonalBest.ts
@@ -21,6 +21,12 @@ export function usePersonalBest(gameKey: string): PersonalBest | null {
       setPb(cache.get(gameKey)!);
       return;
     }
+    // Anonymous visitors (e.g. the public /try demo) can't have personal
+    // bests — skip the authenticated fetch entirely so public surfaces
+    // stay free of 401s. GameShell hides its PB chips when pb is null.
+    if (!localStorage.getItem("bb_access_token")) {
+      return;
+    }
     let cancelled = false;
     api.getGamePersonalBests().then((bests) => {
       if (cancelled) return;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -69,7 +69,23 @@ export type AnalyticsEvent =
       quiz_score?: number;
       grade_band?: string;
     }
-  | { kind: "signup_role_selected"; role: "teacher" | "student" };
+  | { kind: "signup_role_selected"; role: "teacher" | "student" }
+  // Public /try demo funnel (anonymous visitors — no identify call; PostHog
+  // stitches the anonymous session to the user on later signup)
+  | { kind: "demo_page_viewed"; source: "direct" }
+  | { kind: "demo_game_started"; game_id: string }
+  | {
+      kind: "demo_game_completed";
+      game_id: string;
+      score: number;
+      stars: number;
+      time_spent_seconds: number;
+    }
+  | { kind: "demo_replayed"; game_id: string }
+  | {
+      kind: "demo_signup_cta_clicked";
+      placement: "results" | "hero_teacher_whisper";
+    };
 
 let initialized = false;
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1772,5 +1772,14 @@
     "logIn": "Log in",
     "haveCode": "Have a class code from your teacher?",
     "joinClass": "Join your class"
+  },
+  "tryDemo": {
+    "tagline": "A real Bright Boost game \u2014 no signup needed",
+    "resultsHeading": "You did it!",
+    "resultsPitch": "Sign up free to save your stars and unlock 9 more games.",
+    "signupCta": "Sign up free \u2192",
+    "playAgain": "Play again",
+    "teacherWhisper": "Teacher?",
+    "teacherWhisperCta": "Set up your class in under 2 minutes"
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -184,6 +184,16 @@ const Index: React.FC = () => {
                   </Link>
                 </div>
 
+                {/* Curiosity path — distinct from the intent paths above.
+                    Full-width below the pair so the 375px hero stays a
+                    two-row CTA stack, not a button wall. */}
+                <Link
+                  to="/try"
+                  className={`${chunkyPrimary} mt-3 inline-flex w-full sm:w-auto items-center justify-center bg-gradient-to-r from-emerald-500 to-teal-500`}
+                >
+                  ▶ Try a game — no signup
+                </Link>
+
                 <p className="mt-3 text-sm text-brightboost-navy">
                   New to Bright Boost?{" "}
                   <Link

--- a/src/pages/TryDemo.tsx
+++ b/src/pages/TryDemo.tsx
@@ -1,0 +1,292 @@
+/**
+ * /try — public, zero-signup playable demo (homepage growth lever).
+ *
+ * Implements Part 3 of docs/audits/k8-engagement-audit.md: a skeptical
+ * teacher lands here from a colleague's link, on a phone, with 60 seconds.
+ * One tap starts a real K-2 game (Tank Trek — the audit's no-fail gold
+ * standard); finishing lands on a "save your stars → sign up free"
+ * conversion moment. The URL itself is the share unit.
+ *
+ * ISOLATION CONTRACT (the critical property of this page):
+ *  - No auth context, no user state, no API calls. The only network
+ *    traffic permitted from this route is PostHog.
+ *  - TankTrekGame is self-contained (config + onComplete props); its
+ *    GameShell chrome reads personal bests only when a session token
+ *    exists (see usePersonalBest), so anonymous visits stay 401-free.
+ *  - Demo level config is hardcoded below — never fetched.
+ *
+ * Analytics (typed events in src/lib/analytics.ts, documented in
+ * docs/analytics.md): demo_page_viewed → demo_game_started →
+ * demo_game_completed → demo_signup_cta_clicked, plus demo_replayed.
+ * Visitors stay anonymous; PostHog stitches the session to the identity
+ * if they later sign up.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Star } from "lucide-react";
+import TankTrekGame, {
+  type TankTrekConfig,
+} from "@/components/games/TankTrekGame";
+import type { GameResult } from "@/components/games/shared/GameShell";
+import { track } from "@/lib/analytics";
+
+const DEMO_GAME_ID = "tank_trek_demo";
+
+/**
+ * Three short, winnable levels (mirrors Tank Trek chapter 1 "Learning to
+ * Move"). Hardcoded so the route has zero data dependencies. Multilingual
+ * fields follow the game's own content shape.
+ */
+const DEMO_CONFIG: TankTrekConfig = {
+  gameKey: "tank_trek",
+  chapters: [
+    {
+      id: "demo-ch1",
+      titles: {
+        en: "Learning to Move",
+        es: "Aprender a Moverse",
+        vi: "Học Di Chuyển",
+        "zh-CN": "学习移动",
+      },
+      theme: "lab",
+      levels: [
+        {
+          id: "demo-1",
+          names: { en: "Go Straight!", es: "¡Ve Recto!", vi: "Đi Thẳng!", "zh-CN": "直走！" },
+          cols: 3, rows: 3, startRow: 2, startCol: 1, startDir: "N", par: 2,
+          storySnippets: {
+            en: "Bolt just powered on! Press Forward to reach the green goal!",
+            es: "¡Bolt acaba de encenderse! ¡Presiona Adelante para llegar a la meta!",
+            vi: "Bolt vừa bật! Nhấn Tiến để đến đích xanh!",
+            "zh-CN": "Bolt启动了！按前进到达绿色目标！",
+          },
+          hints: {
+            en: "Tap Forward two times!",
+            es: "¡Toca Adelante dos veces!",
+            vi: "Nhấn Tiến hai lần!",
+            "zh-CN": "点两次前进！",
+          },
+          grid: [
+            ["wall", "goal", "wall"],
+            ["wall", "floor", "wall"],
+            ["wall", "start", "wall"],
+          ],
+        },
+        {
+          id: "demo-2",
+          names: { en: "First Turn", es: "Primer Giro", vi: "Rẽ Đầu Tiên", "zh-CN": "第一次转弯" },
+          cols: 3, rows: 3, startRow: 2, startCol: 0, startDir: "N", par: 4,
+          storySnippets: {
+            en: "The path turns! Go forward, then turn right and go forward again.",
+            es: "¡El camino gira! Avanza, gira a la derecha y avanza de nuevo.",
+            vi: "Đường rẽ! Tiến lên, rẽ phải rồi tiến tiếp.",
+            "zh-CN": "路转弯了！先前进，然后右转再前进。",
+          },
+          hints: {
+            en: "Forward, Turn Right, Forward, Forward",
+            es: "Adelante, Girar Derecha, Adelante, Adelante",
+            vi: "Tiến, Rẽ phải, Tiến, Tiến",
+            "zh-CN": "前进、右转、前进、前进",
+          },
+          grid: [
+            ["wall", "floor", "goal"],
+            ["wall", "floor", "floor"],
+            ["start", "floor", "wall"],
+          ],
+        },
+        {
+          id: "demo-3",
+          names: { en: "Turn Left", es: "Gira Izquierda", vi: "Rẽ Trái", "zh-CN": "左转" },
+          cols: 3, rows: 3, startRow: 2, startCol: 2, startDir: "N", par: 4,
+          storySnippets: {
+            en: "Now try turning left! The goal is on the other side.",
+            es: "¡Ahora gira a la izquierda! La meta está al otro lado.",
+            vi: "Bây giờ thử rẽ trái! Đích ở bên kia.",
+            "zh-CN": "现在试试左转！目标在另一边。",
+          },
+          hints: {
+            en: "Forward, Turn Left, Forward, Forward",
+            es: "Adelante, Girar Izquierda, Adelante, Adelante",
+            vi: "Tiến, Rẽ trái, Tiến, Tiến",
+            "zh-CN": "前进、左转、前进、前进",
+          },
+          grid: [
+            ["goal", "floor", "wall"],
+            ["floor", "floor", "wall"],
+            ["wall", "floor", "start"],
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function upsertMeta(name: string, content: string) {
+  let el = document.head.querySelector(
+    `meta[name="${name}"]`,
+  ) as HTMLMetaElement | null;
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute("name", name);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+export default function TryDemo() {
+  const { t } = useTranslation();
+  const [finished, setFinished] = useState<GameResult | null>(null);
+  // Remount key — bumping it restarts the game cleanly for "Play again".
+  const [playKey, setPlayKey] = useState(0);
+  const startedFired = useRef(false);
+  const startMsRef = useRef(Date.now());
+
+  useEffect(() => {
+    track({ kind: "demo_page_viewed", source: "direct" });
+    const previousTitle = document.title;
+    document.title = "Try Bright Boost — free STEM game, no signup";
+    upsertMeta(
+      "description",
+      "Play a real Bright Boost K-2 STEM game right now — free, no account needed. Program Bolt the robot through the maze!",
+    );
+    return () => {
+      document.title = previousTitle;
+    };
+  }, []);
+
+  // demo_game_started fires on the first interaction inside the game area.
+  // GameShell's briefing screen has exactly one interactive element (the
+  // Start Mission button), so the first click is the start tap in practice.
+  // Capture-phase so the game's own handlers are untouched.
+  const handleFirstInteraction = useCallback(() => {
+    if (startedFired.current) return;
+    startedFired.current = true;
+    startMsRef.current = Date.now();
+    track({ kind: "demo_game_started", game_id: DEMO_GAME_ID });
+  }, []);
+
+  const handleComplete = useCallback((result: GameResult) => {
+    track({
+      kind: "demo_game_completed",
+      game_id: DEMO_GAME_ID,
+      score: result.score,
+      stars: result.starsEarned ?? 0,
+      time_spent_seconds: Math.max(
+        1,
+        Math.round((Date.now() - startMsRef.current) / 1000),
+      ),
+    });
+    setFinished(result);
+  }, []);
+
+  const handlePlayAgain = useCallback(() => {
+    track({ kind: "demo_replayed", game_id: DEMO_GAME_ID });
+    startedFired.current = false;
+    setFinished(null);
+    setPlayKey((k) => k + 1);
+  }, []);
+
+  const stars = finished?.starsEarned ?? 0;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-brightboost-lightblue to-white">
+      {/* Slim header — logo home link + the no-signup promise */}
+      <header className="mx-auto max-w-4xl px-4 py-3 flex items-center justify-between gap-3">
+        <Link
+          to="/"
+          className="font-extrabold text-brightboost-navy tracking-tight text-lg"
+        >
+          Bright Boost
+        </Link>
+        <p className="text-xs sm:text-sm font-semibold text-brightboost-navy/80 text-right">
+          {t("tryDemo.tagline", {
+            defaultValue: "A real Bright Boost game — no signup needed",
+          })}
+        </p>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-2 sm:px-4 pb-10">
+        {finished ? (
+          /* ── State 3: results echo + conversion moment ── */
+          <div className="max-w-md mx-auto mt-8 space-y-5">
+            <div className="rounded-2xl border-2 border-[#46B1E6]/20 bg-white shadow-md p-6 text-center space-y-4">
+              <div className="flex justify-center gap-2" aria-hidden>
+                {[0, 1, 2].map((i) => (
+                  <Star
+                    key={i}
+                    className={`w-10 h-10 ${
+                      i < stars
+                        ? "text-yellow-400 fill-yellow-400"
+                        : "text-slate-200 fill-slate-100"
+                    }`}
+                  />
+                ))}
+              </div>
+              <h1 className="text-2xl font-extrabold text-brightboost-navy">
+                {t("tryDemo.resultsHeading", {
+                  defaultValue: "You did it!",
+                })}
+              </h1>
+              <p className="text-sm font-medium text-brightboost-navy/80">
+                {t("tryDemo.resultsPitch", {
+                  defaultValue:
+                    "Sign up free to save your stars and unlock 9 more games.",
+                })}
+              </p>
+              <Link
+                to="/signup"
+                onClick={() =>
+                  track({
+                    kind: "demo_signup_cta_clicked",
+                    placement: "results",
+                  })
+                }
+                className="inline-flex items-center justify-center w-full min-h-[48px] px-6 py-3 rounded-[12px] font-extrabold bg-brightboost-navy text-white hover:brightness-110 active:translate-y-[2px] button-shadow"
+              >
+                {t("tryDemo.signupCta", { defaultValue: "Sign up free →" })}
+              </Link>
+              <button
+                type="button"
+                onClick={handlePlayAgain}
+                className="inline-flex items-center justify-center w-full min-h-[44px] px-4 py-2 rounded-[12px] font-bold text-brightboost-blue hover:bg-brightboost-lightblue/30 transition-colors"
+              >
+                {t("tryDemo.playAgain", { defaultValue: "Play again" })}
+              </button>
+            </div>
+
+            {/* Teacher whisper */}
+            <p className="text-center text-sm text-brightboost-navy/70">
+              {t("tryDemo.teacherWhisper", { defaultValue: "Teacher?" })}{" "}
+              <Link
+                to="/teacher/signup"
+                onClick={() =>
+                  track({
+                    kind: "demo_signup_cta_clicked",
+                    placement: "hero_teacher_whisper",
+                  })
+                }
+                className="font-bold text-brightboost-blue underline underline-offset-2"
+              >
+                {t("tryDemo.teacherWhisperCta", {
+                  defaultValue: "Set up your class in under 2 minutes",
+                })}
+              </Link>
+            </p>
+          </div>
+        ) : (
+          /* ── States 1+2: GameShell briefing (the one-tap gate) + play ── */
+          // onClickCapture observes the first interaction without touching
+          // the game's own handlers — see handleFirstInteraction.
+          <div onClickCapture={handleFirstInteraction}>
+            <TankTrekGame
+              key={playKey}
+              config={DEMO_CONFIG}
+              onComplete={handleComplete}
+            />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/__tests__/TryDemo.test.tsx
+++ b/src/pages/__tests__/TryDemo.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * /try public demo — isolation contract tests.
+ *
+ * The page's defining property: it renders for a fully anonymous visitor
+ * with NO AuthProvider, NO api mocks, and NO fetch activity. If any of
+ * these tests start needing an auth/api mock to pass, the demo's
+ * zero-signup contract has been broken — fix the page, not the test.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import TryDemo from "../TryDemo";
+
+// Resolve i18n keys against en/common.json so assertions match real text.
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+// Track analytics calls without a PostHog key.
+const trackSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({
+  track: trackSpy,
+}));
+
+describe("TryDemo (public /try route)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    trackSpy.mockClear();
+    // Any fetch from the demo path is an isolation bug (PostHog is mocked
+    // out via the analytics mock above, so nothing should call fetch).
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function renderTry() {
+    return render(
+      <MemoryRouter initialEntries={["/try"]}>
+        <TryDemo />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders without an AuthProvider and without any fetch calls", () => {
+    renderTry();
+    // The game briefing (GameShell) is on screen — title appears in both
+    // the ActivityHeader and the briefing card.
+    expect(screen.getAllByText("Tank Trek").length).toBeGreaterThan(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the no-signup tagline and a home link", () => {
+    renderTry();
+    expect(
+      screen.getByText(/no signup needed/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /bright boost/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("fires demo_page_viewed on mount and nothing else", () => {
+    renderTry();
+    expect(trackSpy).toHaveBeenCalledWith({
+      kind: "demo_page_viewed",
+      source: "direct",
+    });
+    // No game_started yet — that needs a user interaction.
+    expect(trackSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "demo_game_started" }),
+    );
+  });
+
+  it("sets the shareable document title", () => {
+    renderTry();
+    expect(document.title).toMatch(/Try Bright Boost/);
+  });
+
+  it("offers a start affordance (GameShell briefing button)", () => {
+    renderTry();
+    // GameShell briefing renders the Start Mission button — the one-tap gate.
+    expect(
+      screen.getByRole("button", { name: /start mission/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What this is

The homepage growth lever from the engagement audit (`docs/audits/k8-engagement-audit.md` Part 3): a public, zero-signup playable demo at **`/try`** — one tap from the homepage hero into a real K-2 game, ending on a "save your stars → sign up free" conversion moment. This is the share unit for champion teachers ("just tap this") and the top-of-funnel for the 1,000-account goal.

## Demo game + isolation contract

**Tank Trek** — the audit's highest-scoring K-2 game (no-fail programming model, retry-as-mechanic, finishable in ~2-3 minutes). Config is three short winnable levels (chapter 1 "Learning to Move"), **hardcoded** in the route against the newly-exported `TankTrekConfig` type — zero data dependencies.

The one isolation leak found and fixed: `usePersonalBest` (used by GameShell) fired an authenticated `GET /api/game/personal-bests` that would 401 for every anonymous visitor. It now skips the fetch when no `bb_access_token` exists — correct everywhere, since anonymous users can't have personal bests. GameShell's PB chips already hide on `null`.

**Isolation is enforced by test**: `TryDemo.test.tsx` renders the page with **no AuthProvider** and a **fetch spy asserting zero network calls**. If a future change breaks the zero-signup contract, CI goes red.

## Mount approach

Full `TankTrekGame` (which embeds GameShell) rather than a stripped wrapper — this gets the existing briefing screen (the spec's one-tap "▶ Play" gate = GameShell's Start Mission) and the existing star-reveal/count-up celebration for State 3's "celebrate first" requirement, with zero duplication and zero game modifications.

## The three states

1. **Instant start** — slim header (logo → home, "A real Bright Boost game — no signup needed") + GameShell briefing. One tap to play.
2. **Playing** — the game, `max-w-4xl`, mobile-first (Tank Trek's command buttons are its existing touch targets).
3. **Results + conversion** — GameShell's stars/score celebration → Finish → conversion card: star echo, *"Sign up free to save your stars and unlock 9 more games"*, 48px primary CTA → `/signup`, low-key "Play again" (full remount), teacher whisper → `/teacher/signup`.

## Homepage entry

"▶ Try a game — no signup" (emerald, visually distinct from the blue/purple intent CTAs) directly under the teacher/student pair — **full-width on mobile** so the 375px hero reads as a two-row stack + one banner, not a button wall. Hero otherwise untouched; Early Access card left pointing at `/signup` (changing its intent felt out of scope — flag if you want it pointed at `/try`).

## Analytics (typed, documented)

New union variants + `docs/analytics.md` taxonomy rows + the funnel insight to create:

`demo_page_viewed` → `demo_game_started` → `demo_game_completed` → `demo_signup_cta_clicked` → `account_registered`

- `demo_game_started` fires on first interaction in the game area (capture-phase listener; the briefing's only interactive element is the Start button)
- `demo_replayed` fires from the conversion screen's Play Again — GameShell's internal results-screen replay is not observable without modifying GameShell; documented as a known undercount
- **No identify call** — demo visitors stay anonymous; PostHog stitches the anonymous session to the identity at later signup (that's what makes the funnel measurable end-to-end). Same COPPA posture as everywhere.

## Bundle impact

The codebase doesn't code-split (all 70 route imports are eager) and Tank Trek is **already in the main bundle** via ActivityPlayer's registry import — the demo adds only the ~300-line page wrapper. Lazy-loading the route would save nothing today; noted in the commit for whenever route-splitting lands.

## Verification

- [x] `npm run lint` / `npm run typecheck` clean · `npm run build` 11.8s
- [x] vitest: **283 passed / 0 failed / 19 skipped** (278 baseline + 5 new TryDemo tests)
- [x] Static check: no `useAuth`/`AuthContext`/`api.`/`fetch(` in the demo path
- [x] Isolation test: zero fetch calls, no AuthProvider needed
- [x] Dev-server smoke: `/try` serves 200
- [ ] **User follow-ups after merge + deploy:**
  - Browser walk at 320/375px: play to completion → CTA lands on `/signup`; logged-in visit to `/try` also works
  - **Create the PostHog demo-funnel insight** (documented in `docs/analytics.md` → "PostHog UI setup")

## Stats

9 files, +451 / −2. The page itself is ~290 lines, most of which is the hardcoded 3-level demo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)