### PR TITLE
docs: make design principles canonical (Lifelong Kindergarten)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,20 @@ Long-term pathway emphasis: AI, quantum, and biotech.
 
 ---
 
+## Design Principles (canonical — see `docs/design-principles.md`)
+Bright Boost is built on the *Lifelong Kindergarten* creative-learning model. Every activity should:
+- **Creators, not consumers** — kids make/author something with many valid solutions, not just respond (match/pick/choose); a kid should walk away with something they made.
+- **Creative spiral as the spine** — Imagine → Create → Play → Share → Reflect, as visible UI moments.
+- **Low floor, high ceiling, wide walls — by grade/level** — K–2 is more structured/scaffolded (a *supported* low floor, never a blank void); later grades and higher levels open up toward more open-ended creation. Structure early, openness later.
+- **Playground, not playpen** — safe experimentation and "breaking" things; mascot/adult is curious, never corrective.
+- **Measure creation, not completion** — things built, iterations, shares, remixes; not completion/badges.
+- **Adult as guide** — Catalyst / Connector / Consultant / Collaborator, not proctor.
+- **Screen use, not screen time; localizable + culturally grounded from day one.**
+
+New activities are checked against these (and the review checklist) before building. Full articulation: `docs/design-principles.md`.
+
+---
+
 ## Source of Truth Order
 
 When repository information conflicts, resolve using this order:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 BrightBoost is a bilingual (English/Spanish) K-8 STEM learning platform that builds strong foundations and prepares students for advanced technology pathways in AI, quantum, and biotech. The platform features tiered learning pathways for K-2, 3-5, and 6-8. The current rollout begins with K-2 content — character-driven stories, Unity-powered mini-games, and a full-featured teacher dashboard — with grades 3-5 and 6-8 planned in future releases. Designed for Title I classrooms and after-school programs, it combines gamification mechanics — XP, streaks, avatars, and arena battles — with standards-aligned content that teachers can assign, track, and assess in real time.
 
+> **Design philosophy:** Bright Boost is built on the *Lifelong Kindergarten* creative-learning model — kids as **creators, not consumers**, moving through the creative spiral (Imagine → Create → Play → Share → Reflect), with a *supported* low floor for K–2 that opens up in later grades. Canonical principles: [`docs/design-principles.md`](docs/design-principles.md).
+
 ## ✅ Current Working Features
 
 ### 👩‍🏫 Teacher Dashboard

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -1,0 +1,49 @@
+# Bright Boost — Design Principles (canonical)
+
+These are the principles every Bright Boost activity, feature, and module is built on and measured against. They come from Mitchel Resnick's *Lifelong Kindergarten* and Papert's constructionism, adapted to our K–8 (+ Pathways) audience.
+
+## Core stance
+Kids are **creators, not consumers.** The test for any activity: *does a child walk away with something they made?* Scores and badges are not the goal — creation is.
+
+## 1. The Creative Learning Spiral is the spine
+Every activity moves a child through **Imagine → Create → Play → Share → Reflect**, and loops back. An activity that only has "Play" (respond to a prompt) is incomplete. Build each stage as a real, visible moment:
+- **Imagine** — an open prompt / blank-ish canvas: "what will you make?"
+- **Create** — the child builds or authors something of their own.
+- **Play** — they run it and see what happens; outcomes are *feedback, not failure*.
+- **Share** — they name it and show it, scoped appropriately.
+- **Reflect** — a gentle wondering prompt; remixing a peer's work loops back to Imagine.
+
+## 2. Creators, not consumers
+Prefer making over responding, and **many valid solutions** over one right answer. Move away from "match / pick / choose"; move toward "build / author / design."
+
+## 3. Low floor, high ceiling, wide walls — with a grade-band progression
+- **Low floor:** anyone can begin; starting is easy and well-supported.
+- **High ceiling:** there's room to grow toward sophisticated, ambitious creation.
+- **Wide walls:** many paths and styles are valid, not one route.
+
+**How this maps to our grades and levels:** the floor lives at the youngest/earliest end, and the ceiling rises with age and progression.
+- **K–2 is more structured.** Young children get more scaffolding, guidance, and guardrails so they learn the fundamentals and can always succeed. The floor here is deliberately *supported* — a starter template, a guided first step, a constrained set of choices — never a blank, unguided void.
+- **Later grades and higher levels open up.** As children age up and progress through levels, activities become progressively more open-ended, handing over more creative freedom toward the high ceiling. Even within a single activity, early levels are more structured and later levels more open.
+
+Structure early, openness later. Both ends must exist: a fully-open experience with no scaffolding fails young kids (they get lost); a fully-structured experience with no openness fails older kids (they hit a ceiling too soon).
+
+## 4. Playground, not playpen
+Children can experiment, take risks, and even "break" things on purpose, safely. Mischief is a creativity signal, not misbehavior. The mascot/adult voice is **curious, never corrective** — it wonders alongside; it doesn't announce right and wrong.
+
+## 5. Measure creation, not completion
+Track soft, non-comparative signals — **things built, times iterated (run → tweak → run), creations shared, peer remixes** — not "lessons completed" or "badges earned."
+
+## 6. The adult is a guide, not a proctor
+The teacher/parent experience is **Catalyst** (optional sparks, never requirements) → **Connector** (pair kids by their creations) → **Consultant** (wondering prompts) → **Collaborator** (builds alongside). Dashboards surface "what they made," not "who finished."
+
+## 7. Screen use, not screen time
+Maximize *creative* time on screen. Where possible, pair an activity with an **unplugged twin** — the same constructionist activity in physical materials — as a genuine equal, not a consolation.
+
+## 8. Localizable and culturally grounded from day one
+All strings keyed and localizable (EN / 中文 and beyond) — never baked into a build. Where an activity draws on a culture's heritage, embed the wisdom **in the making** (discovered by doing), keep myth and history distinct, and have native/heritage reviewers validate it.
+
+## How we apply these
+- **The creative-loop work** (Creation model, authoring, gallery, dashboard/game reframes) is the first implementation of the spiral: kid makes → shares → adult sees. New surfaces extend the spiral, not the score.
+- **Every new activity** is checked against these principles and the team review checklist *before* it is built: spiral present? creator not consumer? supported low floor with a ceiling that rises by grade/level? playground not playpen? measuring creation? adult as guide? localizable?
+
+When a design decision is unclear, resolve it toward creation, toward the spiral, and toward the right floor-and-ceiling for the age.

--- a/docs/gamification.md
+++ b/docs/gamification.md
@@ -3,6 +3,8 @@
 The gamification system increases engagement and retention by introducing game-like elements into the learning experience.  
 Users earn XP, badges, streaks, and levels through actions that reinforce positive behaviors.
 
+> **Design context:** These mechanics serve the canonical [design principles](design-principles.md) — they should reinforce *making and iterating*, not become the goal. Per principle 5 ("measure creation, not completion"), treat signals like things built, iterations, and shares — not XP/badges — as the primary measure of learning.
+
 ---
 
 ## Core Concepts

--- a/docs/roadmap-notes.md
+++ b/docs/roadmap-notes.md
@@ -2,6 +2,8 @@
 
 > Design and roadmap notes — directional thinking grounded in the codebase, not commitments.
 
+> **Canonical design principles:** [`design-principles.md`](design-principles.md). This roadmap doc is the *strategic / directional* source — where notes like the creator-substrate thread below explore how we get there. `design-principles.md` is the *canonical* statement of the principles those notes build toward (creators-not-consumers, the creative spiral, structured-early / open-later).
+
 ## Maze Maps as a creator-substrate — implications for Set 3 (2026-06-25)
 
 **Context.** Maze Maps is currently a closed-content game: hand-authored `MazeMapConfig` literals, a fixed phase machine (tutorial/guided/main), a single correct path, and completion-gated full marks (finishing = 140/140 for everyone). It asks players to respond and complete, not to create — useful to be explicit about, since a long-term goal is moving some experiences toward kids/teachers making things, not only consuming them. (Note: the absence of a star/partial-score system here is intentional — Maze Maps is orb-collection + pattern-reading, not a par/efficiency puzzle like Tank Trek. See the design comment in `src/components/games/MazeMapsGame.tsx`.)


### PR DESCRIPTION
**Docs-only.** Makes Bright Boost's design principles canonical so future work builds on them. No code, schema, migrations, or the open PR #663 touched.

## What changed
- **NEW `docs/design-principles.md`** — the single source of truth: creators-not-consumers; the creative spiral (Imagine → Create → Play → Share → Reflect); low floor / high ceiling / wide walls **with a grade-band progression** (K–2 more structured/scaffolded — a *supported* low floor, never a blank void — opening up in later grades/levels); playground-not-playpen; measure creation not completion; adult-as-guide; screen use not screen time; localizable + culturally grounded.
- **`CLAUDE.md`** — concise "Design Principles" section (near the Product overview) linking the canonical doc.
- **`README.md`** — "Design philosophy" pointer after the Overview.
- **`docs/roadmap-notes.md`** — cross-linked as the *strategic/directional* source (where the #658 creator-substrate thread lives); `design-principles.md` is the *canonical* principles.
- **`docs/gamification.md`** — "Design context" pointer (mechanics serve creation; principle 5 = measure creation, not completion).

## Scope guardrails
- **Markdown only** — verified `git diff` contains no `.ts/.tsx/.cjs/.prisma/.sql` or migration paths.
- No `lifelong-kindergarten*.md` analysis doc exists in the repo to cross-link (confirmed); `docs/roadmap-notes.md` serves as the strategic source.
- Other docs now **point** to the canonical doc rather than duplicating principle statements.

**Please review; do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)