### PR TITLE
docs: db push workaround for fresh local setup (migration history bug, #646)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ npm run db:init
 
 The setup blockers the team has actually hit. Every fix below is **local only** — never run a `migrate` command (especially `reset`) against production.
 
+**`P3018` / "relation does not exist" during migrate (e.g. `relation "Avatar" does not exist`)**
+
+Known issue: the migration history is currently incomplete and **can't build the database from scratch** (tracked in #646). On a fresh setup, `migrate reset` / `migrate deploy` / `migrate resolve` — and `npm run db:init`, which uses `migrate deploy` — will all hit this and fail. It's a repo bug, not your machine.
+
+**Use `db push` for local setup instead** — it builds every table directly from `schema.prisma`, bypassing the migration history:
+
+```bash
+# from the repo ROOT, with your Docker Postgres running (docker compose -f docker-compose-pg.yml up -d)
+npx prisma db push --schema prisma/schema.prisma
+npx prisma db seed
+```
+
+This gives you a correct, fully-seeded local database. It records no migration history, which is fine for local development.
+
+⚠️ `db push` is **local-dev only** — never run it against production (it can drop/alter columns to force-match the schema).
+Until #646 lands, prefer `db push` + seed over `npm run db:init` (or any `migrate` command) for a fresh local DB — including the `P3009` fix below, whose `migrate reset` won't succeed from scratch yet.
+
 **`P3009` — "migrate found failed migrations in the target database"**
 
 A migration was interrupted partway through on your local DB (Ctrl-C, a dropped connection, a transient hiccup), so it's recorded as "failed" and blocks every later migration. The migration itself is fine — this is local DB state, not a code problem.


### PR DESCRIPTION
## What
Adds a **`P3018` / "relation does not exist"** entry to the README's *Troubleshooting database setup* section, documenting the `prisma db push` + seed workaround for fresh local setup.

## Why
The migration history can't build the schema from an empty DB (Avatar + ~13 core tables are never `CREATE`d — tracked in **#646**). So `migrate reset` / `migrate deploy` / `migrate resolve` and `npm run db:init` all fail on a fresh setup. `db push` builds every table directly from `schema.prisma`, bypassing the broken history — the working path for new devs until #646 lands.

Placed at the **top** of the troubleshooting section because it's the first blocker a new dev hits, and it notes that the existing P3009 `migrate reset` advice won't succeed from scratch until #646 is fixed.

## Verified against the repo
- `prisma db seed` → `node prisma/seed.cjs` (package.json)
- schema path `prisma/schema.prisma`; Docker via `docker-compose-pg.yml`
- ⚠️ `db push` flagged local-dev-only (never against prod)

Docs only — no code/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)