### PR TITLE
fix: remove destructive db push --accept-data-loss from prod deploy path (#646)

### DIFF
--- a/backend/scripts/predeploy.sh
+++ b/backend/scripts/predeploy.sh
@@ -20,12 +20,32 @@ echo "predeploy: using schema $SCHEMA"
 echo "predeploy: using seed $SEED_FILE"
 
 echo "predeploy: prisma migrate deploy"
-npx prisma migrate deploy --schema "$SCHEMA" || {
-  echo "predeploy: migrate deploy failed, falling back to db push"
-  npx prisma db push --schema "$SCHEMA" --accept-data-loss || {
-    echo "predeploy: db push also failed — continuing anyway"
-  }
-}
+if npx prisma migrate deploy --schema "$SCHEMA"; then
+  echo "predeploy: migrate deploy succeeded"
+else
+  rc=$?
+  echo "=========================================================================="
+  echo "predeploy: WARNING — 'prisma migrate deploy' FAILED (exit $rc)."
+  echo "predeploy:"
+  echo "predeploy:   Known migration-baseline bug (#646): the committed migration"
+  echo "predeploy:   history can't build the schema from scratch, so 'migrate"
+  echo "predeploy:   deploy' fails on this deploy path until #646 lands."
+  echo "predeploy:"
+  echo "predeploy:   The previous 'db push --accept-data-loss' fallback has been"
+  echo "predeploy:   INTENTIONALLY REMOVED. We do NOT force-sync production —"
+  echo "predeploy:   that risked SILENTLY DROPPING DATA to match schema.prisma."
+  echo "predeploy:"
+  echo "predeploy:   The app will start on its EXISTING schema (correct for a"
+  echo "predeploy:   code-only deploy). A deploy that REQUIRES a schema change must"
+  echo "predeploy:   wait for the #646 baseline fix or a deliberate manual migration"
+  echo "predeploy:   — nothing will be applied automatically here."
+  echo "=========================================================================="
+  # Intentionally do NOT exit non-zero: a code-only deploy must still boot the app
+  # on the existing (already-correct) schema. Removing the destructive
+  # 'db push --accept-data-loss' fallback is an interim safety measure for the
+  # #646 migration-baseline bug. Once #646 lands, this path should use clean
+  # 'migrate deploy' and may reinstate a hard non-zero exit on failure. See #646.
+fi
 
 echo "predeploy: prisma generate"
 npx prisma generate --schema "$SCHEMA"


### PR DESCRIPTION
## The risk being removed
`backend/scripts/predeploy.sh` runs on every backend deploy/start. It ran `prisma migrate deploy` and, **on failure, fell back to `prisma db push --schema "$SCHEMA" --accept-data-loss`** — force-syncing production to match `schema.prisma` and *accepting data loss*.

Because the migration history can't build the schema from scratch (**#646**), `migrate deploy` **always fails** on this path. So production has been maintained **entirely by this destructive fallback** on every deploy — confirmed by prod having **no `_prisma_migrations` table** at all (it has never been migration-managed). This has only been safe *by luck*: schema changes happened to be additive. A change requiring a column/table drop would have **silently destroyed production data**.

## New behavior (Option 1 — fail safe, don't brick code deploys)
On `migrate deploy` failure, the script now:
- **Logs loudly** (citing #646, stating the destructive fallback was intentionally removed and that schema changes won't auto-apply), and
- **Falls through without exiting non-zero**, so the app still boots on its **existing, already-correct schema**.

Net:
- ✅ Code-only deploys keep working (the common case).
- ✅ **No `--accept-data-loss` / `db push` anywhere** — zero chance of destructive auto-sync.
- ✅ A schema-changing deploy no longer silently mutates prod — it surfaces and waits for a deliberate fix.

`set -e` retained; the `if` condition is exempt from it, so a failed `migrate deploy` won't abort the script. Lines for `prisma generate`, seed, and the gamification backfill are unchanged. Verified with `sh -n` (syntax OK) and a grep confirming no executable destructive command remains (only an echo/comment documenting the removal).

## Interim vs. real fix
This is an **interim safety fix**. The real fix is the migration baseline (**#646**); once prod has a proper `_prisma_migrations` history, this path should use clean `migrate deploy` (and may reinstate a hard non-zero exit on failure).

## Timing
Important to merge **before the June 22–30 travel window** — it removes the risk of a destructive auto-sync running against prod while availability is low.

Refs #646 (migration baseline) · companion to #648 (CI enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)