### PR TITLE
docs: P3009 migration troubleshooting + sharpen DB setup gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,41 @@ Or use the shortcut:
 npm run db:init
 ```
 
+### Troubleshooting database setup
+
+The setup blockers the team has actually hit. Every fix below is **local only** — never run a `migrate` command (especially `reset`) against production.
+
+**`P3009` — "migrate found failed migrations in the target database"**
+
+A migration was interrupted partway through on your local DB (Ctrl-C, a dropped connection, a transient hiccup), so it's recorded as "failed" and blocks every later migration. The migration itself is fine — this is local DB state, not a code problem.
+
+```bash
+# Fresh setup (simplest): wipes your LOCAL database, re-runs all migrations + seed
+npx prisma migrate reset
+
+# If you have local data to keep: mark the stuck migration rolled-back, then re-apply
+npx prisma migrate resolve --rolled-back <migration_name>
+npx prisma migrate deploy
+```
+
+⚠️ `migrate reset` is **local only** — never run it (or any `migrate` command) against production.
+⚠️ Don't edit the committed migration file — it's applied fine everywhere else. The fix is your local DB state. Run from the repo root (where your dev `DATABASE_URL` points).
+
+**`P1001` — "Can't reach database server at `host:5432`"**
+
+Either the database isn't running, or your `DATABASE_URL` still has the placeholder values from `.env.example` (a literal `user:pass@host`, or port `5432`, in the error is the giveaway). The Docker Postgres listens on **port 5435**, not 5432.
+
+```bash
+# 1. Bring the DB container up
+docker compose -f docker-compose-pg.yml up -d
+
+# 2. Put the REAL local values in backend/.env (must match docker-compose-pg.yml)
+DATABASE_URL=postgresql://postgres:brightboostpass@localhost:5435/brightboost
+DIRECT_URL=postgresql://postgres:brightboostpass@localhost:5435/brightboost
+```
+
+**Docker won't cooperate?** A plain local Postgres is a fine fallback — install Postgres, create a `brightboost` database, and point `DATABASE_URL` / `DIRECT_URL` at it (any port, as long as the URL matches). Then run `npm run db:init`.
+
 ### Run Locally
 
 ```bash


### PR DESCRIPTION
## What
Adds a **Troubleshooting database setup** section to the README's Getting Started flow (right after *Seed the Database*), covering the three local-setup blockers the team has actually hit:

- **`P3009` — failed/stuck migration.** Explains it's a local interrupted-migration snag (not a broken migration), with the safe local fixes (`migrate reset` for fresh setup, or `migrate resolve --rolled-back` + `migrate deploy` to keep data). ⚠️ Explicit warnings: never reset/migrate against production, never edit the committed migration file.
- **`P1001` — can't reach DB.** The placeholder-`DATABASE_URL` / wrong-port case — Docker Postgres is on **5435**, not 5432. Shows the real local connection string matching `docker-compose-pg.yml`.
- **Docker fallback** — plain local Postgres is a valid alternative.

## Why
Multiple interns have hit DB-setup issues; P3009 (Olivia) is the newest. There was no consolidated troubleshooting section — `prisma/README.md` had only a thin, partly-stale generic blurb. This puts the three real blockers where people actually look: the README setup steps.

## Accuracy
Commands verified against the repo: `docker-compose-pg.yml` (port 5435, `postgres`/`brightboostpass`, db `brightboost`), `npm run db:init`, and the root `prisma/schema.prisma` path.

Docs only — no game/app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)