### PR TITLE
fix: derives creation title instead of trusting client

### DIFF
--- a/backend/src/routes/creations.test.ts
+++ b/backend/src/routes/creations.test.ts
@@ -140,6 +140,33 @@ describe("Creations routes", () => {
 
       expect(res.status).toBe(403);
     });
+
+    it("replaces a crafted title with the derived title on create", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+      prismaMock.creation.create.mockResolvedValue({
+        ...dbCreation,
+        title: "Sort by Water need",
+      });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "data_dash_challenge",
+          title: "this should be ignored",
+          content: validChallenge,
+        });
+
+        expect(res.status).toBe(201);
+        expect(prismaMock.creation.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: "Sort by Water need",
+            })
+          })
+        )
+    })
   });
 
   describe("PATCH /api/creations/:id", () => {
@@ -189,6 +216,36 @@ describe("Creations routes", () => {
 
       expect(res.status).toBe(404);
     });
+
+    it("replaces a crafted title with the derived title on update", async () => {
+      prismaMock.creation.findUnique.mockResolvedValue({
+        id: "creation-1",
+        authorId: KID,
+        type: "data_dash_challenge",
+        content: validChallenge,
+      });
+      prismaMock.creation.update.mockResolvedValue({
+        ...dbCreation,
+        title: "Sort by Water need",
+      });
+
+      const res = await request(app)
+        .patch("/api/creations/creation-1")
+        .set(asStudent(KID))
+        .send({
+          title: "this should be ignored",
+          content: validChallenge,
+        });
+
+        expect(res.status).toBe(200);
+        expect(prismaMock.creation.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: "Sort by Water need",
+            })
+          })
+        )
+    })
   });
 
   describe("GET /api/creations?courseId=", () => {

--- a/backend/src/routes/creations.ts
+++ b/backend/src/routes/creations.ts
@@ -4,6 +4,7 @@ import prisma from "../utils/prisma";
 import { requireAuth, requireRole } from "../utils/auth";
 import {
   CREATION_TYPES,
+  deriveCreationTitle,
   validateCreationContent,
   type CreationType,
 } from "../services/creationContent";
@@ -135,7 +136,7 @@ router.post(
     if (!parsed.success) {
       return res.status(400).json({ error: parsed.error.issues[0].message });
     }
-    const { courseId, type, title, content } = parsed.data;
+    const { courseId, type, content } = parsed.data;
 
     // Author must belong to the group they are publishing into.
     const enrolled = await prisma.enrollment.findUnique({
@@ -153,12 +154,14 @@ router.post(
       return res.status(422).json({ error: check.error });
     }
 
+    const derivedTitle = deriveCreationTitle(type as CreationType, content);
+
     const creation = await prisma.creation.create({
       data: {
         authorId: req.user!.id,
         courseId,
         type,
-        title: title ?? null,
+        title: derivedTitle ?? null,
         content: content as object,
         // status defaults to IN_PROGRESS (private draft) at the DB layer.
       },
@@ -185,7 +188,7 @@ router.patch(
 
     const existing = await prisma.creation.findUnique({
       where: { id: req.params.id },
-      select: { id: true, authorId: true, type: true },
+      select: { id: true, authorId: true, type: true, content: true },
     });
     if (!existing) {
       return res.status(404).json({ error: "creation not found" });
@@ -201,7 +204,8 @@ router.patch(
       status?: "IN_PROGRESS" | "SHARED" | "COMPLETE";
     } = {};
 
-    if (parsed.data.title !== undefined) data.title = parsed.data.title;
+    let effectiveContent = undefined;
+
     if (parsed.data.status !== undefined) data.status = parsed.data.status;
     if (parsed.data.content !== undefined) {
       const check = validateCreationContent(
@@ -211,7 +215,20 @@ router.patch(
       if (!check.ok) {
         return res.status(422).json({ error: check.error });
       }
-      data.content = parsed.data.content as object;
+
+      effectiveContent = parsed.data.content as object;
+      data.content = effectiveContent;
+    }
+
+    const derivedTitle = deriveCreationTitle(
+      existing.type as CreationType,
+      effectiveContent ?? existing.content,
+    );
+
+    if (derivedTitle !== null) {
+      data.title = derivedTitle;
+    } else {
+      data.title = null;
     }
 
     const updated = await prisma.creation.update({

--- a/backend/src/services/creationContent.ts
+++ b/backend/src/services/creationContent.ts
@@ -16,6 +16,12 @@ import { validateDataDashChallenge } from "./dataDashChallenge";
 export const CREATION_TYPES = ["data_dash_challenge"] as const;
 export type CreationType = (typeof CREATION_TYPES)[number];
 
+const dataDashSortRuleLabels: Record<string, string> = {
+  sunlightNeed: "Sunlight need",
+  waterNeed: "Water need",
+  leafType: "Leaf type",
+}
+
 export function isCreationType(value: unknown): value is CreationType {
   return (
     typeof value === "string" &&
@@ -57,5 +63,27 @@ export function validateCreationContent(
     default:
       // Exhaustiveness guard — a new CreationType must declare its rules here.
       return { ok: false, error: `unsupported creation type: ${type}` };
+  }
+}
+
+export function deriveCreationTitle(
+  type: CreationType,
+  content: unknown,
+): string | null {
+  if (!isPlainObject(content)) return null;
+
+  switch(type) {
+    case "data_dash_challenge": {
+      const challenge = content as {
+        sortRule?: string;
+      };
+
+      const label = dataDashSortRuleLabels[challenge.sortRule ?? ""]
+      
+      return label ? `Sort by ${label}` : null;
+    }
+
+    default: 
+      return null;
   }
 }


### PR DESCRIPTION
Closes #667.

- Derives title from the content instead of trusting the client-sent string for both POST and PATCH
- Adds tests for both in creations.test.ts 