### PR TITLE
fix: localizing hardcoded game strings

### DIFF
--- a/src/components/games/BounceBudsGame.tsx
+++ b/src/components/games/BounceBudsGame.tsx
@@ -21,6 +21,7 @@ import GameShell, {
 } from "./shared/GameShell";
 import { getGradeBand, BOUNCE_BUDS_ROUNDS } from "./gradeBandContent";
 import "./shared/game-effects.css";
+import { pickLocale, resolveText } from "@/utils/localizedContent";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Types
@@ -111,15 +112,14 @@ const GATE_STYLES = [
 // ═══════════════════════════════════════════════════════════════════════════
 
 const BRIEFING: MissionBriefing = {
-  title: "Bounce & Buds",
-  story:
-    "Buddy needs your help! Bounce the ball into the right gate to help plants grow. Read the clue and aim carefully!",
+  title: pickLocale({ en: "Bounce & Buds", es: "Rebota y Amigos", vi: "Nảy và Bạn Bè", "zh-CN": "弹跳小伙伴" }, "Bounce & Buds"),
+  story: pickLocale({
+    en: "Buddy needs your help! Bounce the ball into the right gate to help plants grow. Read the clue and aim carefully!"
+  }, "Buddy needs your help! Bounce the ball into the right gate to help plants grow. Read the clue and aim carefully!"),
   icon: "🌿",
-  tips: [
-    "Read the clue at the top",
-    "Move the paddle left and right to aim",
-    "Bounce the ball into the correct gate!",
-  ],
+  tips: pickLocale({
+    en: ["Read the clue at the top", "Move the paddle left and right to aim", "Bounce the ball into the correct gate!",]
+  }, ["Read the clue at the top", "Move the paddle left and right to aim", "Bounce the ball into the correct gate!",]),
   chapterLabel: "Life Science",
   themeColor: "emerald",
 };
@@ -332,7 +332,7 @@ function BouncePlayfield({
     if (roundIndex >= ROUNDS.length || finishedRef.current) return;
 
     const r = ROUNDS[roundIndex];
-    const labels = shuffleArray([r.correctLabel, ...r.distractors]);
+    const labels = shuffleArray([resolveText(t, r.correctLabel), ...pickLocale(r.distractors, r.distractors.en)]);
     gateLabelsRef.current = labels;
     setGateLabels(labels);
     setHitGateIdx(null);
@@ -417,7 +417,7 @@ function BouncePlayfield({
         if (hitGate >= 0) {
           const label = gateLabelsRef.current[hitGate];
           const round = ROUNDS[roundIndex];
-          const isCorrect = label === round?.correctLabel;
+          const isCorrect = label === resolveText(t, round?.correctLabel);
           b.vx = 0;
           b.vy = 0;
           setHitGateIdx(hitGate);
@@ -427,7 +427,7 @@ function BouncePlayfield({
           } else {
             resolveRef.current(
               false,
-              `Almost! The answer was \u201c${round?.correctLabel}\u201d.`,
+              `Almost! The answer was \u201c${resolveText(t, round?.correctLabel)}\u201d.`,
             );
           }
         } else {
@@ -592,7 +592,7 @@ function BouncePlayfield({
             Round {roundIndex + 1} of {ROUNDS.length}
           </p>
           <p className="mt-1 text-xl font-extrabold text-slate-900 md:text-2xl leading-snug">
-            {currentRound.clueText}
+            {resolveText(t, currentRound.clueText)}
           </p>
         </div>
       )}
@@ -743,7 +743,7 @@ function BouncePlayfield({
             {phase === "waiting" && (
               <div className="absolute inset-0 flex items-end justify-center pb-16 pointer-events-none">
                 <p className="slide-up-fade text-sm font-bold text-emerald-800 bg-white/80 px-4 py-1.5 rounded-full shadow">
-                  Drag to aim. Tap anywhere to bounce!
+                  { pickLocale({ en: "Drag to aim. Tap anywhere to bounce!" }, "Drag to aim. Tap anywhere to bounce!") }
                 </p>
               </div>
             )}

--- a/src/components/games/BounceBudsGame.tsx
+++ b/src/components/games/BounceBudsGame.tsx
@@ -111,6 +111,7 @@ const GATE_STYLES = [
 // Briefing (used by GameShell)
 // ═══════════════════════════════════════════════════════════════════════════
 
+// TODO: add translation for the story, tips in briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Bounce & Buds", es: "Rebota y Amigos", vi: "Nảy và Bạn Bè", "zh-CN": "弹跳小伙伴" }, "Bounce & Buds"),
   story: pickLocale({
@@ -743,6 +744,7 @@ function BouncePlayfield({
             {phase === "waiting" && (
               <div className="absolute inset-0 flex items-end justify-center pb-16 pointer-events-none">
                 <p className="slide-up-fade text-sm font-bold text-emerald-800 bg-white/80 px-4 py-1.5 rounded-full shadow">
+                  { /* TODO: add translations for coach string */ }
                   { pickLocale({ en: "Drag to aim. Tap anywhere to bounce!" }, "Drag to aim. Tap anywhere to bounce!") }
                 </p>
               </div>

--- a/src/components/games/FastLaneGame.tsx
+++ b/src/components/games/FastLaneGame.tsx
@@ -9,6 +9,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
+import { pickLocale } from "@/utils/localizedContent";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 type Signal = "safe" | "blocked" | "caution";
@@ -26,10 +27,14 @@ const LANE_LABELS = ["A", "B", "C"];
 const PHASE_ORDER: GamePhase[] = ["practice", "signals", "lookAhead", "challenge", "exitTicket", "celebration"];
 
 const BRIEFING: MissionBriefing = {
-  title: "Fast Lane Signals",
-  story: "Deliver the science supplies safely! Read the road signals and choose the best lane.",
+  title: pickLocale({ en: "Fast Lane Signals", es: "Señales de Carril Rápido", vi: "Tín Hiệu Làn Nhanh", "zh-CN": "快车道信号" }, "Fast Lane Signals"),
+  story: pickLocale({
+    en: "Deliver the science supplies safely! Read the road signals and choose the best lane.",
+  }, "Deliver the science supplies safely! Read the road signals and choose the best lane."),
   icon: "\uD83D\uDEA6",
-  tips: ["Green means safe", "Red means blocked", "Yellow means watch out \u2014 it might close!"],
+  tips: pickLocale({
+    en: ["Green means safe", "Red means blocked", "Yellow means watch out \u2014 it might close!"],
+  }, ["Green means safe", "Red means blocked", "Yellow means watch out \u2014 it might close!"]),
   chapterLabel: "Signal School",
   themeColor: "blue",
 };

--- a/src/components/games/FastLaneGame.tsx
+++ b/src/components/games/FastLaneGame.tsx
@@ -26,6 +26,7 @@ const SIGNAL_COLORS: Record<Signal, string> = {
 const LANE_LABELS = ["A", "B", "C"];
 const PHASE_ORDER: GamePhase[] = ["practice", "signals", "lookAhead", "challenge", "exitTicket", "celebration"];
 
+// TODO: add translations for the story, tips in briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Fast Lane Signals", es: "Señales de Carril Rápido", vi: "Tín Hiệu Làn Nhanh", "zh-CN": "快车道信号" }, "Fast Lane Signals"),
   story: pickLocale({

--- a/src/components/games/GotchaGearsGame.tsx
+++ b/src/components/games/GotchaGearsGame.tsx
@@ -348,6 +348,7 @@ export default function GotchaGearsGame({
     ? config
     : { gameKey: "gotcha_gears_unity", rounds: GOTCHA_GEARS_CONTENT[getGradeBand(config)] };
 
+  // TODO: add translations for the story, tips in briefing
   const briefing: MissionBriefing = {
     title: pickLocale({ en: "Gear Grab!" }, "Gear Grab!"),
     story: pickLocale({

--- a/src/components/games/GotchaGearsGame.tsx
+++ b/src/components/games/GotchaGearsGame.tsx
@@ -8,7 +8,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { GameResult, MissionBriefing } from "./shared/GameShell";
-import { resolveText } from "@/utils/localizedContent";
+import { pickLocale, resolveText } from "@/utils/localizedContent";
 import "./shared/game-effects.css";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -349,12 +349,16 @@ export default function GotchaGearsGame({
     : { gameKey: "gotcha_gears_unity", rounds: GOTCHA_GEARS_CONTENT[getGradeBand(config)] };
 
   const briefing: MissionBriefing = {
-    title: "Gear Grab!",
-    story: "Gearbot's gears are falling from the sky! Read the clue and catch the right gear before it hits the ground.",
+    title: pickLocale({ en: "Gear Grab!" }, "Gear Grab!"),
+    story: pickLocale({
+      en: "Gearbot's gears are falling from the sky! Read the clue and catch the right gear before it hits the ground.",
+    }, "Gearbot's gears are falling from the sky! Read the clue and catch the right gear before it hits the ground."),
     icon: "⚙️",
     chapterLabel: "Gotcha Gears",
     themeColor: "amber",
-    tips: ["Read the clue carefully", "Tap the correct gear", "Streaks earn bonus points!"],
+    tips: pickLocale({
+      en: ["Read the clue carefully", "Tap the correct gear", "Streaks earn bonus points!"]
+    }, ["Read the clue carefully", "Tap the correct gear", "Streaks earn bonus points!"])
   };
 
   return (

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -14,6 +14,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
+import { pickLocale } from "@/utils/localizedContent";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Types
@@ -109,19 +110,24 @@ function applyDir(r: number, c: number, dir: Dir): [number, number] {
 // ═══════════════════════════════════════════════════════════════════════════
 
 const BRIEFING: MissionBriefing = {
-  title: "Maze Maps & Smart Paths",
-  story: "Help Byte Bot collect the Idea Orbs! Watch the Sweepers and choose a smart path through the maze.",
+  title: pickLocale({ en: "Maze Maps & Smart Paths", es: "Mapas de Laberinto", vi: "Bản Đồ Mê Cung", "zh-CN": "迷宫地图" }, "Maze Maps & Smart Paths"),
+  story: pickLocale({ 
+    en: "Help Byte Bot collect the Idea Orbs! Watch the Sweepers and choose a smart path through the maze.",
+  }, "Help Byte Bot collect the Idea Orbs! Watch the Sweepers and choose a smart path through the maze."),
   icon: "🗺️",
-  tips: [
-    "Move one step at a time",
-    "Watch the Sweepers before you move",
-    "Safe Pads protect you from Sweepers",
-  ],
+  tips: pickLocale({
+    en: ["Move one step at a time", "Watch the Sweepers before you move", "Safe Pads protect you from Sweepers"],
+  }, ["Move one step at a time", "Watch the Sweepers before you move", "Safe Pads protect you from Sweepers"]),
   chapterLabel: "AI Lab",
   themeColor: "cyan",
   controlInstructions: {
-    keyboard: ["Use Tab to move to action buttons and Enter or Space to choose."],
-    buttons: ["Choose a move or wait action.", "Watch the pattern before moving."],
+    keyboard: [pickLocale({
+      en: "Use Tab to move to action buttons and Enter or Space to choose.",
+    }, "Use Tab to move to action buttons and Enter or Space to choose."),
+  ],
+    buttons: pickLocale({
+      en: ["Choose a move or wait action.", "Watch the pattern before moving."],
+    }, ["Choose a move or wait action.", "Watch the pattern before moving."]),
   },
 };
 

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -109,6 +109,7 @@ function applyDir(r: number, c: number, dir: Dir): [number, number] {
 // Briefing
 // ═══════════════════════════════════════════════════════════════════════════
 
+// TODO: add translations for the story, tips, control instructions in the briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Maze Maps & Smart Paths", es: "Mapas de Laberinto", vi: "Bản Đồ Mê Cung", "zh-CN": "迷宫地图" }, "Maze Maps & Smart Paths"),
   story: pickLocale({ 

--- a/src/components/games/MoveMeasureGame.tsx
+++ b/src/components/games/MoveMeasureGame.tsx
@@ -7,6 +7,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
+import { pickLocale } from "@/utils/localizedContent";
 
 // ── Types & constants ────────────────────────────────────────────────────
 type Phase = "intro" | "dash" | "jump" | "toss" | "compare" | "improve" | "retry" | "exitTicket" | "celebration";
@@ -48,10 +49,14 @@ export function buildMoveMeasureCompletionPayload(params: {
 }
 
 const BRIEFING: MissionBriefing = {
-  title: "Move, Measure & Improve",
-  story: "Test your body's superpowers! Dash, jump, and toss — then use what you learn to get even better.",
+  title: pickLocale({ en: "Move, Measure & Improve", es: "Mueve, Mide y Mejora", vi: "Đi, Đo và Cải Thiện", "zh-CN": "动、量、进步" }, "Move, Measure & Improve"),
+  story: pickLocale({
+    en: "Test your body's superpowers! Dash, jump, and toss — then use what you learn to get even better.",
+  }, "Test your body's superpowers! Dash, jump, and toss — then use what you learn to get even better."),
   icon: "🏃",
-  tips: ["Tap at the right moment", "Watch the green zone", "Try again to improve!"],
+  tips: pickLocale({
+    en: ["Tap at the right moment", "Watch the green zone", "Try again to improve!"],
+  }, ["Tap at the right moment", "Watch the green zone", "Try again to improve!"]),
   chapterLabel: "Body Lab",
   themeColor: "emerald",
 };

--- a/src/components/games/MoveMeasureGame.tsx
+++ b/src/components/games/MoveMeasureGame.tsx
@@ -48,6 +48,7 @@ export function buildMoveMeasureCompletionPayload(params: {
   };
 }
 
+// TODO: add translations for the story, tips in briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Move, Measure & Improve", es: "Mueve, Mide y Mejora", vi: "Đi, Đo và Cải Thiện", "zh-CN": "动、量、进步" }, "Move, Measure & Improve"),
   story: pickLocale({

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -6,6 +6,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
+import { pickLocale } from "@/utils/localizedContent";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 type Phase = "intro" | "qualify" | "results1" | "tune" | "race" | "compare" | "exitTicket" | "celebration";
@@ -63,15 +64,23 @@ export function buildQualifyTuneRaceCompletionPayload(params: {
 
 // ── Briefing ──────────────────────────────────────────────────────────────
 const BRIEFING: MissionBriefing = {
-  title: "Qualify, Tune, Race",
-  story: "First we test. Then we tune. Then we race again! Change one thing and see what happens.",
+  title: pickLocale({ en: "Qualify, Tune, Race", es: "Califica, Ajusta, Compite", vi: "Thử, Điều Chỉnh, Đua", "zh-CN": "测试、调整、比赛" }, "Qualify, Tune, Race"),
+  story: pickLocale({
+    en: "First we test. Then we tune. Then we race again! Change one thing and see what happens.",
+  }, "First we test. Then we tune. Then we race again! Change one thing and see what happens."),
   icon: "🏎️",
-  tips: ["Drive carefully on the first run", "Pick ONE upgrade to test", "Compare your two runs!"],
+  tips: pickLocale({
+    en: ["Drive carefully on the first run", "Pick ONE upgrade to test", "Compare your two runs!"],
+  }, ["Drive carefully on the first run", "Pick ONE upgrade to test", "Compare your two runs!"]),
   chapterLabel: "Race Lab",
   themeColor: "amber",
   controlInstructions: {
-    keyboard: ["Use Tab to reach lane controls, then use Enter or Space to steer."],
-    buttons: ["Use lane controls or available buttons to steer.", "Test one change at a time."],
+    keyboard: pickLocale({
+      en: ["Use Tab to reach lane controls, then use Enter or Space to steer."],
+    }, ["Use Tab to reach lane controls, then use Enter or Space to steer."]),
+    buttons: pickLocale({
+      en: ["Use lane controls or available buttons to steer.", "Test one change at a time."],
+    }, ["Use lane controls or available buttons to steer.", "Test one change at a time."]),
   },
 };
 

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -63,6 +63,7 @@ export function buildQualifyTuneRaceCompletionPayload(params: {
 }
 
 // ── Briefing ──────────────────────────────────────────────────────────────
+// TODO: add translation for the story, tips, control instructions in briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Qualify, Tune, Race", es: "Califica, Ajusta, Compite", vi: "Thử, Điều Chỉnh, Đua", "zh-CN": "测试、调整、比赛" }, "Qualify, Tune, Race"),
   story: pickLocale({

--- a/src/components/games/SkyShieldGame.tsx
+++ b/src/components/games/SkyShieldGame.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
+import { pickLocale } from "@/utils/localizedContent";
 
 // ── Constants & Types ─────────────────────────────────────────────────────
 const LABELS = ["🔵", "🟡", "🩷"];
@@ -21,10 +22,14 @@ type Phase = "intro" | "practice" | "pattern" | "scan" | "challenge" | "exitTick
 interface Drop { lane: number; kind: "normal" | "mystery"; hiddenColor?: number }
 
 const BRIEFING: MissionBriefing = {
-  title: "Sky Shield Patterns",
-  story: "Light drops are falling from the sky! Watch the pattern and place your shield to protect the land.",
+  title: pickLocale({ en: "Sky Shield Patterns", es: "Patrones del Cielo", vi: "Mẫu Lá Chắn Bầu Trời", "zh-CN": "天空护盾图案" }, "Sky Shield Patterns"),
+  story: pickLocale({
+    en: "Light drops are falling from the sky! Watch the pattern and place your shield to protect the land.",
+  }, "Light drops are falling from the sky! Watch the pattern and place your shield to protect the land."),
   icon: "🛡️",
-  tips: ["Watch which lane the light falls in", "Look for repeating patterns", "Scan mystery lights before choosing"],
+  tips: pickLocale({
+    en: ["Watch which lane the light falls in", "Look for repeating patterns", "Scan mystery lights before choosing"],
+  }, ["Watch which lane the light falls in", "Look for repeating patterns", "Scan mystery lights before choosing"]),
   chapterLabel: "Pattern Lab",
   themeColor: "violet",
 };

--- a/src/components/games/SkyShieldGame.tsx
+++ b/src/components/games/SkyShieldGame.tsx
@@ -21,6 +21,7 @@ const PRACTICE_N = 5, PATTERN_N = 3, CHALLENGE_N = 10, MYSTERY_N = 2;
 type Phase = "intro" | "practice" | "pattern" | "scan" | "challenge" | "exitTicket" | "celebration";
 interface Drop { lane: number; kind: "normal" | "mystery"; hiddenColor?: number }
 
+// TODO: add translations for the story, tips in briefing
 const BRIEFING: MissionBriefing = {
   title: pickLocale({ en: "Sky Shield Patterns", es: "Patrones del Cielo", vi: "Mẫu Lá Chắn Bầu Trời", "zh-CN": "天空护盾图案" }, "Sky Shield Patterns"),
   story: pickLocale({

--- a/src/components/games/gradeBandContent.ts
+++ b/src/components/games/gradeBandContent.ts
@@ -16,31 +16,91 @@ export function getGradeBand(config?: any): GradeBand {
 // ── Gotcha Gears content ────────────────────────────────────────────────
 
 export interface GearRoundContent {
-  clueText: string;
-  correctLabel: string;
-  distractors: string[];
-  hint?: string;
+  clueText: Record<string, string>;
+  correctLabel: Record<string, string>;
+  distractors: Record<string,string[]>;
+  hint?: Record<string, string>;
 }
 
 export const GOTCHA_GEARS_CONTENT: Record<GradeBand, GearRoundContent[]> = {
   k2: [
-    { clueText: "I help a robot think and learn", correctLabel: "AI Brain", distractors: ["Hammer", "Paintbrush"], hint: "Think about what makes a robot smart!" },
-    { clueText: "I store information like a library", correctLabel: "Memory Chip", distractors: ["Wheel", "Speaker"], hint: "Where do computers keep things?" },
-    { clueText: "I tell the robot what to do step by step", correctLabel: "Program", distractors: ["Snack", "Balloon"], hint: "It's like a recipe for computers!" },
-    { clueText: "I help a robot see the world", correctLabel: "Camera Sensor", distractors: ["Pillow", "Crayon"], hint: "What do YOUR eyes do?" },
-    { clueText: "I protect the robot from mistakes", correctLabel: "Debug Tool", distractors: ["Umbrella", "Toy Car"], hint: "Finding and fixing errors!" },
-    { clueText: "I move the robot's arms and wheels", correctLabel: "Motor", distractors: ["Book", "Flower"], hint: "What makes things spin and move?" },
-    { clueText: "I let robots talk to each other", correctLabel: "Antenna", distractors: ["Spoon", "Hat"], hint: "Think about how signals travel!" },
+    { clueText: { en: "I help a robot think and learn" }, 
+      correctLabel: { en: "AI Brain" }, 
+      distractors: { en: ["Hammer", "Paintbrush"] }, 
+      hint: { en: "Think about what makes a robot smart!" }
+    },
+    { clueText: { en: "I store information like a library" },
+      correctLabel: { en: "Memory Chip" }, 
+      distractors: { en: ["Wheel", "Speaker"] }, 
+      hint: { en: "Where do computers keep things?" }
+    },
+    { clueText: { en: "I tell the robot what to do step by step" }, 
+      correctLabel: { en: "Program" }, 
+      distractors: { en: ["Snack", "Balloon"] }, 
+      hint: {en: "It's like a recipe for computers!" }
+    },
+    { clueText: { en: "I help a robot see the world" }, 
+      correctLabel: { en: "Camera Sensor" }, 
+      distractors: { en: ["Pillow", "Crayon"] }, 
+      hint: { en: "What do YOUR eyes do?" }
+    },
+    { clueText: { en: "I protect the robot from mistakes" }, 
+      correctLabel: { en: "Debug Tool" }, 
+      distractors: { en: ["Umbrella", "Toy Car"] }, 
+      hint: { en: "Finding and fixing errors!" }
+    },
+    { clueText: { en: "I move the robot's arms and wheels" }, 
+      correctLabel: { en: "Motor" }, 
+      distractors: { en: ["Book", "Flower"] }, 
+      hint: { en: "What makes things spin and move?" }
+    },
+    { clueText: { en: "I let robots talk to each other" }, 
+      correctLabel: { en: "Antenna" }, 
+      distractors: { en: ["Spoon", "Hat"] }, 
+      hint: { en: "Think about how signals travel!" }
+    },
   ],
   g3_5: [
-    { clueText: "I process data to make decisions", correctLabel: "CPU", distractors: ["Battery", "Speaker", "Fan"], hint: "The brain of a computer!" },
-    { clueText: "I store data even when power is off", correctLabel: "Hard Drive", distractors: ["Screen", "Keyboard", "Mouse"], hint: "Where do files live permanently?" },
-    { clueText: "I detect changes in temperature, light, or motion", correctLabel: "Sensor", distractors: ["Printer", "Charger", "Cable"], hint: "How do robots know what's around them?" },
-    { clueText: "I convert electrical signals into movement", correctLabel: "Actuator", distractors: ["Microphone", "Filter", "Lens"], hint: "What turns signals into action?" },
-    { clueText: "I repeat a set of instructions until a condition is met", correctLabel: "Loop", distractors: ["Variable", "Comment", "Import"], hint: "Think about doing something over and over!" },
-    { clueText: "I protect a system by checking inputs before processing", correctLabel: "Validation", distractors: ["Encryption", "Compression", "Rendering"], hint: "Making sure data is correct before using it!" },
-    { clueText: "I allow two systems to communicate using a shared protocol", correctLabel: "API", distractors: ["URL", "DNS", "RAM"], hint: "A bridge between programs!" },
-    { clueText: "I find and fix errors in code by testing step by step", correctLabel: "Debugging", distractors: ["Compiling", "Deploying", "Formatting"], hint: "Like being a code detective!" },
+    { clueText: { en: "I process data to make decisions" }, 
+      correctLabel: { en: "CPU" }, 
+      distractors: { en: ["Battery", "Speaker", "Fan"] }, 
+      hint: { en: "The brain of a computer!" }
+    },
+    { clueText: { en: "I store data even when power is off" }, 
+      correctLabel: { en: "Hard Drive" }, 
+      distractors: { en: ["Screen", "Keyboard", "Mouse"] }, 
+      hint: { en: "Where do files live permanently?" }
+    },
+    { clueText: { en: "I detect changes in temperature, light, or motion" }, 
+      correctLabel: { en: "Sensor" }, 
+      distractors: { en: ["Printer", "Charger", "Cable"] }, 
+      hint: { en: "How do robots know what's around them?" }
+    },
+    { clueText: { en: "I convert electrical signals into movement" }, 
+      correctLabel: { en: "Actuator" }, 
+      distractors: { en: ["Microphone", "Filter", "Lens"] }, 
+      hint: { en: "What turns signals into action?" }
+    },
+    { clueText: { en: "I repeat a set of instructions until a condition is met" }, 
+      correctLabel: { en: "Loop" }, 
+      distractors: { en: ["Variable", "Comment", "Import"] }, 
+      hint: { en: "Think about doing something over and over!" }
+    },
+    { clueText: { en: "I protect a system by checking inputs before processing" }, 
+      correctLabel: { en: "Validation" }, 
+      distractors: { en: ["Encryption", "Compression", "Rendering"] }, 
+      hint: { en: "Making sure data is correct before using it!" }
+    },
+    { clueText: { en: "I allow two systems to communicate using a shared protocol" }, 
+      correctLabel: { en: "API" }, 
+      distractors: { en: ["URL", "DNS", "RAM"] }, 
+      hint: { en: "A bridge between programs!" }
+    },
+    { clueText: { en: "I find and fix errors in code by testing step by step" }, 
+      correctLabel: { en: "Debugging" }, 
+      distractors: { en: ["Compiling", "Deploying", "Formatting"] }, 
+      hint: { en: "Like being a code detective!" }
+    },
   ],
 };
 
@@ -73,33 +133,101 @@ export const BOOST_PATH_LEVELS: Record<GradeBand, PathLevel[]> = {
 // ── Bounce & Buds content ───────────────────────────────────────────────
 
 export interface BounceRoundContent {
-  clueText: string;
-  correctLabel: string;
-  distractors: string[];
-  theme: string;
+  clueText: Record<string, string>;
+  correctLabel: Record<string, string>;
+  distractors: Record<string, string[]>;
+  theme: Record<string, string>;
 }
 
 export const BOUNCE_BUDS_ROUNDS: Record<GradeBand, BounceRoundContent[]> = {
   k2: [
-    { clueText: "Which one helps a plant grow?", correctLabel: "Water", distractors: ["Rock", "Metal"], theme: "plant-needs" },
-    { clueText: "Which part drinks water from the soil?", correctLabel: "Root", distractors: ["Cloud", "Button"], theme: "plant-parts" },
-    { clueText: "Plants use this to make food!", correctLabel: "Sunlight", distractors: ["Wind", "Ice"], theme: "plant-needs" },
-    { clueText: "This part helps make food for the plant.", correctLabel: "Leaf", distractors: ["Sand", "Coin"], theme: "plant-parts" },
-    { clueText: "Roots grow in this!", correctLabel: "Soil", distractors: ["Glass", "Plastic"], theme: "plant-needs" },
-    { clueText: "Which one is a tiny living helper?", correctLabel: "Microbe", distractors: ["Brick", "Wire"], theme: "tiny-living-things" },
-    { clueText: "This part holds the plant up tall!", correctLabel: "Stem", distractors: ["Rope", "Tape"], theme: "plant-parts" },
-    { clueText: "Every living thing is made of these!", correctLabel: "Cell", distractors: ["Pixel", "Dot"], theme: "tiny-living-things" },
+    { clueText: { en: "Which one helps a plant grow?" }, 
+      correctLabel: { en: "Water" }, 
+      distractors: { en: ["Rock", "Metal"] }, 
+      theme: { en: "plant-needs" }
+    },
+    { clueText: { en: "Which part drinks water from the soil?" }, 
+      correctLabel: { en: "Root" }, 
+      distractors: { en: ["Cloud", "Button"] }, 
+      theme: { en: "plant-parts" }
+    },
+    { clueText: { en: "Plants use this to make food!" }, 
+      correctLabel: { en: "Sunlight" }, 
+      distractors: { en: ["Wind", "Ice"] }, 
+      theme: { en: "plant-needs" }
+    },
+    { clueText: { en: "This part helps make food for the plant." }, 
+      correctLabel: { en: "Leaf" }, 
+      distractors: { en: ["Sand", "Coin"] }, 
+      theme: { en: "plant-parts" }
+    },
+    { clueText: { en: "Roots grow in this!" }, 
+      correctLabel: { en: "Soil" }, 
+      distractors: { en: ["Glass", "Plastic"] }, 
+      theme: { en: "plant-needs" }
+    },
+    { clueText: { en: "Which one is a tiny living helper?" }, 
+      correctLabel: { en: "Microbe" }, 
+      distractors: { en: ["Brick", "Wire"] }, 
+      theme: { en: "tiny-living-things" }
+    },
+    { clueText: { en: "This part holds the plant up tall!" }, 
+      correctLabel: { en: "Stem" }, 
+      distractors: { en: ["Rope", "Tape"] }, 
+      theme: { en: "plant-parts" }
+    },
+    { clueText: { en: "Every living thing is made of these!" }, 
+      correctLabel: { en: "Cell" }, 
+      distractors: { en: ["Pixel", "Dot"] }, 
+      theme: { en: "tiny-living-things" }
+    },
   ],
   g3_5: [
-    { clueText: "Which process converts sunlight into energy for plants?", correctLabel: "Photosynthesis", distractors: ["Evaporation", "Combustion", "Erosion"], theme: "plant-science" },
-    { clueText: "What gas do plants absorb from the air?", correctLabel: "Carbon Dioxide", distractors: ["Oxygen", "Nitrogen", "Helium"], theme: "plant-science" },
-    { clueText: "Which part of a plant carries water from roots to leaves?", correctLabel: "Xylem", distractors: ["Petal", "Seed", "Bark"], theme: "plant-parts" },
-    { clueText: "What do plants release into the air as a byproduct?", correctLabel: "Oxygen", distractors: ["Carbon Dioxide", "Methane", "Smoke"], theme: "plant-science" },
-    { clueText: "Which organism breaks down dead plants and returns nutrients to soil?", correctLabel: "Decomposer", distractors: ["Predator", "Pollinator", "Parasite"], theme: "ecosystems" },
-    { clueText: "What is the green pigment in leaves called?", correctLabel: "Chlorophyll", distractors: ["Melanin", "Keratin", "Cellulose"], theme: "plant-science" },
-    { clueText: "Which variable would you change in a plant growth experiment?", correctLabel: "Amount of water", distractors: ["Type of ruler", "Color of pot", "Day of week"], theme: "fair-test" },
-    { clueText: "A fair test changes only ONE variable. What stays the same?", correctLabel: "Controlled variables", distractors: ["All variables", "The hypothesis", "The conclusion"], theme: "fair-test" },
-    { clueText: "Plants compete for sunlight. What happens to a plant in shade?", correctLabel: "It grows taller to reach light", distractors: ["It turns blue", "It stops growing roots", "It makes more seeds"], theme: "ecosystems" },
+    { clueText: { en: "Which process converts sunlight into energy for plants?" }, 
+      correctLabel: { en: "Photosynthesis" }, 
+      distractors: { en: ["Evaporation", "Combustion", "Erosion"] }, 
+      theme: { en: "plant-science" }
+    },
+    { clueText: { en: "What gas do plants absorb from the air?" }, 
+      correctLabel: { en: "Carbon Dioxide" }, 
+      distractors: { en: ["Oxygen", "Nitrogen", "Helium"] }, 
+      theme: { en: "plant-science" }
+    },
+    { clueText: { en: "Which part of a plant carries water from roots to leaves?" }, 
+      correctLabel: { en: "Xylem" }, 
+      distractors: { en: ["Petal", "Seed", "Bark"] }, 
+      theme: { en: "plant-parts" }
+    },
+    { clueText: { en: "What do plants release into the air as a byproduct?" }, 
+      correctLabel: { en: "Oxygen" }, 
+      distractors: { en: ["Carbon Dioxide", "Methane", "Smoke"] }, 
+      theme: { en: "plant-science" }
+    },
+    { clueText: { en: "Which organism breaks down dead plants and returns nutrients to soil?" }, 
+      correctLabel: { en: "Decomposer" }, 
+      distractors: { en: ["Predator", "Pollinator", "Parasite"] }, 
+      theme: { en: "ecosystems" }
+    },
+    { clueText: { en: "What is the green pigment in leaves called?" }, 
+      correctLabel: { en: "Chlorophyll" }, 
+      distractors: { en: ["Melanin", "Keratin", "Cellulose"] }, 
+      theme: { en: "plant-science" }
+    },
+    { clueText: { en: "Which variable would you change in a plant growth experiment?" }, 
+      correctLabel: { en: "Amount of water" }, 
+      distractors: { en: ["Type of ruler", "Color of pot", "Day of week"] }, 
+      theme: { en: "fair-test" }
+    },
+    { clueText: { en: "A fair test changes only ONE variable. What stays the same?" }, 
+      correctLabel: { en: "Controlled variables" }, 
+      distractors: { en: ["All variables", "The hypothesis", "The conclusion"] }, 
+      theme: { en: "fair-test" }
+    },
+    { clueText: { en: "Plants compete for sunlight. What happens to a plant in shade?" }, 
+      correctLabel: { en: "It grows taller to reach light" }, 
+      distractors: { en: ["It turns blue", "It stops growing roots", "It makes more seeds"] }, 
+      theme: { en: "ecosystems" }
+    },
   ],
 };
 

--- a/src/components/games/gradeBandContent.ts
+++ b/src/components/games/gradeBandContent.ts
@@ -22,6 +22,7 @@ export interface GearRoundContent {
   hint?: Record<string, string>;
 }
 
+// TODO: add translations
 export const GOTCHA_GEARS_CONTENT: Record<GradeBand, GearRoundContent[]> = {
   k2: [
     { clueText: { en: "I help a robot think and learn" }, 
@@ -139,6 +140,7 @@ export interface BounceRoundContent {
   theme: Record<string, string>;
 }
 
+// TODO: add translations
 export const BOUNCE_BUDS_ROUNDS: Record<GradeBand, BounceRoundContent[]> = {
   k2: [
     { clueText: { en: "Which one helps a plant grow?" }, 


### PR DESCRIPTION
Addresses #631. Localizes hardcoded strings using PickLocale:
- briefings for MazeMaps, MoveMeasure, SkyShield, FastLane, QualifyTuneRace, GotchaGears, BounceBuds
- round-content data: GOTCHA_GEARS_CONTENT, BOUNCE_BUDS_ROUNDS
- BounceBuds coach string: "Drag to aim. Tap anywhere to bounce!"