### PR TITLE
fix: Free Access Plans Learn More links route to plan pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
 import ForReviewers from "./pages/ForReviewers";
 import TryDemo from "./pages/TryDemo";
+import PlanDetail from "./pages/PlanDetail";
 import StudentBenchmark from "./pages/StudentBenchmark";
 import StudentSettings from "./pages/StudentSettings";
 import ExperimentDashboard from "./components/admin/ExperimentDashboard";
@@ -123,6 +124,9 @@ function App() {
                   Must stay outside any auth-gated layout. */}
               <Route path="/try" element={<TryDemo />} />
               <Route path="/for-reviewers" element={<ForReviewers />} />
+              {/* Free Access Plans detail pages — reached from the homepage
+                  "Learn more" buttons. Public, persona-routed CTAs. */}
+              <Route path="/plans/:plan" element={<PlanDetail />} />
               <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="/terms" element={<TermsOfService />} />
               <Route path="/feedback" element={<HomeSectionRedirect sectionId="feedback" />} />

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -85,7 +85,10 @@ export type AnalyticsEvent =
   | {
       kind: "demo_signup_cta_clicked";
       placement: "results" | "hero_teacher_whisper";
-    };
+    }
+  // Free Access Plans detail pages (/plans/:plan)
+  | { kind: "plan_page_viewed"; plan: string }
+  | { kind: "plan_cta_clicked"; plan: string; cta: string };
 
 let initialized = false;
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -267,12 +267,13 @@ const Index: React.FC = () => {
                   </CardHeader>
                   <CardContent>
                     <p className="text-brightboost-navy/85 font-medium">{plan.details}</p>
-                    <Button
-                      className="mt-4 rounded-[12px] font-extrabold bg-brightboost-navy text-white hover:bg-brightboost-navy/90"
+                    <Link
+                      to={`/plans/${plan.name.toLowerCase()}`}
+                      className="mt-4 inline-flex items-center justify-center min-h-[44px] px-5 py-2.5 rounded-[12px] font-extrabold bg-brightboost-navy text-white text-sm hover:bg-brightboost-navy/90"
                       onClick={() => track({ kind: "free_plan_clicked", plan: plan.name.toLowerCase() })}
                     >
-                      Learn more
-                    </Button>
+                      Learn more →
+                    </Link>
                   </CardContent>
                 </Card>
               ))}

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -1,0 +1,160 @@
+// src/pages/PlanDetail.tsx
+//
+// Free Access Plans detail pages: /plans/learner, /plans/classroom,
+// /plans/organization. Public, short (one phone-scroll), each ending in a
+// persona-routed CTA. Reached from the "Learn more" buttons on the homepage
+// Free Access Plans section (src/pages/Index.tsx).
+//
+// Honesty rule: only promise features that exist TODAY. In particular we do NOT
+// claim teachers can "assign modules" — that UI is a known gap.
+//
+// i18n NOTE: copy is intentionally hardcoded English to match the rest of the
+// landing/marketing surface (Index.tsx is not i18n'd). i18n for the whole
+// marketing surface is tracked as debt — see the PR.
+import { useEffect } from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+import { ArrowLeft, Check } from "lucide-react";
+import GameBackground from "../components/GameBackground";
+import LanguageToggle from "../components/LanguageToggle";
+import { track } from "@/lib/analytics";
+
+type PlanCta = { label: string; to: string; cta: string };
+type PlanContent = {
+  title: string;
+  tagline: string;
+  bullets: string[];
+  primary: PlanCta;
+  secondary: PlanCta;
+};
+
+const PLAN_CONTENT: Record<string, PlanContent> = {
+  learner: {
+    title: "Bright Boost for Learners",
+    tagline:
+      "Hands-on STEM games you can jump into right now — no setup, no cost.",
+    bullets: [
+      "Play STEM games across AI, quantum, and biotech themes",
+      "Earn XP, level up an avatar, and track your own progress",
+      "Available in English and Spanish",
+      "Content for K-2 and grades 3-5",
+    ],
+    primary: { label: "Play a game now", to: "/try", cta: "try" },
+    secondary: { label: "Sign up free", to: "/signup", cta: "signup" },
+  },
+  classroom: {
+    title: "Bright Boost for Classrooms",
+    tagline: "Free tools for teachers — set up a class in minutes.",
+    bullets: [
+      "Create a class and share one join code",
+      "Students sign in with an emoji and a secret number — no email needed",
+      "See each student's progress across the STEM games",
+      "English and Spanish, with K-2 and grades 3-5 content",
+    ],
+    primary: {
+      label: "Create your class — it's free",
+      to: "/teacher/signup",
+      cta: "teacher_signup",
+    },
+    secondary: { label: "See a student demo", to: "/try", cta: "try" },
+  },
+  organization: {
+    title: "Bright Boost for Organizations",
+    tagline: "Free for schools, libraries, and community programs.",
+    bullets: [
+      "Bring multiple teachers and classrooms onto one platform",
+      "Bilingual access (English and Spanish) for diverse communities",
+      "Measurable student progress teachers can see",
+      "Always free — no per-seat cost",
+    ],
+    primary: {
+      label: "Get started — teacher sign up",
+      to: "/teacher/signup",
+      cta: "teacher_signup",
+    },
+    secondary: { label: "Contact us", to: "/feedback", cta: "contact" },
+  },
+};
+
+export default function PlanDetail() {
+  const { plan } = useParams();
+  const key = (plan ?? "").toLowerCase();
+  const content = PLAN_CONTENT[key];
+
+  useEffect(() => {
+    if (content) track({ kind: "plan_page_viewed", plan: key });
+  }, [content, key]);
+
+  // Unknown plan slug → send them home rather than a dead page.
+  if (!content) return <Navigate to="/" replace />;
+
+  return (
+    <GameBackground>
+      <div className="relative z-10 min-h-screen px-4 py-10">
+        <div className="absolute top-4 right-4">
+          <LanguageToggle />
+        </div>
+        <div className="mx-auto max-w-xl">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 text-sm font-semibold text-brightboost-navy hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" /> Back to home
+          </Link>
+
+          <div className="mt-4 rounded-[18px] border-2 border-[#46B1E6]/20 bg-white p-6 shadow-sm">
+            <span className="inline-flex w-fit rounded-full bg-[#69D681]/25 px-3 py-1 text-xs font-bold text-brightboost-navy">
+              Always Free
+            </span>
+            <h1 className="mt-3 text-2xl font-extrabold text-brightboost-navy">
+              {content.title}
+            </h1>
+            <p className="mt-1 font-medium text-brightboost-navy/80">
+              {content.tagline}
+            </p>
+
+            <ul className="mt-4 space-y-2">
+              {content.bullets.map((b) => (
+                <li
+                  key={b}
+                  className="flex items-start gap-2 font-medium text-brightboost-navy/90"
+                >
+                  <Check className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#69D681]" />
+                  <span>{b}</span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Link
+                to={content.primary.to}
+                onClick={() =>
+                  track({
+                    kind: "plan_cta_clicked",
+                    plan: key,
+                    cta: content.primary.cta,
+                  })
+                }
+                className="inline-flex min-h-[44px] items-center justify-center rounded-[12px] bg-brightboost-navy px-5 py-2.5 text-sm font-extrabold text-white hover:brightness-110"
+              >
+                {content.primary.label} →
+              </Link>
+              <Link
+                to={content.secondary.to}
+                onClick={() =>
+                  track({
+                    kind: "plan_cta_clicked",
+                    plan: key,
+                    cta: content.secondary.cta,
+                  })
+                }
+                className="inline-flex min-h-[44px] items-center justify-center rounded-[12px] border-2 border-brightboost-navy px-5 py-2.5 text-sm font-extrabold text-brightboost-navy hover:bg-brightboost-navy/5"
+              >
+                {content.secondary.label}
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </GameBackground>
+  );
+}

--- a/src/pages/__tests__/PlanDetail.test.tsx
+++ b/src/pages/__tests__/PlanDetail.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+import PlanDetail from "../PlanDetail";
+
+const track = vi.fn();
+vi.mock("@/lib/analytics", () => ({ track: (e: unknown) => track(e) }));
+vi.mock("../../components/GameBackground", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../../components/LanguageToggle", () => ({ default: () => null }));
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/plans/:plan" element={<PlanDetail />} />
+        <Route path="/" element={<div>HOME</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => track.mockClear());
+
+describe("PlanDetail", () => {
+  it("renders the Classroom plan and fires plan_page_viewed", () => {
+    renderAt("/plans/classroom");
+    expect(screen.getByText("Bright Boost for Classrooms")).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith({
+      kind: "plan_page_viewed",
+      plan: "classroom",
+    });
+    expect(screen.getByText(/Create your class/).closest("a")).toHaveAttribute(
+      "href",
+      "/teacher/signup",
+    );
+  });
+
+  it("routes the Learner primary CTA to /try and fires plan_cta_clicked", () => {
+    renderAt("/plans/learner");
+    const primary = screen.getByText(/Play a game now/).closest("a")!;
+    expect(primary).toHaveAttribute("href", "/try");
+    fireEvent.click(primary);
+    expect(track).toHaveBeenCalledWith({
+      kind: "plan_cta_clicked",
+      plan: "learner",
+      cta: "try",
+    });
+  });
+
+  it("maps each plan to its OWN page + CTA (no copy-paste)", () => {
+    renderAt("/plans/organization");
+    expect(
+      screen.getByText("Bright Boost for Organizations"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Contact us/).closest("a")).toHaveAttribute(
+      "href",
+      "/feedback",
+    );
+  });
+
+  it("redirects an unknown plan slug to home (no dead page, no event)", () => {
+    renderAt("/plans/bogus");
+    expect(screen.getByText("HOME")).toBeInTheDocument();
+    expect(track).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Verdict: (A) — the plan pages were never built

Diagnosis evidence:
- **No `/plans/*` routes** in `App.tsx` and **no plan page components** anywhere.
- The three homepage "Learn more" buttons (`Index.tsx`) were `<Button>`s whose **only** action was `onClick={() => track({ kind: "free_plan_clicked", ... })}` — **no `to`/`href`/`navigate`**. They weren't links; they fired an event and went nowhere. That's why all three were dead.
- `plan_page_viewed` / `plan_cta_clicked` existed **nowhere** — which is exactly why the scoreboard's plan funnel reads zero.
- A prod `curl /plans/classroom` returns `200`, but that's the **Cloudflare SPA fallback** (index.html for any path), not a resolving route — so not a deploy gap (C), and the buttons had no route to point at (rules out B).

## Fix
- **New `src/pages/PlanDetail.tsx`** at public route **`/plans/:plan`** (`learner` / `classroom` / `organization`). Short (one phone-scroll), each ending in **persona-routed CTAs**:
  - Learner → **Play a game now** (`/try`) + **Sign up free** (`/signup`)
  - Classroom → **Create your class** (`/teacher/signup`) + **See a student demo** (`/try`)
  - Organization → **Get started** (`/teacher/signup`) + **Contact us** (`/feedback`)
  - Unknown slug → redirect home (no dead page).
- **Homepage buttons** now `Link` to `/plans/<plan>` (per-plan mapping driven by the existing card array — no copy-paste; each card → its own page). Keeps the existing `free_plan_clicked` event.
- **Analytics:** `plan_page_viewed { plan }` on page load + `plan_cta_clicked { plan, cta }` on each CTA (added to the typed `AnalyticsEvent` union). When deployed, these populate the previously-empty scoreboard plan tile — that's the proof the fix shipped.

## Honesty rule
Copy lists **only shipping features** — no teacher "assign modules" claim (known gap). Classroom = create class / join code / emoji+PIN login / progress visibility; Organization = multiple teachers, bilingual, measurable progress, always free.

## Button → page mapping (confirmed)
| Card | Route | Primary CTA | Secondary CTA |
|---|---|---|---|
| Learner | `/plans/learner` | `/try` | `/signup` |
| Classroom | `/plans/classroom` | `/teacher/signup` | `/try` |
| Organization | `/plans/organization` | `/teacher/signup` | `/feedback` |

## ⚠️ i18n debt (flagged)
Copy is **hardcoded English** to match the rest of the landing surface (`Index.tsx` is not i18n'd). Introducing lone i18n on these pages would be inconsistent; tracked as **marketing-surface i18n debt**, not done here.

## CI
`lint` ✅ · `typecheck` ✅ · `build` ✅ · unit suite **339 passing** (+4 `PlanDetail` tests: per-plan render, `plan_page_viewed`, CTA mapping, unknown-slug redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
