### PR TITLE
feat: differentiate sweeper visuals by type

### DIFF
--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -24,6 +24,7 @@ type Dir = "up" | "down" | "left" | "right" | "wait";
 
 interface SweepConfig {
   id: string;
+  type: keyof typeof SWEEPER_STYLES;
   loop: [number, number][];
   startIndex: number;
 }
@@ -49,6 +50,17 @@ type GamePhase = "intro" | "tutorial" | "watchPattern" | "guided" | "main" | "ex
 const CELL = 52;
 const MAX_COLLISIONS_FOR_HINT = 2;
 
+interface SweeperStyle {
+  color: string;
+  icon: string;
+  label: string;
+}
+
+const SWEEPER_STYLES: Record<string, SweeperStyle> = {
+  loop: { icon: "🔴", color: "text-red-500", label: "Loop Sweeper" },
+  linear: { icon: "🟢", color: "text-blue-500", label: "Line Sweeper" },
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Map Data (build-in maps for K2)
 // ═══════════════════════════════════════════════════════════════════════════
@@ -69,7 +81,7 @@ export const MAPS_k2: Record<string, MazeMapConfig> = {
     orbs: [[0, 2], [2, 0], [4, 3], [3, 1]],
     safePads: [[2, 2]],
     sweepers: [
-      { id: "s1", loop: [[1, 3], [1, 4], [2, 4], [2, 3], [1, 3]], startIndex: 0 },
+      { id: "s1", type: "loop", loop: [[1, 3], [1, 4], [2, 4], [2, 3], [1, 3]], startIndex: 0 },
     ],
   },
   main: {
@@ -79,8 +91,8 @@ export const MAPS_k2: Record<string, MazeMapConfig> = {
     orbs: [[0, 2], [1, 5], [2, 0], [4, 6], [5, 3], [6, 5]],
     safePads: [[3, 3], [1, 4]],
     sweepers: [
-      { id: "s1", loop: [[2, 2], [2, 3], [3, 3], [3, 2], [2, 2]], startIndex: 0 },
-      { id: "s2", loop: [[4, 4], [4, 5], [5, 5], [5, 4], [4, 4]], startIndex: 0 },
+      { id: "s1", type: "loop", loop: [[2, 2], [2, 3], [3, 3], [3, 2], [2, 2]], startIndex: 0 },
+      { id: "s2", type: "loop", loop: [[4, 4], [4, 5], [5, 5], [5, 4], [4, 4]], startIndex: 0 },
     ],
   },
 };
@@ -193,12 +205,29 @@ function MazeBoard({
       ))}
 
       {/* Sweepers */}
-      {Object.entries(sweeperPositions).map(([id, [sr, sc]]) => (
-        <div key={id} className="absolute flex items-center justify-center z-10 transition-all duration-200"
-          style={{ left: sc * CELL, top: sr * CELL, width: CELL, height: CELL }}>
-          <span className="text-2xl">🔴</span>
+      {Object.entries(sweeperPositions).map(([id, [sr, sc]]) => {
+      const sweeper = map.sweepers.find((s) => s.id === id);
+      const style =
+        SWEEPER_STYLES[sweeper?.type as keyof typeof SWEEPER_STYLES]
+        ?? {
+          icon: "⚫",
+          color: "text-black",
+          label: "Unknown Sweeper",
+        };
+
+      return (
+        <div
+        key={id}
+        className="absolute flex items-center justify-center z-10 transition-all duration-200"
+        style={{left: sc * CELL, top: sr * CELL, width: CELL, height: CELL,}}
+        title={style.label}
+        >
+        <span className={`text-2xl ${style.color}`}>
+            {style.icon}
+        </span>
         </div>
-      ))}
+      );
+      })}
 
       {/* Player */}
       <div className="absolute flex items-center justify-center z-20 transition-all duration-200"

--- a/src/components/games/gradeBandContent.ts
+++ b/src/components/games/gradeBandContent.ts
@@ -376,8 +376,20 @@ export function applyG35StoryOverrides(
 // 
 // 
 
+interface SweeperStyle {
+  color: string;
+  icon: string;
+  label: string;
+}
+
+const SWEEPER_STYLES: Record<string, SweeperStyle> = {
+  loop: { icon: "🔴", color: "text-red-500", label: "Loop Sweeper" },
+  linear: { icon: "🟢", color: "text-blue-500", label: "Line Sweeper" },
+};
+
 export interface SweepConfig {
   id: string;
+  type: keyof typeof SWEEPER_STYLES;
   loop: [number, number][];
   startIndex: number;
 }
@@ -403,6 +415,7 @@ export const MAPS_G3_5: Record<string, MazeMapConfig> = {
     safePads: [],
     sweepers: [],
   },
+
   guided: {
     id: "guided", rows: 6, cols: 6,
     start: [5, 0], goal: [5, 5],
@@ -410,10 +423,11 @@ export const MAPS_G3_5: Record<string, MazeMapConfig> = {
     orbs: [[2, 0], [2, 3], [3, 5], [5, 2]],
     safePads: [[1, 3]],
     sweepers: [
-      { id: "s1", loop: [[3, 3], [3, 2], [2, 2], [2, 3], [3, 3]], startIndex: 0 },
-      { id: "s2", loop: [[0, 4], [1, 4], [2, 4], [3, 4], [2, 4], [1, 4], [0, 4]], startIndex: 0 },
+      { id: "s1", type: "loop", loop: [[3, 3], [3, 2], [2, 2], [2, 3], [3, 3]], startIndex: 0 },
+      { id: "s2", type: "linear", loop: [[0, 4], [1, 4], [2, 4], [3, 4], [2, 4], [1, 4], [0, 4]], startIndex: 0 },
     ],
   },
+  
   main: {
     id: "main", rows: 7, cols: 7,
     start: [6, 0], goal: [5, 3],
@@ -421,10 +435,12 @@ export const MAPS_G3_5: Record<string, MazeMapConfig> = {
     orbs: [[3, 0], [1, 3], [2, 6], [4, 4], [6, 2], [5, 6]],
     safePads: [[2, 1], [0, 6]],
     sweepers: [
-      { id: "s1", loop: [[5, 1], [5, 0], [4, 0], [4, 1], [5, 1]], startIndex: 0 },
-      { id: "s2", loop: [[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]], startIndex: 0 },
-      { id: "s3", loop: [[0, 5], [1, 5], [2, 5], [3, 5], [4, 5], [5, 5], [6, 5], [5, 5], [4, 5], [3, 5], [2, 5], [1, 5], [0, 5]], startIndex: 0 },
-      { id: "s4", loop: [[6, 6], [6, 5], [5, 5], [5, 6], [6, 6]], startIndex: 0 },
+      { id: "s1", type: "loop", loop: [[5, 1], [5, 0], [4, 0], [4, 1], [5, 1]], startIndex: 0 },
+      { id: "s2", type: "loop", loop: [[1, 2], [2, 2], [2, 3], [1, 3], [1, 2]], startIndex: 0 },
+      { id: "s3", type: "linear", 
+        loop: [[0, 5], [1, 5], [2, 5], [3, 5], [4, 5], [5, 5], [6, 5], [5, 5], [4, 5], [3, 5], [2, 5], [1, 5], [0, 5]], 
+        startIndex: 0 },
+      { id: "s4", type: "loop", loop: [[6, 6], [6, 5], [5, 5], [5, 6], [6, 6]], startIndex: 0 },
     ],
   },
 };


### PR DESCRIPTION
## Summary

This PR introduces visual differentiation for multiple sweeper behaviors in Grade 3–5 Maze Maps.

Previously, all sweepers shared the same visual representation, making it difficult to distinguish movement patterns during gameplay.

## Changes

- Added SWEEPER_STYLES mapping for sweeper types (e.g. loop, linear)
- Introduced type field support in SweepConfig 
- Render sweepers with distinct icons/colors based on their type:
  - Loop sweepers: 🔴 
  - Linear sweepers: 🟢
- Added fallback rendering (⚫) for unknown or missing sweeper types

Closes #659