### PR TITLE
fix: green up build-and-test (AvatarPicker stories need AuthContext)

### DIFF
--- a/src/components/AvatarPicker.stories.tsx
+++ b/src/components/AvatarPicker.stories.tsx
@@ -1,5 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import AvatarPicker from "./AvatarPicker";
+import { AuthContext } from "../contexts/AuthContext";
+
+// AvatarPicker calls useAuth() (for updateUser after an upload), so it must render
+// inside an AuthContext provider. Supply a minimal stub value rather than the real
+// <AuthProvider>, which would also pull in the router and a session-check fetch.
+const mockAuthValue = {
+  user: null,
+  token: null,
+  login: () => {},
+  logout: () => {},
+  updateUser: () => {},
+  isAuthenticated: false,
+  isLoading: false,
+};
 
 const meta: Meta<typeof AvatarPicker> = {
   title: "Components/AvatarPicker",
@@ -8,6 +22,13 @@ const meta: Meta<typeof AvatarPicker> = {
     layout: "centered",
   },
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <AuthContext.Provider value={mockAuthValue}>
+        <Story />
+      </AuthContext.Provider>
+    ),
+  ],
   argTypes: {
     onAvatarChange: { action: "avatar-changed" },
     currentAvatarUrl: {

--- a/src/components/__tests__/AvatarPicker.test.tsx
+++ b/src/components/__tests__/AvatarPicker.test.tsx
@@ -20,13 +20,15 @@ vi.mock("@/components/ui/avatar", () => ({
   ),
 }));
 
-// TODO(green-ci-recovery): AvatarPicker now calls `useAuth` and the tests
-// render the component without an AuthProvider — all three fail with
-// "useAuth must be used within an AuthProvider". The fix is mechanical
-// (wrap render in <AuthProvider> + matching mock) but requires verifying
-// what the picker actually reads from the auth context. Quarantined here
-// rather than papered over so the next person sees the real assertion
-// surface, not a passing-but-meaningless test.
+// TODO(orphan-cleanup): AvatarPicker is not rendered anywhere in the app —
+// only this test and AvatarPicker.stories.tsx reference it. These unit tests
+// are stale in two ways: (1) the component now calls useAuth() so it needs an
+// AuthContext provider, and (2) they mock @/components/ui/avatar's AvatarImage
+// and assert an old S3 presigned-upload flow, but the component now renders
+// SafeAvatarImage and POSTs to /user/avatar/upload. The *stories* were given
+// an AuthContext decorator so CI's build-and-test is green; these unit tests
+// stay skipped pending a decision on whether to delete the orphaned component
+// or wire it back into the app (flagged for confirmation, not deleted here).
 describe.skip("AvatarPicker", () => {
   let originalImage: typeof Image;
 


### PR DESCRIPTION
## Why
Last blocker before CI enforcement (#648) can be turned on: `build-and-test` was red. It runs the **full** `npm test` (the Vitest Storybook **chromium** project, after installing Playwright), so the failures live there — `test:unit` (added in #652) excludes that project and stays green, which is why this hid.

## Failure inventory (reproduced via `npm test`)
| Test | Result | Classification |
|---|---|---|
| `AvatarPicker.stories.tsx` → Default, With Existing Avatar, Different Initials, Long Initials, With Custom Avatar (5) | **FAILED** — `useAuth must be used within an AuthProvider` | **stale test setup** |
| `SpacewarArena.test.tsx` | passing (the "avatar down" stderr is a *passing* fallback test) | not a failure |

That was the complete set: **5 failed / 343 passed → now 0 failed / 348 passed**.

## What I fixed and why
`AvatarPicker` legitimately calls `useAuth()` (for `updateUser` after an upload) and must render inside an `AuthContext` provider. The component is **correct** — the **stories** were never updated to supply the context (their args still match the component's props). So this is a stale test setup, **not** a code bug and **not** a skip-to-go-green.

- **`AvatarPicker.stories.tsx`** — added an `AuthContext.Provider` decorator with a minimal stub value (avoids the router + session-check fetch the real `<AuthProvider>` would pull in). All 5 stories render and pass.
- **`AvatarPicker.test.tsx`** — corrected the misleading quarantine TODO. It claimed the fix was "mechanical," but these unit tests are stale beyond the auth issue (mock `AvatarImage` while the component now renders `SafeAvatarImage`; assert a removed S3 presigned-upload flow). Left `describe.skip` (it's not in the failing path) with an honest note.

## Flagged, not fixed
**`AvatarPicker` appears orphaned** — nothing in the app renders it (only its own component/test/story reference it; `/user/avatar/upload` is referenced only here). Options: delete the orphan (component + story + skipped test) or wire it back in. Per the orphan-cleanup discipline, **flagged for confirmation rather than deleted unilaterally**. If the team confirms it's dead, that's a clean follow-up that removes both the dead component and the skipped test.

## Verified locally (build-and-test steps)
- `npm test` (full workspace incl. chromium Storybook project): **348 passed / 19 skipped / 0 failed**; AvatarPicker stories ✓.
- `npm run lint` ✓ · `npm run typecheck` ✓ · `npm run build` ✓ (15.96s).
- Not run locally (need infra, untouched by this change): backend typecheck, Prisma drift check, Cypress smoke.

## Unblocks #648?
Yes for `build-and-test` — it can now be made a **required** check. **Caveat:** the separate `db-check` job still fails until the migration baseline (#646) is fixed, so #648 should enable `build-and-test` (and `build-only`) as required now, but **not** `db-check` until #646 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)