### PR TITLE
fix: maze map exit ticket auto-advance

### DIFF
--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -48,6 +48,7 @@ type GamePhase = "intro" | "tutorial" | "watchPattern" | "guided" | "main" | "ex
 
 const CELL = 52;
 const MAX_COLLISIONS_FOR_HINT = 2;
+const playPhases = new Set(["tutorial", "guided", "main"]);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Map Data (build-in maps for K2)
@@ -430,11 +431,11 @@ function MazeMapsCore({
 
   // Auto-advance on level complete
   useEffect(() => {
-    if (levelComplete) {
+    if (levelComplete && playPhases.has(phase)) {
       const t = setTimeout(advancePhase, 1500);
       return () => clearTimeout(t);
     }
-  }, [levelComplete, advancePhase]);
+  }, [levelComplete, phase, advancePhase]);
 
   // ── Watch Pattern phase: auto-cycle sweeper ──
   const watchTimerRef = useRef<ReturnType<typeof setInterval>>();

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -431,10 +431,13 @@ function MazeMapsCore({
 
   // Auto-advance on level complete
   useEffect(() => {
-    if (levelComplete && playPhases.has(phase)) {
-      const t = setTimeout(advancePhase, 1500);
-      return () => clearTimeout(t);
-    }
+    if (!levelComplete) return;
+    if (!playPhases.has(phase)) return;
+    const t = setTimeout(() => {
+      advancePhase();
+      setLevelComplete(false);
+    }, 1500);
+    return () => clearTimeout(t);
   }, [levelComplete, phase, advancePhase]);
 
   // ── Watch Pattern phase: auto-cycle sweeper ──


### PR DESCRIPTION
## Summary

Fix auto-advance bug in Maze Map. Previously the exit ticket phase was skipped immediately upon entering because levelComplete remained true from the previous gameplay phase.

## Changes
- Reset levelComplete after phase advancement
- Only auto-advance during active play phases


Closes #657. 