### PR TITLE
fix: class-code sign-in asks for code only once (remove double-entry)

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -227,6 +227,7 @@
     "hiName": "Hi, {{name}}!",
     "go": "Go!",
     "backToHome": "Back to Home",
+    "loadingClass": "Finding your class…",
     "error": {
       "typeCode": "Type your class code!",
       "noStudents": "No students set up yet. Ask your teacher!",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -227,6 +227,7 @@
     "hiName": "¡Hola, {{name}}!",
     "go": "¡Vamos!",
     "backToHome": "Volver al inicio",
+    "loadingClass": "Buscando tu clase…",
     "error": {
       "typeCode": "¡Escribe tu código de clase!",
       "noStudents": "¡No hay estudiantes listos todavía. Pregúntale a tu profe!",

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -227,6 +227,7 @@
     "hiName": "Chào, {{name}}!",
     "go": "Đi thôi!",
     "backToHome": "Về trang chủ",
+    "loadingClass": "Đang tìm lớp của con…",
     "error": {
       "typeCode": "Nhập mã lớp của con!",
       "noStudents": "Chưa có học sinh nào. Hỏi cô giáo nhé!",

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -227,6 +227,7 @@
     "hiName": "你好，{{name}}！",
     "go": "出发！",
     "backToHome": "回到首页",
+    "loadingClass": "正在查找你的班级…",
     "error": {
       "typeCode": "请输入你的班级代码！",
       "noStudents": "还没有设置学生，问问你的老师！",

--- a/src/pages/StudentClassLogin.tsx
+++ b/src/pages/StudentClassLogin.tsx
@@ -1,6 +1,6 @@
 // src/pages/StudentClassLogin.tsx
 import { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../contexts/AuthContext";
 import { API_BASE, join } from "../services/api";
@@ -71,24 +71,33 @@ const LAST_CLASS_CODE_KEY = "bb_last_class_code";
 export default function StudentClassLogin() {
   const { t } = useTranslation();
   const { login } = useAuth();
+  const [searchParams] = useSearchParams();
+  // A class code may arrive from the unified login (/student-login) as
+  // `?code=STARS1`. If present, the student already typed it there — consume
+  // it here instead of asking for the code a second time.
+  const urlCode = (searchParams.get("code") || "").toUpperCase().trim();
   const [step, setStep] = useState<Step>("code");
   const [classCode, setClassCode] = useState(
-    () => localStorage.getItem(LAST_CLASS_CODE_KEY) || "",
+    () => urlCode || localStorage.getItem(LAST_CLASS_CODE_KEY) || "",
   );
   const [classInfo, setClassInfo] = useState<ClassInfo | null>(null);
   const [selectedStudent, setSelectedStudent] = useState<ClassInfo["students"][0] | null>(null);
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  // True while we auto-resolve a code passed in via ?code= — shows a spinner
+  // instead of the code form so the student isn't re-prompted.
+  const [bootstrapping, setBootstrapping] = useState(() => urlCode.length >= 3);
 
   // Clear error when step changes
   useEffect(() => {
     setError("");
   }, [step]);
 
-  // Step 1: Enter class code
-  const handleCodeSubmit = async () => {
-    const code = classCode.toUpperCase().trim();
+  // Step 1: Resolve a class code → advance to the icon picker. Shared by the
+  // manual form (handleCodeSubmit) and the auto-advance effect below.
+  const lookupClass = async (rawCode: string) => {
+    const code = rawCode.toUpperCase().trim();
     if (code.length < 3) {
       setError(t("classLogin.error.typeCode"));
       return;
@@ -110,6 +119,19 @@ export default function StudentClassLogin() {
       setLoading(false);
     }
   };
+
+  const handleCodeSubmit = () => lookupClass(classCode);
+
+  // Arrived from /student-login with a class code already entered? Resolve it
+  // immediately and skip the redundant code screen, landing straight on the
+  // icon picker. On failure, fall back to the code step with an inline error
+  // (the code stays pre-filled) — never a dead end.
+  useEffect(() => {
+    if (urlCode.length >= 3) {
+      lookupClass(urlCode).finally(() => setBootstrapping(false));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Step 2: Pick icon → auto-advance to PIN or login
   const handleIconSelect = (student: ClassInfo["students"][0]) => {
@@ -154,8 +176,18 @@ export default function StudentClassLogin() {
           <LanguageToggle />
         </div>
         <div className="game-card p-8 w-full max-w-lg ui-sheen">
+          {/* Auto-resolving a code passed in from the unified login */}
+          {bootstrapping && step === "code" && (
+            <div className="flex flex-col items-center justify-center py-12 gap-4">
+              <Loader2 className="w-10 h-10 animate-spin text-brightboost-blue" />
+              <p className="text-sm text-gray-500">
+                {t("classLogin.loadingClass")}
+              </p>
+            </div>
+          )}
+
           {/* Step 1: Enter Class Code */}
-          {step === "code" && (
+          {step === "code" && !bootstrapping && (
             <div className="text-center space-y-6">
               <div>
                 <span className="text-5xl mb-2 block">🏫</span>

--- a/src/pages/__tests__/StudentClassLogin.test.tsx
+++ b/src/pages/__tests__/StudentClassLogin.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+import StudentClassLogin from "../StudentClassLogin";
+
+// Resolve i18n keys to real English text so assertions match the UI.
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+// Auth context — we only need a stable `login` stub for this flow.
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ login: vi.fn() }),
+}));
+
+// Presentational shells — keep the test focused on the code-entry logic.
+vi.mock("../../components/GameBackground", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../../components/LanguageToggle", () => ({ default: () => null }));
+
+const mockClass = {
+  courseId: "course-1",
+  className: "Ms. Frizzle's Class",
+  teacherName: "Ms. Frizzle",
+  defaultLanguage: "en",
+  students: [{ id: "s1", name: "Ada Lovelace", loginIcon: "🦊", hasPin: false }],
+};
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/class-login" element={<StudentClassLogin />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("StudentClassLogin — single code entry", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    global.fetch = vi.fn((url: RequestInfo | URL) => {
+      if (String(url).includes("/classes/by-code/")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockClass),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      } as Response);
+    }) as unknown as typeof fetch;
+  });
+
+  it("consumes ?code= from the unified login and skips the code screen", async () => {
+    renderAt("/class-login?code=STARS1");
+
+    // Lands straight on the icon picker — the code screen is never shown.
+    expect(await screen.findByText("Find your icon!")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("ABC123")).toBeNull();
+
+    // It looked the class up using the code carried over in the URL.
+    const calledUrls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => String(c[0]),
+    );
+    expect(calledUrls.some((u) => u.includes("/classes/by-code/STARS1"))).toBe(true);
+  });
+
+  it("still asks for the code when none is supplied (direct visit)", () => {
+    renderAt("/class-login");
+
+    // Code screen renders, and no lookup fires until the student submits.
+    expect(screen.getByPlaceholderText("ABC123")).toBeInTheDocument();
+    expect(screen.queryByText("Find your icon!")).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug

Signing in with a class code asked for the code **twice**. On `/student-login` (`LoginSelection`) the student types the code → it `navigate`s to `/class-login?code=STARS1` → but `StudentClassLogin` **never read the `code` query param**. It initialized from `localStorage` (empty for a new student) and started at the code step, re-prompting for a code the student had just typed. Every extra step bleeds activation, and this is on the student activation path.

## Root cause

**(A) — code captured on screen 1, not consumed on screen 2.** `LoginSelection` already passes the code in the URL; `StudentClassLogin` ignored it.

(For the record: `JoinClass` / `student_joined_class` is a *separate, authenticated enrollment* flow with a single code entry — not part of this sign-in path and not affected.)

## Fix (`src/pages/StudentClassLogin.tsx`)

- Read `?code=` via `useSearchParams`, pre-fill `classCode` from it.
- On mount, if a valid code is present, auto-resolve the class and jump straight to the **icon picker** — skipping the redundant code screen. A small spinner (`classLogin.loadingClass`) shows during the lookup so the code form never flashes.
- On an **invalid** code: fall back to the code step with the code pre-filled and an inline error — never a dead end.
- Direct visits to `/class-login` (no param) are unchanged; the code step still renders.
- COPPA posture preserved — no new fields. New i18n key added to en/es/vi/zh-CN.

## Flow now (one code entry)

`/student-login` → type code once → lookup → **`/class-login?code=…`** → auto-resolves → **pick icon** → (PIN if set) → in class. The student is never asked for the code a second time.

## Tests / CI

- New `src/pages/__tests__/StudentClassLogin.test.tsx`: asserts `?code=` skips the code screen (lands on icon picker, no code input) and that the no-code path still prompts. 2 passing.
- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run build` ✅ · unit suite ✅ (335 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
