### PR TITLE
Catarina/in game progress hud

### DIFF
--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -47,7 +47,7 @@ type GamePhase = "intro" | "tutorial" | "watchPattern" | "guided" | "main" | "ex
 
 const CELL = 52;
 const MAX_COLLISIONS_FOR_HINT = 2;
-const LEVELS = 3;
+const LEVELS = 4; // 3, but +1 offset
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Map Data

--- a/src/components/games/MazeMapsGame.tsx
+++ b/src/components/games/MazeMapsGame.tsx
@@ -12,7 +12,7 @@
  */
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
+import GameShell, { ProgressHUD, type GameResult, type MissionBriefing } from "./shared/GameShell";
 import "./shared/game-effects.css";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -47,6 +47,7 @@ type GamePhase = "intro" | "tutorial" | "watchPattern" | "guided" | "main" | "ex
 
 const CELL = 52;
 const MAX_COLLISIONS_FOR_HINT = 2;
+const LEVELS = 3;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Map Data
@@ -506,6 +507,7 @@ function MazeMapsCore({ onFinish }: { onFinish: (result: GameResult) => void }) 
     ];
     return (
       <div className="text-center space-y-6 py-8 slide-up-fade max-w-lg mx-auto">
+        <ProgressHUD step={3} totalLevels={LEVELS}/>
         <div className="text-5xl">🤔</div>
         <h3 className="text-xl font-extrabold text-cyan-800">
           {t("games.mazeMaps.exitQuestion", { defaultValue: "Which path is smartest?" })}
@@ -616,6 +618,9 @@ function MazeMapsCore({ onFinish }: { onFinish: (result: GameResult) => void }) 
           </span>
         )}
       </div>
+      <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto">
+          <ProgressHUD step={phase === "tutorial" ? 0 : phase === "guided" ? 1 : 2} totalLevels={LEVELS}/>
+        </div>
 
       {/* Board */}
       <MazeBoard

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -232,7 +232,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
           )}
         </div>
         {/*current progress bar*/}
-        <div className="h-3 bg-slate-200 rounded-full overflow-hidden"> 
+        <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto"> 
           {/* <div className="h-full bg-gradient-to-r from-amber-400 to-amber-500 transition-all duration-100 rounded-full"
             style={{ width: `${progress * 100}%` }} /> */}
           <ProgressHUD step={step} totalLevels={LEVELS} />
@@ -295,10 +295,11 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
   // ── Phase: results1 ─────────────────────────────────────────────────
   if (phase === "results1" && run1) return (
     <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto">
+      <ProgressHUD step={1} totalLevels={LEVELS} />      
       <h2 className="text-2xl font-extrabold text-amber-900">
         {t("games.qualifyTuneRace.qualifyResults", { defaultValue: "Qualifying Results" })}
       </h2>
-      <ProgressHUD step={1} totalLevels={LEVELS} />
+
       <div className="grid grid-cols-3 gap-3">
         <MetricCard icon={timeIcon(run1.time)} value={`${run1.time}s`}
           label={`⏱️ ${t("games.qualifyTuneRace.time", { defaultValue: "Time" })}`}
@@ -333,11 +334,12 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
         desc: t("games.qualifyTuneRace.steeringDesc", { defaultValue: "Smoother, more predictable turns" }) },
     ];
     return (
-      <div className="slide-up-fade text-center space-y-6 py-6 max-w-lg mx-auto">
+      <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto">
+        <ProgressHUD step={step} totalLevels={LEVELS} />
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.tuneTitle", { defaultValue: "Pick ONE Upgrade" })}
         </h2>
-        <ProgressHUD step={step} totalLevels={LEVELS} />
+
         <p className="text-base text-slate-600">
           {t("games.qualifyTuneRace.tuneHint", { defaultValue: "Change only one thing — that's how scientists test!" })}
         </p>
@@ -378,11 +380,13 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
       { label: t("games.qualifyTuneRace.smoothness", { defaultValue: "Smoothness" }), icon: "🌊", v1: run1.smoothness, v2: run2.smoothness, unit: "", lb: false },
     ];
     return (
+
       <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto">
+        <ProgressHUD step={2} totalLevels={LEVELS} />              
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.compareTitle", { defaultValue: "Run 1 vs Run 2" })}
         </h2>
-        <ProgressHUD step={step} totalLevels={LEVELS} />
+
         <div className="space-y-3">
           {metrics.map((m) => {
             const better = m.lb ? m.v2 < m.v1 : m.v2 > m.v1;
@@ -425,10 +429,11 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
     const answered = exitAnswer !== null, correct = exitAnswer === "one";
     return (
       <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto">
+      <ProgressHUD step={2} totalLevels={LEVELS} />        
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.exitQuestion", { defaultValue: "To make a fair test, how many things should you change?" })}
         </h2>
-        <ProgressHUD step={step} totalLevels={LEVELS} />
+   
         <div className="grid gap-3">
           {opts.map((o) => {
             const isSel = exitAnswer === o.key, isCorr = o.key === "one";

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -4,7 +4,7 @@
  */
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import GameShell, { type GameResult, type MissionBriefing } from "./shared/GameShell";
+import GameShell, { type GameResult, type MissionBriefing, ProgressHUD } from "./shared/GameShell";
 import "./shared/game-effects.css";
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -17,6 +17,7 @@ interface Obstacle { lane: number; y: number }
 const TRACK_W = 360, TRACK_H = 480, LANE_W = TRACK_W / 3;
 const CAR_W = 48, CAR_H = 64, CONE_SIZE = 36;
 const SCROLL_SPEED = 2.5, TRACK_LENGTH = 3200, BUMP_ZONE = 28;
+const LEVELS = 3; // Account for +1 offset
 
 const OBSTACLES: Obstacle[] = [
   { lane: 1, y: 300 }, { lane: 0, y: 600 }, { lane: 2, y: 900 },
@@ -103,6 +104,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
   const [run2, setRun2] = useState<RunResult | null>(null);
   const [upgrade, setUpgrade] = useState<Upgrade | null>(null);
   const [exitAnswer, setExitAnswer] = useState<string | null>(null);
+  const [step, setStep] = useState(0);
 
   const rafId = useRef(0);
   const startTime = useRef(0);
@@ -212,7 +214,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
 
   // ── Phase: qualify / race ───────────────────────────────────────────
   if (phase === "qualify" || phase === "race") {
-    const progress = Math.min(scrollY / TRACK_LENGTH, 1);
+    //const progress = Math.min(scrollY / TRACK_LENGTH, 1);
     const isRacePhase = phase === "race";
     return (
       <div className="space-y-3">
@@ -229,9 +231,11 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
             </span>
           )}
         </div>
-        <div className="h-3 bg-slate-200 rounded-full overflow-hidden">
-          <div className="h-full bg-gradient-to-r from-amber-400 to-amber-500 transition-all duration-100 rounded-full"
-            style={{ width: `${progress * 100}%` }} />
+        {/*current progress bar*/}
+        <div className="h-3 bg-slate-200 rounded-full overflow-hidden"> 
+          {/* <div className="h-full bg-gradient-to-r from-amber-400 to-amber-500 transition-all duration-100 rounded-full"
+            style={{ width: `${progress * 100}%` }} /> */}
+          <ProgressHUD step={step} totalLevels={LEVELS} />
         </div>
         <div ref={wrapperRef} className="mx-auto select-none" style={{ maxWidth: TRACK_W }}>
           <div className="relative overflow-hidden rounded-2xl border-2 border-amber-300 shadow-lg"
@@ -294,6 +298,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
       <h2 className="text-2xl font-extrabold text-amber-900">
         {t("games.qualifyTuneRace.qualifyResults", { defaultValue: "Qualifying Results" })}
       </h2>
+      <ProgressHUD step={1} totalLevels={LEVELS} />
       <div className="grid grid-cols-3 gap-3">
         <MetricCard icon={timeIcon(run1.time)} value={`${run1.time}s`}
           label={`⏱️ ${t("games.qualifyTuneRace.time", { defaultValue: "Time" })}`}
@@ -307,7 +312,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
       <p className="text-lg font-bold text-slate-700">
         {t("games.qualifyTuneRace.whatChange", { defaultValue: "What should we change?" })}
       </p>
-      <button onClick={() => setPhase("tune")}
+      <button onClick={() => {setPhase("tune"); setStep(prev => prev + 1);}}
         className="px-8 py-4 text-lg font-bold rounded-2xl bg-gradient-to-r from-amber-500 to-amber-600 text-white shadow-lg hover:scale-105 active:scale-95 transition-transform">
         {t("games.qualifyTuneRace.pickUpgrade", { defaultValue: "Pick an Upgrade!" })}
       </button>
@@ -332,6 +337,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.tuneTitle", { defaultValue: "Pick ONE Upgrade" })}
         </h2>
+        <ProgressHUD step={step} totalLevels={LEVELS} />
         <p className="text-base text-slate-600">
           {t("games.qualifyTuneRace.tuneHint", { defaultValue: "Change only one thing — that's how scientists test!" })}
         </p>
@@ -376,6 +382,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.compareTitle", { defaultValue: "Run 1 vs Run 2" })}
         </h2>
+        <ProgressHUD step={step} totalLevels={LEVELS} />
         <div className="space-y-3">
           {metrics.map((m) => {
             const better = m.lb ? m.v2 < m.v1 : m.v2 > m.v1;
@@ -421,6 +428,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
         <h2 className="text-2xl font-extrabold text-amber-900">
           {t("games.qualifyTuneRace.exitQuestion", { defaultValue: "To make a fair test, how many things should you change?" })}
         </h2>
+        <ProgressHUD step={step} totalLevels={LEVELS} />
         <div className="grid gap-3">
           {opts.map((o) => {
             const isSel = exitAnswer === o.key, isCorr = o.key === "one";

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -17,7 +17,7 @@ interface Obstacle { lane: number; y: number }
 const TRACK_W = 360, TRACK_H = 480, LANE_W = TRACK_W / 3;
 const CAR_W = 48, CAR_H = 64, CONE_SIZE = 36;
 const SCROLL_SPEED = 2.5, TRACK_LENGTH = 3200, BUMP_ZONE = 28;
-const LEVELS = 2;
+const LEVELS = 3; // 2 levels, but +1 offset
 
 const OBSTACLES: Obstacle[] = [
   { lane: 1, y: 300 }, { lane: 0, y: 600 }, { lane: 2, y: 900 },

--- a/src/components/games/QualifyTuneRaceGame.tsx
+++ b/src/components/games/QualifyTuneRaceGame.tsx
@@ -17,7 +17,7 @@ interface Obstacle { lane: number; y: number }
 const TRACK_W = 360, TRACK_H = 480, LANE_W = TRACK_W / 3;
 const CAR_W = 48, CAR_H = 64, CONE_SIZE = 36;
 const SCROLL_SPEED = 2.5, TRACK_LENGTH = 3200, BUMP_ZONE = 28;
-const LEVELS = 3; // Account for +1 offset
+const LEVELS = 2;
 
 const OBSTACLES: Obstacle[] = [
   { lane: 1, y: 300 }, { lane: 0, y: 600 }, { lane: 2, y: 900 },
@@ -214,7 +214,6 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
 
   // ── Phase: qualify / race ───────────────────────────────────────────
   if (phase === "qualify" || phase === "race") {
-    //const progress = Math.min(scrollY / TRACK_LENGTH, 1);
     const isRacePhase = phase === "race";
     return (
       <div className="space-y-3">
@@ -231,10 +230,7 @@ function RacePlayfield({ onFinish, reducedEffects }: { onFinish: (r: GameResult)
             </span>
           )}
         </div>
-        {/*current progress bar*/}
         <div className="slide-up-fade text-center space-y-6 py-6 max-w-md mx-auto"> 
-          {/* <div className="h-full bg-gradient-to-r from-amber-400 to-amber-500 transition-all duration-100 rounded-full"
-            style={{ width: `${progress * 100}%` }} /> */}
           <ProgressHUD step={step} totalLevels={LEVELS} />
         </div>
         <div ref={wrapperRef} className="mx-auto select-none" style={{ maxWidth: TRACK_W }}>

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -8,7 +8,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
-import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy, Flame } from "lucide-react";
+import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy, Flame, Check } from "lucide-react";
 import ActivityHeader from "@/components/activities/ActivityHeader";
 import { usePersonalBest } from "@/hooks/usePersonalBest";
 import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
@@ -153,18 +153,18 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
   return (
     <div
       ref={containerRef}
-      className="relative h-[10px] rounded-full"
+      className="relative h-[30px] rounded-full"
       style={{
         background: "#FF8C00",
-        padding: "2px",
+        padding: "3px",
       }}
       >
        {/*Streak bar body*/}    
         <div
         className="w-full h-full rounded-full"
         style={{
-          backgroundColor: "#94a3b8", // use a dark gray instead
-          padding: "1px",
+          backgroundColor: "#fed7aa", // use a dark gray instead
+          padding: "2px",
         }}
         >
           <div
@@ -178,26 +178,32 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
 
     {/*Dots for each Level*/}
       {Array.from({ length: totalLevels}).map((_, i) => {
-        const dotPos = (i / (totalLevels - 1)) * containerWidth;
+        const dotPos = (minLeftPx + 11) + (i / (totalLevels - 1)) * (maxLeftPx - (minLeftPx + 18));
         // const n = i + 1;
         return (
           <span 
             key = {i}
-            className={`absolute rounded-full transition-all duration-300 ${
+            className={`absolute rounded-full ${
               i === step
-              ? "w-2.5 h-2.5 bg-red-500"
+              ? "w-5 h-5"
               : i < step
-                ? "w-2.5 h-2.5 bg-red-500" //make red when hit
-                : "w-2.5 h-2.5 bg-slate-200" 
+                ? "w-5 h-5 bg-red-500" //make red when hit
+                : "w-5 h-5 bg-white" 
             }`}
             style={{
             left: dotPos,
             top: "50%",
             transform:"translate(-50%, -50%)",
             }}
-          />
-        );
-      })}
+          >
+          {i < step && (
+            <span className="text-white font-bold">
+            <Check className="w-5 h-4.5" />
+            </span>
+          )}
+        </span>
+       );
+    })}
 
       {/*Flame slider icon */}
       <div 
@@ -208,7 +214,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
           transform: "translate(-50%, -50%)",
         }}
       >
-        <Flame className="w-5 h-5 text-red-500 fill-orange-300 drop-shadow-md" />
+        <Flame className="w-10 h-10 text-red-500 fill-orange-300 drop-shadow-md" />
       </div>
   </div>
   );

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -125,6 +125,35 @@ function AchievementBadge({ name, index }: { name: string; index: number }) {
   );
 }
 
+
+// ── In Game Progress HUD ────────────────────────────────────────────
+
+export function ProgressHUD({step, totalLevels}: {step:number, totalLevels: number}) {
+  return (
+    <div 
+      className = "flex items-center justify-center gap-1.5"
+      aria-hidden="true"
+    >
+      {Array.from({ length: totalLevels}).map((_, i) => {
+        const n = i + 1;
+        return (
+          <span 
+            key = {n}
+            className={`rounded-full transition-all duration-300 ${
+              i === step
+              ? "w-6 h-2.5 bg-brightboost-blue"
+              : i < step
+                ? "w-2.5 h-2.5 bg-brightboost-green"
+                : "w-2.5 h-2.5 bg-slate-200" 
+            }`}
+          />
+        );
+
+      })}
+      </div>
+  )
+}
+
 // ── Results screen (own component so hooks are never conditional) ──────────
 
 function GameResultsView({

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -149,9 +149,8 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
   const dotRadius = 10;
   const dotStart = minLeftPx + dotRadius; 
   const dotEnd = maxLeftPx - dotRadius;
-  const getPos = (index: number) => (dotStart) + (index / (totalLevels - 1)) * (dotEnd - dotStart);
   const innerWidth = containerWidth - 10;
-  
+  const getPos = (index: number) => (dotStart) + (index / (totalLevels - 1)) * (dotEnd - dotStart);
   return (
     <div
       ref={containerRef}

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -146,7 +146,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
   
   const minLeftPx = 4;
   const maxLeftPx = containerWidth - 8;
-  const progress = step / (totalLevels - 1);
+  const progress = step / (totalLevels);
   const desiredLeftPx = progress * containerWidth;
   const clampedLeftPx = Math.min(Math.max(desiredLeftPx, minLeftPx), maxLeftPx);
   
@@ -163,7 +163,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
         <div
         className="w-full h-full rounded-full"
         style={{
-          backgroundColor: "#fed7aa", // use a dark gray instead
+          backgroundColor: "#fed7aa",
           padding: "2px",
         }}
         >
@@ -178,8 +178,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
 
     {/*Dots for each Level*/}
       {Array.from({ length: totalLevels}).map((_, i) => {
-        const dotPos = (minLeftPx + 11) + (i / (totalLevels - 1)) * (maxLeftPx - (minLeftPx + 18));
-        // const n = i + 1;
+        const dotPos = (minLeftPx + 11) + (i / (totalLevels)) * (maxLeftPx - (minLeftPx + 18));
         return (
           <span 
             key = {i}
@@ -187,7 +186,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
               i === step
               ? "w-5 h-5"
               : i < step
-                ? "w-5 h-5 bg-red-500" //make red when hit
+                ? "w-5 h-5 bg-red-500"
                 : "w-5 h-5 bg-white" 
             }`}
             style={{

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -8,7 +8,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
-import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy } from "lucide-react";
+import { Star, ArrowRight, RotateCcw, Home, Sparkles, ChevronRight, Award, Trophy, Flame } from "lucide-react";
 import ActivityHeader from "@/components/activities/ActivityHeader";
 import { usePersonalBest } from "@/hooks/usePersonalBest";
 import { ReducedEffectsToggle } from "./ReducedEffectsToggle";
@@ -16,6 +16,7 @@ import { useReducedGameEffects } from "./useReducedGameEffects";
 import { ControlInstructions } from "./ControlInstructions";
 import { mergeControlInstructions, type ControlInstructionsModel } from "./controlInstructionsData";
 import "./game-effects.css";
+
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -127,31 +128,90 @@ function AchievementBadge({ name, index }: { name: string; index: number }) {
 
 
 // ── In Game Progress HUD ────────────────────────────────────────────
-
-export function ProgressHUD({step, totalLevels}: {step:number, totalLevels: number}) {
+export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: number,}){
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  useEffect(() => {
+    if (containerRef.current) {
+      setContainerWidth(containerRef.current.offsetWidth);
+    }
+    const handleResize = () => {
+      if (containerRef.current) {
+        setContainerWidth(containerRef.current.offsetWidth);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  
+  const minLeftPx = 4;
+  const maxLeftPx = containerWidth - 8;
+  const progress = step / (totalLevels - 1);
+  const desiredLeftPx = progress * containerWidth;
+  const clampedLeftPx = Math.min(Math.max(desiredLeftPx, minLeftPx), maxLeftPx);
+  
   return (
-    <div 
-      className = "flex items-center justify-center gap-1.5"
-      aria-hidden="true"
-    >
+    <div
+      ref={containerRef}
+      className="relative h-[10px] rounded-full"
+      style={{
+        background: "#FF8C00",
+        padding: "2px",
+      }}
+      >
+       {/*Streak bar body*/}    
+        <div
+        className="w-full h-full rounded-full"
+        style={{
+          backgroundColor: "#94a3b8", // use a dark gray instead
+          padding: "1px",
+        }}
+        >
+          <div
+            className="h-full rounded-full transition-all duration-300 ease-in-out"
+            style={{
+              width: `${progress * 100}%`,
+              background:"#FF8C00",
+            }}
+            />
+        </div>
+
+    {/*Dots for each Level*/}
       {Array.from({ length: totalLevels}).map((_, i) => {
-        const n = i + 1;
+        const dotPos = (i / (totalLevels - 1)) * containerWidth;
+        // const n = i + 1;
         return (
           <span 
-            key = {n}
-            className={`rounded-full transition-all duration-300 ${
+            key = {i}
+            className={`absolute rounded-full transition-all duration-300 ${
               i === step
-              ? "w-6 h-2.5 bg-brightboost-blue"
+              ? "w-2.5 h-2.5 bg-red-500"
               : i < step
-                ? "w-2.5 h-2.5 bg-brightboost-green"
+                ? "w-2.5 h-2.5 bg-red-500" //make red when hit
                 : "w-2.5 h-2.5 bg-slate-200" 
             }`}
+            style={{
+            left: dotPos,
+            top: "50%",
+            transform:"translate(-50%, -50%)",
+            }}
           />
         );
-
       })}
+
+      {/*Flame slider icon */}
+      <div 
+        className="absolute z-20"
+        style={{
+          left: clampedLeftPx,
+          top: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        <Flame className="w-5 h-5 text-red-500 fill-orange-300 drop-shadow-md" />
       </div>
-  )
+  </div>
+  );
 }
 
 // ── Results screen (own component so hooks are never conditional) ──────────

--- a/src/components/games/shared/GameShell.tsx
+++ b/src/components/games/shared/GameShell.tsx
@@ -145,10 +145,12 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
   }, []);
   
   const minLeftPx = 4;
-  const maxLeftPx = containerWidth - 8;
-  const progress = step / (totalLevels);
-  const desiredLeftPx = progress * containerWidth;
-  const clampedLeftPx = Math.min(Math.max(desiredLeftPx, minLeftPx), maxLeftPx);
+  const maxLeftPx = containerWidth - 4;
+  const dotRadius = 10;
+  const dotStart = minLeftPx + dotRadius; 
+  const dotEnd = maxLeftPx - dotRadius;
+  const getPos = (index: number) => (dotStart) + (index / (totalLevels - 1)) * (dotEnd - dotStart);
+  const innerWidth = containerWidth - 10;
   
   return (
     <div
@@ -168,9 +170,9 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
         }}
         >
           <div
-            className="h-full rounded-full transition-all duration-300 ease-in-out"
+            className="h-full rounded-full"
             style={{
-              width: `${progress * 100}%`,
+              width: `${getPos(step) / innerWidth * 100}%`,
               background:"#FF8C00",
             }}
             />
@@ -178,7 +180,6 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
 
     {/*Dots for each Level*/}
       {Array.from({ length: totalLevels}).map((_, i) => {
-        const dotPos = (minLeftPx + 11) + (i / (totalLevels)) * (maxLeftPx - (minLeftPx + 18));
         return (
           <span 
             key = {i}
@@ -190,7 +191,7 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
                 : "w-5 h-5 bg-white" 
             }`}
             style={{
-            left: dotPos,
+            left: getPos(i),
             top: "50%",
             transform:"translate(-50%, -50%)",
             }}
@@ -208,8 +209,8 @@ export function ProgressHUD({step, totalLevels}: {step: number, totalLevels: num
       <div 
         className="absolute z-20"
         style={{
-          left: clampedLeftPx,
-          top: "50%",
+          left: getPos(step),
+          top: "35%",
           transform: "translate(-50%, -50%)",
         }}
       >


### PR DESCRIPTION
### Summary
Added progress HUD in MazeMaps and QualifyTuneRace game. HUD is a bar with dots previously used in `ActivityPlayer` and a streak flame that follows the dots.

### Changes
Added a general template component to `GameShell`, then pulled into `MazeMApsGame `and `QualifyTuneRaceGame`. Pulled flame from `StreakMeter `and dots from `ActivityPlayer `and `WelcomeLayout`.
Closes #624 