### PR TITLE
fix: Chip Collector solvable + programmatic solvability guard for all Tank Trek levels

### DIFF
--- a/src/components/games/TankTrekGame.tsx
+++ b/src/components/games/TankTrekGame.tsx
@@ -171,7 +171,10 @@ export function buildTankTrekCompletionPayload(params: {
 
 // ── Built-in Levels ────────────────────────────────────────────────────────
 
-const BUILTIN_LEVELS: TankTrekConfig = {
+// Exported for the solvability guard test (src/components/games/__tests__)
+// which programmatically proves every level is completable within its
+// maxCommands cap and that 3 stars is reachable. Not used outside tests.
+export const BUILTIN_LEVELS: TankTrekConfig = {
   gameKey: "tank_trek",
   chapters: [
     {

--- a/src/components/games/__tests__/TankTrekSolvability.test.ts
+++ b/src/components/games/__tests__/TankTrekSolvability.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tank Trek solvability guard — every level in every catalog must be
+ * programmatically provably completable, within its own command cap, with
+ * 3 stars reachable. Hand-authored levels broke once (g35-2-1 "Chip
+ * Collector" shipped with chips uncollectable inside its maxCommands cap);
+ * this guard turns the next authoring mistake into red CI instead of a
+ * production dead-end for a grade-3-5 student.
+ *
+ * Contract per level (matching the game's actual semantics — completion =
+ * reach the goal; chips are collectibles, sometimes on optional branches):
+ *  1. The FULL objective (every chip + goal) is geometrically reachable.
+ *  2. GOAL completion fits within maxCommands with ≥2 commands of headroom
+ *     (a cap equal to the only solution leaves zero room to think).
+ *  3. The FULL objective also fits within maxCommands with headroom —
+ *     chips must never be a trap a kid can chase but not finish.
+ *  4. 3 stars (forwards ≤ par) is reachable on the goal objective — pars
+ *     are authored as shortest-path footstep counts (see PR #605).
+ *  5. The full-objective route earns ≥2 stars (forwards ≤ par + 2) —
+ *     collecting everything must never feel like punishment.
+ */
+import { describe, expect, it } from "vitest";
+import { BUILTIN_LEVELS } from "../TankTrekGame";
+import { TANK_TREK_G35_LEVELS } from "../gradeBandContent";
+import { DEMO_CONFIG } from "@/pages/TryDemo";
+import {
+  solveTankLevel,
+  type SolvableLevel,
+} from "@/test/tankTrekSolver";
+
+interface CatalogEntry {
+  catalog: string;
+  level: SolvableLevel;
+}
+
+function collect(): CatalogEntry[] {
+  const entries: CatalogEntry[] = [];
+  for (const ch of BUILTIN_LEVELS.chapters) {
+    for (const level of ch.levels) {
+      entries.push({ catalog: "builtin", level: level as SolvableLevel });
+    }
+  }
+  for (const ch of TANK_TREK_G35_LEVELS.chapters) {
+    for (const level of ch.levels) {
+      entries.push({ catalog: "g35", level: level as unknown as SolvableLevel });
+    }
+  }
+  for (const ch of DEMO_CONFIG.chapters) {
+    for (const level of ch.levels) {
+      entries.push({ catalog: "demo", level: level as SolvableLevel });
+    }
+  }
+  return entries;
+}
+
+describe("Tank Trek level solvability guard", () => {
+  const entries = collect();
+
+  it("covers all catalogs (builtin + g35 + /try demo)", () => {
+    const catalogs = new Set(entries.map((e) => e.catalog));
+    expect(catalogs).toEqual(new Set(["builtin", "g35", "demo"]));
+    expect(entries.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(entries.map((e) => [`${e.catalog}/${e.level.id}`, e] as const))(
+    "%s: solvable within cap, 3 stars reachable, chips never a trap",
+    (_name, entry) => {
+      const { level } = entry;
+      const goal = solveTankLevel(level, "goal");
+      const full = solveTankLevel(level, "full");
+
+      // 1. Reachability — both the goal and the full objective.
+      expect(
+        goal,
+        `${level.id}: the goal is UNREACHABLE — check the grid`,
+      ).not.toBeNull();
+      expect(
+        full,
+        `${level.id}: the full objective (all chips + goal) is UNREACHABLE — a chip is walled off`,
+      ).not.toBeNull();
+
+      // 2 + 3. Cap fits with ≥2 headroom — for completion AND for chips.
+      if (level.maxCommands !== undefined) {
+        expect(
+          goal!.minTotalCommands,
+          `${level.id}: completing needs ${goal!.minTotalCommands} commands but maxCommands is ${level.maxCommands} — dead-end (or zero thinking room)`,
+        ).toBeLessThanOrEqual(level.maxCommands - 2);
+        expect(
+          full!.minTotalCommands,
+          `${level.id}: collecting all chips needs ${full!.minTotalCommands} commands but maxCommands is ${level.maxCommands} — the chips are a trap`,
+        ).toBeLessThanOrEqual(level.maxCommands - 2);
+      }
+
+      // 4. 3 stars reachable (goal objective; pars are footstep counts).
+      expect(
+        level.par,
+        `${level.id}: missing par — author it as the optimal forward-move count (${goal!.minForwardMoves})`,
+      ).toBeDefined();
+      expect(
+        goal!.minForwardMoves,
+        `${level.id}: optimal completion uses ${goal!.minForwardMoves} forward moves but par is ${level.par} — 3 stars is unreachable`,
+      ).toBeLessThanOrEqual(level.par!);
+
+      // 5. Full-objective route earns ≥2 stars.
+      expect(
+        full!.minForwardMoves,
+        `${level.id}: the all-chips route uses ${full!.minForwardMoves} forwards vs par ${level.par} — collecting everything would rate only 1 star`,
+      ).toBeLessThanOrEqual(level.par! + 2);
+    },
+  );
+
+  it("prints the proof table (informational)", () => {
+    const rows = entries.map(({ catalog, level }) => {
+      const goal = solveTankLevel(level, "goal");
+      const full = solveTankLevel(level, "full");
+      return {
+        level: `${catalog}/${level.id}`,
+        goalCmds: goal?.minTotalCommands ?? "UNREACHABLE",
+        fullCmds: full?.minTotalCommands ?? "UNREACHABLE",
+        cap: level.maxCommands ?? "—",
+        capMargin:
+          full && level.maxCommands !== undefined
+            ? level.maxCommands - full.minTotalCommands
+            : "—",
+        goalFwd: goal?.minForwardMoves ?? "—",
+        fullFwd: full?.minForwardMoves ?? "—",
+        par: level.par ?? "—",
+        threeStar:
+          goal && level.par !== undefined && goal.minForwardMoves <= level.par
+            ? "yes"
+            : "NO",
+      };
+    });
+    console.table(rows);
+    expect(rows.length).toBe(entries.length);
+  });
+});

--- a/src/components/games/gradeBandContent.ts
+++ b/src/components/games/gradeBandContent.ts
@@ -166,7 +166,14 @@ export const TANK_TREK_G35_LEVELS = {
         {
           id: "g35-2-1",
           names: { en: "Chip Collector", es: "Colector de Chips", vi: "Thu Thập Chip", "zh-CN": "芯片收集者" },
-          cols: 5, rows: 5, startRow: 4, startCol: 0, startDir: "E" as const, par: 10, maxCommands: 12,
+          // Solver-derived (see TankTrekSolvability.test.ts): collecting both
+          // chips + reaching the goal takes a minimum of 20 commands
+          // (12 forwards + 8 turns). The original maxCommands: 12 made the
+          // level's own stated objective impossible. Cap = 25 (~1.25× the
+          // optimal, matching the chapter's optimal-to-cap ratio); par = 12
+          // = optimal full-route forwards, so chip collectors — the point of
+          // the level — earn 3 stars.
+          cols: 5, rows: 5, startRow: 4, startCol: 0, startDir: "E" as const, par: 12, maxCommands: 25,
           storySnippets: { en: "Collect all data chips AND reach the goal in minimum moves!", es: "¡Recoge todos los chips Y llega a la meta con el mínimo de movimientos!", vi: "Thu thập tất cả chip DÀ đến đích với ít bước nhất!", "zh-CN": "收集所有芯片并用最少步数到达目标！" },
           hints: { en: "Plan to collect chips along the way, not as detours", es: "Planifica recoger chips en el camino, no como desvíos", vi: "Lên kế hoạch nhặt chip dọc đường, không đi vòng", "zh-CN": "计划沿途收集芯片，不要绕路" },
           grid: [["wall","wall","wall","floor","goal"],["floor","chip","wall","floor","floor"],["floor","floor","floor","floor","wall"],["wall","floor","wall","chip","floor"],["start","floor","floor","wall","wall"]],

--- a/src/pages/TryDemo.tsx
+++ b/src/pages/TryDemo.tsx
@@ -38,7 +38,9 @@ const DEMO_GAME_ID = "tank_trek_demo";
  * Move"). Hardcoded so the route has zero data dependencies. Multilingual
  * fields follow the game's own content shape.
  */
-const DEMO_CONFIG: TankTrekConfig = {
+// Exported for the Tank Trek solvability guard test — the demo levels are
+// copies of chapter 1 and could drift; the guard keeps them honest too.
+export const DEMO_CONFIG: TankTrekConfig = {
   gameKey: "tank_trek",
   chapters: [
     {

--- a/src/test/tankTrekSolver.ts
+++ b/src/test/tankTrekSolver.ts
@@ -1,0 +1,193 @@
+/**
+ * Tank Trek solvability solver — TEST UTILITY ONLY (never import from game
+ * code; lives under src/test so it stays out of the app bundle).
+ *
+ * Mirrors the game's exact execution mechanics
+ * (src/components/games/TankTrekGame.tsx run loop):
+ *  - Commands: FWD (move one cell in facing direction), LEFT, RIGHT.
+ *    Every command — including turns — counts toward maxCommands.
+ *  - FWD into a wall or off-grid ends the run as a failure, so valid
+ *    solutions only ever make legal moves.
+ *  - Chips collect when the robot ENTERS their cell (latched in a set).
+ *  - Crossing the goal LATCHES reachedGoal but does NOT stop execution —
+ *    so chips may be collected before or after the goal crossing. The
+ *    solver therefore tracks goal-visited as a latch bit, not a terminal.
+ *  - "switch"/"gate" cell types exist in the type union but have no
+ *    handling in the executor — the game treats them as floor, so the
+ *    solver does too.
+ *
+ * Completion objective verified: ALL chips collected AND goal visited.
+ *
+ * Two metrics per level:
+ *  - minimal TOTAL commands (BFS, every command costs 1)
+ *      → must be ≤ maxCommands (when a cap exists)
+ *  - minimal FORWARD moves over complete solutions (0-1 BFS: turns cost 0)
+ *      → must be ≤ par, i.e. 3 stars must be reachable while doing the
+ *        full objective (extends PR #605's star contract to all content)
+ */
+
+type Dir = "N" | "E" | "S" | "W";
+
+export interface SolvableLevel {
+  id: string;
+  cols: number;
+  rows: number;
+  grid: string[][];
+  startRow: number;
+  startCol: number;
+  startDir: Dir;
+  maxCommands?: number;
+  par?: number;
+}
+
+export interface SolveResult {
+  /** Minimal total command count (forwards + turns) for the full objective. */
+  minTotalCommands: number;
+  /** Minimal forward-move count over all complete solutions. */
+  minForwardMoves: number;
+}
+
+const DIR_DELTA: Record<Dir, [number, number]> = {
+  N: [-1, 0],
+  E: [0, 1],
+  S: [1, 0],
+  W: [0, -1],
+};
+const TURN_LEFT: Record<Dir, Dir> = { N: "W", W: "S", S: "E", E: "N" };
+const TURN_RIGHT: Record<Dir, Dir> = { N: "E", E: "S", S: "W", W: "N" };
+const DIRS: Dir[] = ["N", "E", "S", "W"];
+
+interface Searched {
+  r: number;
+  c: number;
+  d: Dir;
+  mask: number;
+  goal: boolean;
+}
+
+function encode(s: Searched, chipCount: number): number {
+  // r,c ≤ 7 bits is plenty for our grids; mask up to chipCount bits; goal 1 bit.
+  const dirIdx = DIRS.indexOf(s.d);
+  return (
+    (((s.r * 32 + s.c) * 4 + dirIdx) * (1 << chipCount) + s.mask) * 2 +
+    (s.goal ? 1 : 0)
+  );
+}
+
+export type Objective = "goal" | "full";
+
+/**
+ * Generic shortest-path over the level's state space with a configurable
+ * cost per command type. cost=1/1 → minimal total commands (plain BFS);
+ * cost fwd=1, turn=0 → minimal forwards (0-1 BFS via deque).
+ *
+ * objective "goal" = the game's hard completion semantics (chips optional);
+ * objective "full" = all chips collected AND goal visited (the level's
+ * stated objective for chip levels — chips must never be a trap).
+ */
+function shortestPath(
+  level: SolvableLevel,
+  fwdCost: number,
+  turnCost: number,
+  objective: Objective,
+): number | null {
+  const chips: Array<[number, number]> = [];
+  for (let r = 0; r < level.rows; r++) {
+    for (let c = 0; c < level.cols; c++) {
+      if (level.grid[r][c] === "chip") chips.push([r, c]);
+    }
+  }
+  const chipCount = chips.length;
+  const chipIndex = new Map<string, number>(
+    chips.map(([r, c], i) => [`${r}-${c}`, i]),
+  );
+  const fullMask = (1 << chipCount) - 1;
+
+  const start: Searched = {
+    r: level.startRow,
+    c: level.startCol,
+    d: level.startDir,
+    mask: 0,
+    goal: level.grid[level.startRow][level.startCol] === "goal",
+  };
+
+  // 0-1 BFS deque: states with 0-cost edges go to the front. Relaxation
+  // re-enqueues on improvement (SPFA-style), so we run to exhaustion and
+  // take the best satisfying distance rather than early-returning — state
+  // spaces here are tiny (≤ ~800 states), correctness over micro-speed.
+  const dist = new Map<number, number>();
+  const deque: Searched[] = [start];
+  dist.set(encode(start, chipCount), 0);
+  let best: number | null = null;
+
+  while (deque.length > 0) {
+    const cur = deque.shift()!;
+    const curKey = encode(cur, chipCount);
+    const curDist = dist.get(curKey)!;
+
+    const satisfied =
+      cur.goal && (objective === "goal" || cur.mask === fullMask);
+    if (satisfied) {
+      if (best === null || curDist < best) best = curDist;
+      continue;
+    }
+    if (best !== null && curDist >= best) continue;
+
+    // Turns
+    for (const nd of [TURN_LEFT[cur.d], TURN_RIGHT[cur.d]]) {
+      const next: Searched = { ...cur, d: nd };
+      const key = encode(next, chipCount);
+      const nDist = curDist + turnCost;
+      if (!dist.has(key) || dist.get(key)! > nDist) {
+        dist.set(key, nDist);
+        if (turnCost === 0) deque.unshift(next);
+        else deque.push(next);
+      }
+    }
+
+    // Forward
+    const [dr, dc] = DIR_DELTA[cur.d];
+    const nr = cur.r + dr;
+    const nc = cur.c + dc;
+    if (
+      nr >= 0 &&
+      nr < level.rows &&
+      nc >= 0 &&
+      nc < level.cols &&
+      level.grid[nr][nc] !== "wall"
+    ) {
+      const cell = level.grid[nr][nc];
+      const chipIdx = chipIndex.get(`${nr}-${nc}`);
+      const next: Searched = {
+        r: nr,
+        c: nc,
+        d: cur.d,
+        mask: chipIdx !== undefined ? cur.mask | (1 << chipIdx) : cur.mask,
+        goal: cur.goal || cell === "goal",
+      };
+      const key = encode(next, chipCount);
+      const nDist = curDist + fwdCost;
+      if (!dist.has(key) || dist.get(key)! > nDist) {
+        dist.set(key, nDist);
+        deque.push(next);
+      }
+    }
+  }
+
+  return best; // null = objective unreachable
+}
+
+/**
+ * Solve a level for the given objective. Returns null when the objective
+ * is unreachable regardless of program length.
+ */
+export function solveTankLevel(
+  level: SolvableLevel,
+  objective: Objective = "full",
+): SolveResult | null {
+  const minTotalCommands = shortestPath(level, 1, 1, objective);
+  if (minTotalCommands === null) return null;
+  const minForwardMoves = shortestPath(level, 1, 0, objective);
+  if (minForwardMoves === null) return null;
+  return { minTotalCommands, minForwardMoves };
+}


### PR DESCRIPTION
## The bug (found in PR #605's sweep, now solver-proven)

**g35-2-1 "Chip Collector" was unsolvable as shipped.** Its stated objective — "Collect all data chips AND reach the goal" — requires a minimum of **20 commands (12 forwards + 8 turns)** against the level's own `maxCommands: 12`. Margin: **−8**. Every grade 3-5 student who chased the chips hit a guaranteed dead-end; goal-only completion fit at *exactly* 12 commands with zero room to think.

## The proof is mechanized

A BFS solver (`src/test/tankTrekSolver.ts` — test-only, never bundled) mirrors the game's exact run-loop semantics, including the subtle one: **crossing the goal latches `reachedGoal` but does not stop execution** (verified in the executor), so chips may legally be collected after the goal crossing — the solver tracks goal-visited as a state bit. Turns count toward the cap (as the game enforces); forwards-only is the star metric (post-#605).

### The proof table (all 13 levels across all 3 catalogs)

| Level | goalCmds | fullCmds | cap | margin | goalFwd | par | 3⭐ |
| --- | --- | --- | --- | --- | --- | --- | --- |
| builtin/1-1 | 2 | 2 | — | — | 2 | 2 | ✅ |
| builtin/1-2 | 7 | 7 | — | — | 4 | 4 | ✅ |
| builtin/1-3 | 7 | 7 | — | — | 4 | 4 | ✅ |
| builtin/2-1 | 9 | 9 | — | — | 5 | 6 | ✅ |
| builtin/2-2 | 8 | 8 | — | — | 5 | 5 | ✅ |
| builtin/3-1 | 7 | 7 | — | — | 5 | 6 | ✅ |
| builtin/3-2 | 8 | 8 | 10 | +2 | 6 | 8 | ✅ |
| g35/g35-1-1 | 10 | 10 | — | — | 6 | 6 | ✅ |
| g35/g35-1-2 | 10 | 13 | — | — | 7 | 8 | ✅ |
| **g35/g35-2-1 (fixed)** | 12 | **20** | **25** | **+5** | 8 | **12** | ✅ |
| demo/demo-1..3 | 2/7/7 | same | — | — | 2/4/4 | 2/4/4 | ✅ |

## The fix (minimal — cap + par, grid untouched)

- `maxCommands: 12 → 25` (~1.25× the 20-command optimum, matching the chapter's existing optimal-to-cap ratio — builtin 3-2 is 8 vs cap 10)
- `par: 10 → 12` = optimal full-route forwards, so **chip collectors — the point of a level named Chip Collector — earn 3 stars**; the goal-only speedrun (8 fwd) also rates 3⭐

The layout was sound; the cap was mis-authored.

## The guard (15 new tests)

`TankTrekSolvability.test.ts` asserts for **every level** in `BUILTIN_LEVELS` + `TANK_TREK_G35_LEVELS` + the `/try` `DEMO_CONFIG` (both now exported for tests):

1. Full objective geometrically reachable (no walled-off chips)
2. Goal completion ≤ `maxCommands − 2` (no dead-ends, with thinking room)
3. Full objective ≤ `maxCommands − 2` (**chips are never a trap**)
4. Goal-optimal forwards ≤ par (3⭐ reachable — extends #605's star contract to all shipped content)
5. Full-route forwards ≤ par + 2 (collecting everything never rates 1⭐)

Plus an informational test printing the proof table on every CI run. **The next mis-authored level turns CI red instead of dead-ending a student in production.**

## Other solver findings (no fixes needed)

- **g35-1-2 "Debug the Route"**: the solver found a 7-forward goal route — *better than #605's hand-derived 8*, which is exactly why mechanized proof beats hand-math. 3⭐ comfortably reachable; the chip path (9 fwd) rates 2⭐ by design ("two paths — one is shorter").
- All K-2 + demo levels: chips sit on the only path, goal ≡ full objective, all pars achievable post-#605.

## Verification

- [x] lint / typecheck clean · build 12.5s
- [x] vitest **303 passed / 0 failed / 19 skipped** (288 baseline + 15 guard)
- [ ] **User step:** play g35-2-1 in a browser (logged-in g3_5 account, e.g. jordan@test.com) — collect both chips + goal within the cap; optimal-ish run shows 3⭐

## Stats

5 files, +344 / −3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)