### PR TITLE
fix: 3-5 band routing (block removed modules at route) + sequencing button contrast

### DIFF
--- a/src/components/games/BoostPathPlannerGame.tsx
+++ b/src/components/games/BoostPathPlannerGame.tsx
@@ -232,19 +232,19 @@ export default function BoostPathPlannerGame({
             <p className="mb-2 text-sm font-semibold">{t("games.boostPath.buildProgram")}</p>
             <div className="flex flex-wrap gap-2">
               <button
-                className="rounded-lg border px-3 py-2"
+                className="rounded-lg border bg-white px-3 py-2 text-slate-900 hover:bg-slate-100"
                 onClick={() => addCommand("F")}
               >
                 {t("games.boostPath.forward")}
               </button>
               <button
-                className="rounded-lg border px-3 py-2"
+                className="rounded-lg border bg-white px-3 py-2 text-slate-900 hover:bg-slate-100"
                 onClick={() => addCommand("L")}
               >
                 {t("games.boostPath.turnLeft")}
               </button>
               <button
-                className="rounded-lg border px-3 py-2"
+                className="rounded-lg border bg-white px-3 py-2 text-slate-900 hover:bg-slate-100"
                 onClick={() => addCommand("R")}
               >
                 {t("games.boostPath.turnRight")}
@@ -269,7 +269,7 @@ export default function BoostPathPlannerGame({
               {t("games.boostPath.run")}
             </button>
             <button
-              className="rounded-lg border px-4 py-2"
+              className="rounded-lg border bg-white px-4 py-2 text-slate-900 hover:bg-slate-100"
               onClick={clearProgram}
             >
               {t("games.boostPath.clear")}

--- a/src/pages/ActivityPlayer.tsx
+++ b/src/pages/ActivityPlayer.tsx
@@ -15,6 +15,7 @@ import {
   canAccessModule,
   isSpecializationModuleSlug,
 } from "@/lib/moduleAccess";
+import { HIDDEN_MODULE_SLUGS } from "@/constants/stemSets";
 import { Check, Zap, Heart, Star, ArrowRight, TreePine } from "lucide-react";
 import {
   Dialog,
@@ -157,6 +158,14 @@ export default function ActivityPlayer() {
 
   useEffect(() => {
     if (!slug || !lessonId || !activityId) return;
+
+    // Removed/archived modules (e.g. lost-steps / "Fix the Order") are hidden
+    // from the module list but were still reachable by direct URL — block the
+    // activity route too so they can't open into a broken half-state.
+    if (HIDDEN_MODULE_SLUGS.has(slug)) {
+      navigate("/student/modules", { replace: true });
+      return;
+    }
 
     setLoading(true);
     // clear stale content to avoid "half-loaded" UI when rate-limited

--- a/src/pages/ModuleDetail.tsx
+++ b/src/pages/ModuleDetail.tsx
@@ -14,6 +14,7 @@ import {
   isSpecializationModuleSlug,
 } from "@/lib/moduleAccess";
 import { translateContentName } from "@/utils/localizedContent";
+import { HIDDEN_MODULE_SLUGS } from "@/constants/stemSets";
 
 export default function ModuleDetail() {
   const { slug } = useParams();
@@ -27,6 +28,14 @@ export default function ModuleDetail() {
 
   useEffect(() => {
     if (!slug) return;
+
+    // Removed/archived modules (e.g. "Fix the Order" / lost-steps) are
+    // filtered from the module list but were still reachable by direct URL.
+    // Block the route too so a dead module can't be opened.
+    if (HIDDEN_MODULE_SLUGS.has(slug)) {
+      navigate("/student/modules", { replace: true });
+      return;
+    }
 
     // Guard: if the module requires specialization, check archetype first
     if (isSpecializationModuleSlug(slug)) {

--- a/src/pages/__tests__/ModuleDetailHiddenGuard.test.tsx
+++ b/src/pages/__tests__/ModuleDetailHiddenGuard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+import ModuleDetail from "../ModuleDetail";
+
+// Removed/archived modules (HIDDEN_MODULE_SLUGS) were filtered from the module
+// list but still reachable by direct URL — that's how a 3-5 student (jordan)
+// landed on the removed `k2-stem-sequencing` / lost-steps activity. This pins
+// the route-level guard that now blocks them.
+
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+// getModule kept pending so a non-hidden slug stays on the loading state
+// (and therefore visibly does NOT redirect).
+vi.mock("@/services/api", () => ({
+  api: {
+    getModule: vi.fn(() => new Promise(() => {})),
+    getProgress: vi.fn(() => Promise.resolve({ progress: [] })),
+    getAvatar: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+function renderAt(slug: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/student/modules/${slug}`]}>
+      <Routes>
+        <Route path="/student/modules/:slug" element={<ModuleDetail />} />
+        <Route path="/student/modules" element={<div>MODULES LIST</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ModuleDetail — hidden-module route guard", () => {
+  it("redirects a removed/hidden module (k2-stem-sequencing) to the module list", async () => {
+    renderAt("k2-stem-sequencing");
+    expect(await screen.findByText("MODULES LIST")).toBeInTheDocument();
+  });
+
+  it("does not redirect a normal module", () => {
+    renderAt("k2-stem-bounce-buds");
+    expect(screen.queryByText("MODULES LIST")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Reproduced as jordan@test.com (grade 3-5)

jordan landed on a **removed K-2 module** by URL — `/student/modules/k2-stem-sequencing/.../activities/lost-steps` — where the Forward / Turn buttons were dark, unreadable blocks and the program couldn't be built.

## Diagnosis (three problems, two real bugs + one architectural gap)

**1. Band routing — mostly a misread + one real bug.**
- jordan's band is **correct**: `gradeBand` lives on `Course` (the `GRADE35` course is `g3_5`, jordan is enrolled). Not null, not defaulted.
- **There is no separate 3-5 module track.** Every module slug is `k2-` prefixed; band differentiation exists only *inside* some game components via `config.gradeBand`. So a 3-5 student being served `k2-` modules is **by design** — the `k2-` slug is not proof of misrouting. *(This architectural gap — no g3_5 track at the routing layer — is a **scope decision**, flagged below, deliberately not built here.)*
- The **real bug**: `HIDDEN_MODULE_SLUGS` was enforced only in the module **list** (`Modules.tsx`); `ModuleDetail` / `ActivityPlayer` had **no guard**, so removed modules stayed fully reachable by direct URL.

**2. Blacked-out buttons — a contrast bug, NOT the band issue.** The Forward/Turn/Clear buttons had `border` but no `bg`/`text` color (unlike the explicitly-styled `Run` button), so they inherited dark-on-dark. Level data + handlers are fine (`BOOST_PATH_LEVELS.g3_5` is valid, maxSteps 7/10/12/14). Independent of Part 1.

**3. Redundancy — confirmed.** `lost-steps` → `LostStepsGame` → re-export of `BoostPathPlannerGame` (registry: `boost_path_planner` + `sequence_drag_drop`). It's the retired "Fix the Order," same Forward/Turn-Left/Turn-Right + goal-maze mechanic as Tank Trek, sole consumer is the hidden `k2-stem-sequencing` module → an **orphan**.

## Fix (routing-first, minimal, reversible)

Enforce `HIDDEN_MODULE_SLUGS` at the **route layer** — `ModuleDetail` and `ActivityPlayer` redirect hidden slugs to `/student/modules`. One change resolves all three reachable symptoms: the dead module is no longer URL-reachable (routing), the redundant lost-steps is removed from reach **without destructively deleting files** (redundancy), and the broken buttons are behind a now-unreachable game. Also restored button contrast (`bg-white text-slate-900`) so the diagnosed Part-2 defect is actually fixed for the shared component.

## Not done (needs your decision)
- **Architectural:** building a real g3_5 module/track is a product/scope call — not built on the fly.
- **Hard deletion** of the lost-steps component/registry/seed entries: recommended follow-up, left for you to confirm (per "don't remove unilaterally").

## Tests / CI
- New `ModuleDetailHiddenGuard.test.tsx`: hidden slug redirects, normal slug doesn't. 2 passing.
- `lint` ✅ · `typecheck` ✅ · `build` ✅ · unit suite ✅ (337 passed, +2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
