### PR TITLE
chore: remove vestigial Vercel deploy config (we deploy via Railway)

### DIFF
--- a/DEPLOYMENT_RAILWAY.md
+++ b/DEPLOYMENT_RAILWAY.md
@@ -1,16 +1,16 @@
-# Deployment: Vercel (FE) + Railway (BE) + Supabase (DB)
+# Deployment: Railway (FE + BE) + Supabase (DB)
 
 This guide provides instructions for deploying the BrightBoost application stack.
 
 ## Architecture
 
-- **Frontend**: React (Vite) hosted on Vercel.
+- **Frontend**: React (Vite) build served on Railway (nginx via `Dockerfile.frontend`, or Express with `SERVE_FRONTEND=true`).
 - **Backend**: Node.js (Express) hosted on Railway.
 - **Database**: PostgreSQL hosted on Supabase.
 
 ## Prerequisites
 
-- Accounts on [Vercel](https://vercel.com), [Railway](https://railway.app), and [Supabase](https://supabase.com).
+- Accounts on [Railway](https://railway.app) and [Supabase](https://supabase.com).
 - GitHub repository with the codebase.
 
 ## 1. Database (Supabase)
@@ -38,17 +38,15 @@ This guide provides instructions for deploying the BrightBoost application stack
     - `NODE_ENV`: `production`
     - _For local dev, `DIRECT_URL` can equal `DATABASE_URL` (both point at your local Postgres)._
 
-## 3. Frontend (Vercel)
+## 3. Frontend (Railway)
 
-1.  Create a new project on Vercel.
-2.  Import the GitHub repo.
-3.  Configure the project:
-    - **Framework Preset**: Vite
-    - **Root Directory**: `.` (default)
-    - **Build Command**: `npm run build`
-    - **Output Directory**: `dist`
-4.  Set Environment Variables:
-    - `VITE_AWS_API_URL`: The URL of your deployed Railway backend (e.g., `https://brightboost-backend.up.railway.app`). **Important:** Do not add a trailing slash.
+1.  Create a second Railway service from the same GitHub repo (the frontend).
+2.  Configure the service to build from `Dockerfile.frontend` (Vite build served by nginx).
+3.  Set Build/Service Variables:
+    - `VITE_API_BASE`: `/api` (default) — keeps API calls same-origin. The nginx config (`docs/nginx.conf`) proxies `/api/` → `${BACKEND_URL}/api/`.
+    - `BACKEND_URL`: The URL of your deployed Railway backend (e.g., `https://brightboost-backend.up.railway.app`). **Important:** Do not add a trailing slash.
+
+    _Note: `VITE_*` vars are inlined at build time, so they must be present in Railway's service variables when the image builds (see `Dockerfile.frontend`)._
 
 ## 4. Database Initialization
 
@@ -76,4 +74,4 @@ After deploying, you need to initialize the database schema and seed it.
 ## Troubleshooting
 
 - **Prisma Errors**: Ensure your `DATABASE_URL` is correct and the database is reachable. If you see connection limit errors, consider using the Supabase Transaction pooler (port 6543) for the app, but keep using Session pooler (port 5432) for migrations.
-- **CORS Issues**: If the frontend cannot talk to the backend, check the browser console. You might need to configure CORS in `backend/src/server.ts` to accept requests from your Vercel domain.
+- **CORS Issues**: If the frontend cannot talk to the backend, check the browser console. With same-origin `/api` (nginx proxy) you should not hit CORS; if you serve the frontend from a different origin, configure CORS in `backend/src/server.ts` to accept requests from your frontend domain.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ brightboost/
 ├── dist/games/spacewar/        # Built Spacewar WebGL assets
 ├── cypress/                    # E2E tests
 ├── public/                     # Static assets
-├── vercel.json                 # Vercel deployment config
 └── package.json
 ```
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/api/:path*",
-      "destination": "https://brightboost-production.up.railway.app/api/:path*"
-    }
-  ]
-}


### PR DESCRIPTION
## What & why

Production runs entirely on **Railway** (frontend served by nginx via `Dockerfile.frontend`, backend on Railway, Supabase DB). The `vercel.json` in the repo was inert leftover config — its only live effect was the Vercel↔GitHub integration uselessly building every PR, which surfaced as a **failing check nobody could action**. No CI workflow ever referenced Vercel.

This removes the repo-side Vercel config. **Confirmed vestigial before removing** — see the `/api` note below.

## The one real risk: `/api` routing — survives without `vercel.json` ✅

`vercel.json` only proxied `/api` → Railway, and only mattered *if* deployed on Vercel. Production `/api` routing is handled elsewhere:
- **nginx** — `docs/nginx.conf`: `location /api/ { proxy_pass ${BACKEND_URL}/api/; }`
- Bundle defaults `API_BASE` to `/api` — `Dockerfile.frontend` `ARG VITE_API_BASE=/api`, `src/services/api.ts`
- Local dev — Vite proxy in `vite.config.ts`

`vercel.json` was never on the production path. `npm run build` passes after removal.

## Changes
- Delete `vercel.json` (the `/api` proxy rewrite)
- Rename `DEPLOYMENT_VERCEL_RAILWAY.md` → `DEPLOYMENT_RAILWAY.md`; rewrite the frontend section to Railway
- Drop the `vercel.json` line from the README file tree

## Still required outside this PR (founder action)
This PR removes the *config* but does **not** stop the failing check by itself:
- Vercel dashboard → the project → Settings → Disconnect Git / Delete project
- GitHub → repo Settings → GitHub Apps → Vercel → remove repo access (if Vercel isn't used elsewhere)

## Branch protection
Vercel is **not** a CI job, so it can't be a required check via workflows. When required checks are enabled, set them to `build-and-test` + `build-only` ONLY — never `vercel` or `db-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016xGTAyN6dAVmis8h5RqP2C)_