### PR TITLE
feat(set3): add gated Boost Track Builder and team test fixture (#676)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ npx prisma generate            # root schema dual-generates BOTH clients (fronte
 ```
 
 Traps:
+
 - `npm run start` runs a **build**, not a server (deploy artifact; misleading name).
 - Root `npm run typecheck` gives false confidence for backend changes — backend TS errors only surface
   via `cd backend && npm run typecheck` (this is the schema-drift failure mode below).
@@ -47,6 +48,7 @@ Node: **20.x** (`package.json` engines + `.nvmrc`). `frontend/CONTRIBUTING.md` s
 ## Environment gotchas (these burn sessions)
 
 ### CI: `db-check` is red on every PR — expected
+
 The `db-check` job (`.github/workflows/ci-cd.yml`: postgres service → `prisma migrate deploy` →
 `npm run test:db`) **fails on every PR** until the migration-baseline bug **#646** lands, because the
 committed migration history cannot build the schema from scratch (~13 tables incl. Avatar never CREATEd).
@@ -54,6 +56,7 @@ A red db-check is not a signal about your change. **Never make db-check a requir
 fixed. (Verified failing on open PRs #662, #663.)
 
 ### Migrations: two trees, broken history — do not "fix" ad hoc
+
 - Migrations exist in BOTH `prisma/migrations/` (root) and `backend/prisma/migrations/`. The **root
   schema/migrations are authoritative for deploys**: `backend/scripts/predeploy.sh` and backend
   `db:migrate`/`db:generate` prefer `../prisma/schema.prisma`. The two trees are supposed to stay in
@@ -64,23 +67,25 @@ fixed. (Verified failing on open PRs #662, #663.)
   removed (it risked silent data loss). See the comments in `backend/scripts/predeploy.sh`.
 
 ### Schema sync: root vs backend copy
+
 `prisma/schema.prisma` (root, dual generators) and `backend/prisma/schema.prisma` must be kept in sync.
 The backend **Docker build** generates its Prisma client from the **root** schema
 (`backend/Dockerfile:16-17`), as do predeploy and the backend `db:*` scripts — the backend-local copy is
 a sync mirror; keep it matching so local backend workflows and deploys see the same models.
 
 ### Test accounts (seeded by `prisma/seed.cjs`)
+
 Seed is find-or-create and **always refreshes password hashes**, so these plaintext values always work:
 
-| Email | Password | Role | Notes |
-|-------|----------|------|-------|
-| teacher@school.com | password123 | K-8 Teacher (Ms. Frizzle) | Demo class owner |
-| student@test.com | password | K-8 Student | Incomplete Set 1 |
-| explorer@test.com | explore123 | K-8 Student | Set 1 complete, Set 2 unlocked |
-| jordan@test.com | jordan123 | K-8 Student | Grade 3-5 class (`GRADE35`), fresh |
-| facilitator@test.com | pathway123 | Pathways Facilitator (Coach Davis) | ETO cohort manager |
-| marcus@test.com | marcus123 | Pathways Student (Launch) | 3/7 Cyber Launch done |
-| aisha@test.com | aisha123 | Pathways Student (Explorer) | Fresh, 0 completions |
+| Email                | Password    | Role                               | Notes                              |
+| -------------------- | ----------- | ---------------------------------- | ---------------------------------- |
+| teacher@school.com   | password123 | K-8 Teacher (Ms. Frizzle)          | Demo class owner                   |
+| student@test.com     | password    | K-8 Student                        | Incomplete Set 1                   |
+| explorer@test.com    | explore123  | K-8 Student                        | Set 1 complete, Set 2 unlocked     |
+| jordan@test.com      | jordan123   | K-8 Student                        | Grade 3-5 class (`GRADE35`), fresh |
+| facilitator@test.com | pathway123  | Pathways Facilitator (Coach Davis) | ETO cohort manager                 |
+| marcus@test.com      | marcus123   | Pathways Student (Launch)          | 3/7 Cyber Launch done              |
+| aisha@test.com       | aisha123    | Pathways Student (Explorer)        | Fresh, 0 completions               |
 
 Class join codes seeded: `STARS1` (K-2 emoji-login demo class "Ms. Frizzle's Star Class", band k2,
 with 3 emoji students: Nova ⭐ / Comet 🚀 / Luna 🌙, no PIN), `GRADE35` and `UPPER35` (both grade
@@ -88,6 +93,7 @@ with 3 emoji students: Nova ⭐ / Comet 🚀 / Luna 🌙, no PIN), `GRADE35` and
 — South Side"; ended pilot: `ETO2025F`).
 
 ### Misc
+
 - Slack notifications are optional — without `SLACK_WEBHOOK_URL` they silently no-op (`backend/src/utils/slack.ts`).
 - Docker postgres (docker-compose-pg.yml) runs on port **5435**.
 
@@ -103,11 +109,13 @@ with 3 emoji students: Nova ⭐ / Comet 🚀 / Luna 🌙, no PIN), `GRADE35` and
 - Labels, priority (`P0`/`P1`/`P2`) & delegation: canonical in `docs/team-workflow.md`.
 
 ### Code style
+
 - Functional React components + hooks only; TypeScript strict, no `any` unless commented.
 - **Minimal diff over broad refactor, always.** Match adjacent files' patterns before inventing new ones.
   Reuse existing components/hooks/utils. No architecture changes unless the task requires it.
 
 ### i18n (never hardcode UI English)
+
 - UI strings via `useTranslation()` keys. New copy goes to `en.json` + `es.json` at minimum (also
   `vi`/`zh-CN` when possible); uncertain translations get English + `// TODO: translate`.
 - Locale files: `src/locales/{en,es,vi,zh-CN}/{common,pathways}.json` — one `translation` namespace,
@@ -117,21 +125,25 @@ with 3 emoji students: Nova ⭐ / Comet 🚀 / Luna 🌙, no PIN), `GRADE35` and
   `pathways.glossary.terms.<slug>.*`; `src/data/glossary.ts` holds slug + category only.
 
 ### Educational intent & K-2 bar
+
 - Preserve each game's learning goal, pacing, and instructional clarity — never swap in generic gameplay.
 - K–2: simple vocabulary, large tap targets, clear visual hierarchy; readability beats visual complexity.
 - Keep teacher and student flows consistent with existing app patterns.
 
 ### Definition of "good"
+
 K–2 clarity ✓ educational intent intact ✓ bilingual keys (not hardcoded) ✓ teacher-demo-ready ✓
 small diff, existing patterns ✓.
 
 ---
 
 ## Design Principles (canonical — see `docs/design-principles.md`)
-Bright Boost is built on the *Lifelong Kindergarten* creative-learning model. Every activity should:
+
+Bright Boost is built on the _Lifelong Kindergarten_ creative-learning model. Every activity should:
+
 - **Creators, not consumers** — kids make/author something with many valid solutions, not just respond (match/pick/choose); a kid should walk away with something they made.
 - **Creative spiral as the spine** — Imagine → Create → Play → Share → Reflect, as visible UI moments.
-- **Low floor, high ceiling, wide walls — by grade/level** — K–2 is more structured/scaffolded (a *supported* low floor, never a blank void); later grades and higher levels open up toward more open-ended creation. Structure early, openness later.
+- **Low floor, high ceiling, wide walls — by grade/level** — K–2 is more structured/scaffolded (a _supported_ low floor, never a blank void); later grades and higher levels open up toward more open-ended creation. Structure early, openness later.
 - **Playground, not playpen** — safe experimentation and "breaking" things; mascot/adult is curious, never corrective.
 - **Measure creation, not completion** — things built, iterations, shares, remixes; not completion/badges.
 - **Adult as guide** — Catalyst / Connector / Consultant / Collaborator, not proctor.
@@ -142,6 +154,7 @@ New activities are checked against these (and the review checklist) before build
 ---
 
 ## Team workflow (canonical — see `docs/team-workflow.md`)
+
 Label taxonomy (five axes: Pod / Size / Audience / Topic / State) plus the priority axis
 (`P0 — now` / `P1 — this week` / `P2 — when free`), lead delegation, and the team-up protocol
 for collaborating on someone else's ticket. Full framework: `docs/team-workflow.md`.
@@ -151,10 +164,12 @@ for collaborating on someone else's ticket. Full framework: `docs/team-workflow.
 ## Source of truth
 
 When repository information conflicts, resolve in this order:
+
 1. **Actual code** (imports, runtime behavior) → 2. **package.json** → 3. **prisma/schema.prisma** →
-4. **Root README.md** → 5. **Current passing tests** → 6. **Docs in active use** → 7. **Legacy docs**.
+2. **Root README.md** → 5. **Current passing tests** → 6. **Docs in active use** → 7. **Legacy docs**.
 
 Pointers, not copies:
+
 - `docs/design-principles.md` — **canonical** design principles (merged #664).
 - `docs/team-workflow.md` — **canonical** label taxonomy, priority axis, delegation & team-up protocol.
 - `docs/roadmap-notes.md` — strategic/directional notes (not commitments).
@@ -162,6 +177,7 @@ Pointers, not copies:
 - `docs/audits/g35-first-set-audit.md` — grade 3-5 audit + Set 2 variant briefs.
 
 Known conflicts (flag new ones explicitly — never silently pick a side):
+
 - `frontend/CONTRIBUTING.md` says Node 18; truth is Node 20 (engines + `.nvmrc`).
 - `backend/README.md` describes retired AWS Lambda/Aurora and self-flags as stale; production is
   **Railway + Supabase (PostgreSQL)**.
@@ -183,28 +199,36 @@ logic (`isSetComplete`, Set 2 unlocks when all Set 1 IDs have `COMPLETED` record
 `src/constants/stemSets.ts`. All 10 games below are implemented, registered, and seeded with story slides.
 
 ### Set 1 — Foundation
-| Game | File (src/components/games/) | Game key | Activity ID | Strand | g3_5 |
-|------|------------------------------|----------|-------------|--------|------|
-| Bounce & Buds | BounceBudsGame.tsx | `buddy_garden_sort` | `bounce-buds` | Biotech | ✅ |
-| Gotcha Gears | GotchaGearsGame.tsx | `gotcha_gears_unity` | `gotcha-gears` | Quantum | ✅ |
-| Rhyme & Ride | RhymeRideGame.tsx | `rhymo_rhyme_rocket` | `rhyme-ride` | AI + Biotech | ✅ (banded worlds, 1.25×) |
-| Tank Trek | TankTrekGame.tsx | `tank_trek` | `tank-trek` | Quantum + AI | ✅ (appended chapters) |
-| Quantum Quest | QuantumQuestGame.tsx | `quantum_quest` | `quantum-quest` | Quantum | ✅ (g3_5 math sectors) |
+
+| Game          | File (src/components/games/) | Game key             | Activity ID     | Strand       | g3_5                      |
+| ------------- | ---------------------------- | -------------------- | --------------- | ------------ | ------------------------- |
+| Bounce & Buds | BounceBudsGame.tsx           | `buddy_garden_sort`  | `bounce-buds`   | Biotech      | ✅                        |
+| Gotcha Gears  | GotchaGearsGame.tsx          | `gotcha_gears_unity` | `gotcha-gears`  | Quantum      | ✅                        |
+| Rhyme & Ride  | RhymeRideGame.tsx            | `rhymo_rhyme_rocket` | `rhyme-ride`    | AI + Biotech | ✅ (banded worlds, 1.25×) |
+| Tank Trek     | TankTrekGame.tsx             | `tank_trek`          | `tank-trek`     | Quantum + AI | ✅ (appended chapters)    |
+| Quantum Quest | QuantumQuestGame.tsx         | `quantum_quest`      | `quantum-quest` | Quantum      | ✅ (g3_5 math sectors)    |
 
 ### Set 2 — Exploration (unlocks after Set 1)
-| Game | File | Game key | Activity ID | Strand | g3_5 |
-|------|------|----------|-------------|--------|------|
-| Maze Maps | MazeMapsGame.tsx | `maze_maps` | `maze-maps` | AI | ✅ (#654) |
-| Move & Measure | MoveMeasureGame.tsx | `move_measure` | `move-measure` | Biotech | K-2 only |
-| Sky Shield | SkyShieldGame.tsx | `sky_shield` | `sky-shield` | Quantum | K-2 only |
-| Fast Lane | FastLaneGame.tsx | `fast_lane` | `fast-lane` | AI + Biotech | K-2 only |
-| Qualify & Race | QualifyTuneRaceGame.tsx | `qualify_tune_race` | `qualify-tune-race` | Capstone | K-2 only |
 
-### Set 3 — Mastery
-Placeholder IDs only (`set3-game-1`..`set3-game-5`); no components or seed data. Specialization
-(AI/Quantum/Biotech archetype) gating on Set 3 is planned, **not implemented**.
+| Game           | File                    | Game key            | Activity ID         | Strand       | g3_5      |
+| -------------- | ----------------------- | ------------------- | ------------------- | ------------ | --------- |
+| Maze Maps      | MazeMapsGame.tsx        | `maze_maps`         | `maze-maps`         | AI           | ✅ (#654) |
+| Move & Measure | MoveMeasureGame.tsx     | `move_measure`      | `move-measure`      | Biotech      | K-2 only  |
+| Sky Shield     | SkyShieldGame.tsx       | `sky_shield`        | `sky-shield`        | Quantum      | K-2 only  |
+| Fast Lane      | FastLaneGame.tsx        | `fast_lane`         | `fast-lane`         | AI + Biotech | K-2 only  |
+| Qualify & Race | QualifyTuneRaceGame.tsx | `qualify_tune_race` | `qualify-tune-race` | Capstone     | K-2 only  |
+
+### Set 3 — Mastery ("mastery through making" — creation-first, #676)
+
+Game 1 is implemented but **GATED from students** (via `HIDDEN_MODULE_SLUGS`; ungate = one line):
+Boost Track Builder — `TrackMakerGame.tsx` / `track_maker` / `track-maker` / module
+`k2-stem-track-maker`. The kid's track persists as a `Creation` (`type: "race_track"`,
+strict-parsed validator in `backend/src/services/raceTrack.ts`). Slots 2-5 remain placeholders
+(`set3-game-2`..`set3-game-5`); Set 3 unlocks after Set 2 (`isSet3Locked`). Specialization
+(AI/Quantum/Biotech archetype) gating on Set 3 completion is planned, **not implemented**.
 
 ### Grade bands
+
 - `Course.gradeBand`: `k2` (default) | `g3_5`; teacher sets it at class creation and in class detail.
 - Content variants live in `src/components/games/gradeBandContent.ts` (central registry; K-2 + g3_5).
   Games read the band from config; ActivityPlayer injects it from the student's enrolled course and
@@ -212,6 +236,7 @@ Placeholder IDs only (`set3-game-1`..`set3-game-5`); no components or seed data.
   `useGradeBand()` (`src/hooks/useGradeBand.ts`) fetches the student's class band.
 
 ### Removed / hidden (don't resurrect)
+
 - **Build-a-Bot** — removed 2026-04-07 (files fully deleted); Tank Trek → Quantum Quest replaced it.
 - **Fix the Order / Lost Steps** (`k2-stem-sequencing`, keys `boost_path_planner` + `sequence_drag_drop`) —
   hidden 2026-04-09 via `HIDDEN_MODULE_SLUGS`; component `BoostPathPlannerGame.tsx` still exists.
@@ -241,6 +266,7 @@ no mascots, direct empowering language for teens).
 ## Authentication & login
 
 Unified login page `src/pages/LoginSelection.tsx` at **`/student-login`** (`/login` redirects there):
+
 - **Email + password:** POST `/api/login` → JWT. Redirect by `userType`+`role`
   (`src/contexts/AuthContext.tsx`): k8 teacher → `/teacher/dashboard`; k8 student → `/student/dashboard`;
   pathways teacher → `/pathways/facilitator`; pathways student → `/pathways`.

--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -163,7 +163,9 @@ async function main() {
 
   // Test Explorer — student with Set 1 fully completed (for Set 2 testing)
   const explorerHash = await bcrypt.hash("explore123", 10);
-  let explorer = await prisma.user.findUnique({ where: { email: "explorer@test.com" } });
+  let explorer = await prisma.user.findUnique({
+    where: { email: "explorer@test.com" },
+  });
   if (!explorer) {
     explorer = await prisma.user.create({
       data: {
@@ -186,10 +188,17 @@ async function main() {
   }
 
   // Enroll explorer in teacher's class
-  const teacherCourse = await prisma.course.findFirst({ where: { teacherId: teacher.id } });
+  const teacherCourse = await prisma.course.findFirst({
+    where: { teacherId: teacher.id },
+  });
   if (teacherCourse) {
     await prisma.enrollment.upsert({
-      where: { studentId_courseId: { studentId: explorer.id, courseId: teacherCourse.id } },
+      where: {
+        studentId_courseId: {
+          studentId: explorer.id,
+          courseId: teacherCourse.id,
+        },
+      },
       create: { studentId: explorer.id, courseId: teacherCourse.id },
       update: {},
     });
@@ -199,13 +208,24 @@ async function main() {
   // Create avatar for explorer
   await prisma.avatar.upsert({
     where: { studentId: explorer.id },
-    create: { studentId: explorer.id, level: 5, xp: 650, hp: 100, energy: 100, speed: 4, control: 3, focus: 3 },
+    create: {
+      studentId: explorer.id,
+      level: 5,
+      xp: 650,
+      hp: 100,
+      energy: 100,
+      speed: 4,
+      control: 3,
+      focus: 3,
+    },
     update: { level: 5, xp: 650, speed: 4, control: 3, focus: 3 },
   });
 
   // Jordan — 9-year-old student in a grade 3-5 class
   const jordanHash = await bcrypt.hash("jordan123", 10);
-  let jordan = await prisma.user.findUnique({ where: { email: "jordan@test.com" } });
+  let jordan = await prisma.user.findUnique({
+    where: { email: "jordan@test.com" },
+  });
   if (!jordan) {
     jordan = await prisma.user.create({
       data: {
@@ -232,11 +252,18 @@ async function main() {
   // Create a grade 3-5 class and enroll Jordan
   const g35Class = await prisma.course.upsert({
     where: { joinCode: "GRADE35" },
-    create: { name: "Grade 3-5 STEM", joinCode: "GRADE35", teacherId: teacher.id, gradeBand: "g3_5" },
+    create: {
+      name: "Grade 3-5 STEM",
+      joinCode: "GRADE35",
+      teacherId: teacher.id,
+      gradeBand: "g3_5",
+    },
     update: { gradeBand: "g3_5" },
   });
   await prisma.enrollment.upsert({
-    where: { studentId_courseId: { studentId: jordan.id, courseId: g35Class.id } },
+    where: {
+      studentId_courseId: { studentId: jordan.id, courseId: g35Class.id },
+    },
     create: { studentId: jordan.id, courseId: g35Class.id },
     update: {},
   });
@@ -262,7 +289,11 @@ async function main() {
   const starsClass = await prisma.course.upsert({
     where: { joinCode: "STARS1" },
     // gradeBand intentionally omitted on create — schema default is "k2".
-    create: { name: "Ms. Frizzle's Star Class", joinCode: "STARS1", teacherId: teacher.id },
+    create: {
+      name: "Ms. Frizzle's Star Class",
+      joinCode: "STARS1",
+      teacherId: teacher.id,
+    },
     update: { gradeBand: "k2", teacherId: teacher.id },
   });
 
@@ -287,7 +318,9 @@ async function main() {
       update: { name: s.name, loginIcon: s.loginIcon },
     });
     await prisma.enrollment.upsert({
-      where: { studentId_courseId: { studentId: kid.id, courseId: starsClass.id } },
+      where: {
+        studentId_courseId: { studentId: kid.id, courseId: starsClass.id },
+      },
       create: { studentId: kid.id, courseId: starsClass.id },
       update: {},
     });
@@ -298,6 +331,47 @@ async function main() {
     "star students.",
   );
 
+  // Shared Track Builder fixture for gallery + ride-path testing. The creator
+  // studio remains intentionally gated, but any STARS1 student can open the
+  // gallery and ride Nova's deterministic, server-valid track.
+  const seededRaceTrack = {
+    v: 1,
+    name: "Star Sprint",
+    grid: { w: 6, h: 6 },
+    pieces: [
+      { x: 0, y: 1, type: "start", rot: 0 },
+      { x: 1, y: 1, type: "straight", rot: 0 },
+      { x: 2, y: 1, type: "gentleCurve", rot: 180 },
+      { x: 2, y: 2, type: "straight", rot: 90 },
+      { x: 2, y: 3, type: "gentleCurve", rot: 0 },
+      { x: 3, y: 3, type: "boost", rot: 0 },
+      { x: 4, y: 3, type: "finish", rot: 0 },
+    ],
+  };
+  await prisma.creation.upsert({
+    where: { id: "seed-race-track-star-sprint" },
+    create: {
+      id: "seed-race-track-star-sprint",
+      authorId: "star-nova",
+      courseId: starsClass.id,
+      type: "race_track",
+      title: seededRaceTrack.name,
+      content: seededRaceTrack,
+      status: "SHARED",
+      encouragements: 2,
+    },
+    update: {
+      authorId: "star-nova",
+      courseId: starsClass.id,
+      type: "race_track",
+      title: seededRaceTrack.name,
+      content: seededRaceTrack,
+      status: "SHARED",
+      encouragements: 2,
+    },
+  });
+  console.log("Seeded shared STARS1 Track Builder creation: Star Sprint.");
+
   // 5. Seed Content
   console.log("Seeding modules...");
 
@@ -305,14 +379,16 @@ async function main() {
     where: { slug: "stem-1-intro" },
     update: {
       title: "Quantum Explorers",
-      description: "Discover the tiny particles that power the future! Unlocks with specialization.",
+      description:
+        "Discover the tiny particles that power the future! Unlocks with specialization.",
       level: "K-2",
       published: true,
     },
     create: {
       slug: "stem-1-intro",
       title: "Quantum Explorers",
-      description: "Discover the tiny particles that power the future! Unlocks with specialization.",
+      description:
+        "Discover the tiny particles that power the future! Unlocks with specialization.",
       level: "K-2",
       published: true,
     },
@@ -373,14 +449,89 @@ async function main() {
   const storyContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "bpp-s1", text: { en: "Boost is a little helper robot in the Bright Lab. Today, Boost has one job: carry a tiny battery to the charging station.", es: "Boost es un pequeño robot ayudante en el Laboratorio Brillante. Hoy, Boost tiene un trabajo: llevar una pequeña batería a la estación de carga." }, icon: "🤖" },
-      { id: "bpp-s2", text: { en: "Boost cannot just rush forward. Boost has to look, think, and put the steps in the right order.", es: "Boost no puede apresurarse. Boost tiene que mirar, pensar y poner los pasos en el orden correcto." }, icon: "🧠" },
-      { id: "bpp-s3", text: { en: "When we help Boost turn and move the right way, we are practicing sequencing. Sequencing means putting steps in order.", es: "Cuando ayudamos a Boost a girar y moverse correctamente, estamos practicando la secuenciación. Secuenciar significa poner los pasos en orden." }, icon: "📋" },
+      {
+        id: "bpp-s1",
+        text: {
+          en: "Boost is a little helper robot in the Bright Lab. Today, Boost has one job: carry a tiny battery to the charging station.",
+          es: "Boost es un pequeño robot ayudante en el Laboratorio Brillante. Hoy, Boost tiene un trabajo: llevar una pequeña batería a la estación de carga.",
+        },
+        icon: "🤖",
+      },
+      {
+        id: "bpp-s2",
+        text: {
+          en: "Boost cannot just rush forward. Boost has to look, think, and put the steps in the right order.",
+          es: "Boost no puede apresurarse. Boost tiene que mirar, pensar y poner los pasos en el orden correcto.",
+        },
+        icon: "🧠",
+      },
+      {
+        id: "bpp-s3",
+        text: {
+          en: "When we help Boost turn and move the right way, we are practicing sequencing. Sequencing means putting steps in order.",
+          es: "Cuando ayudamos a Boost a girar y moverse correctamente, estamos practicando la secuenciación. Secuenciar significa poner los pasos en orden.",
+        },
+        icon: "📋",
+      },
     ],
     questions: [
-      { id: "bpp-q1", prompt: { en: "What is Boost trying to do?", es: "¿Qué intenta hacer Boost?" }, choices: [{ en: "Reach the charging station", es: "Llegar a la estación de carga" }, { en: "Go to sleep", es: "Irse a dormir" }, { en: "Paint the wall", es: "Pintar la pared" }], answerIndex: 0, hint: { en: "Read the first slide again — what is Boost's job today?", es: "Lee la primera diapositiva de nuevo — ¿cuál es el trabajo de Boost hoy?" } },
-      { id: "bpp-q2", prompt: { en: "What should Boost do first?", es: "¿Qué debe hacer Boost primero?" }, choices: [{ en: "Make a plan", es: "Hacer un plan" }, { en: "Guess fast", es: "Adivinar rápido" }, { en: "Spin in circles", es: "Girar en círculos" }], answerIndex: 0, hint: { en: "Boost has to look and think before moving.", es: "Boost tiene que mirar y pensar antes de moverse." } },
-      { id: "bpp-q3", prompt: { en: "What does sequencing mean?", es: "¿Qué significa secuenciar?" }, choices: [{ en: "Putting steps in order", es: "Poner los pasos en orden" }, { en: "Jumping over walls", es: "Saltar sobre paredes" }, { en: "Moving as fast as possible", es: "Moverse lo más rápido posible" }], answerIndex: 0, hint: { en: "The last slide explains what sequencing means.", es: "La última diapositiva explica qué significa secuenciar." } },
+      {
+        id: "bpp-q1",
+        prompt: {
+          en: "What is Boost trying to do?",
+          es: "¿Qué intenta hacer Boost?",
+        },
+        choices: [
+          {
+            en: "Reach the charging station",
+            es: "Llegar a la estación de carga",
+          },
+          { en: "Go to sleep", es: "Irse a dormir" },
+          { en: "Paint the wall", es: "Pintar la pared" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Read the first slide again — what is Boost's job today?",
+          es: "Lee la primera diapositiva de nuevo — ¿cuál es el trabajo de Boost hoy?",
+        },
+      },
+      {
+        id: "bpp-q2",
+        prompt: {
+          en: "What should Boost do first?",
+          es: "¿Qué debe hacer Boost primero?",
+        },
+        choices: [
+          { en: "Make a plan", es: "Hacer un plan" },
+          { en: "Guess fast", es: "Adivinar rápido" },
+          { en: "Spin in circles", es: "Girar en círculos" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Boost has to look and think before moving.",
+          es: "Boost tiene que mirar y pensar antes de moverse.",
+        },
+      },
+      {
+        id: "bpp-q3",
+        prompt: {
+          en: "What does sequencing mean?",
+          es: "¿Qué significa secuenciar?",
+        },
+        choices: [
+          { en: "Putting steps in order", es: "Poner los pasos en orden" },
+          { en: "Jumping over walls", es: "Saltar sobre paredes" },
+          {
+            en: "Moving as fast as possible",
+            es: "Moverse lo más rápido posible",
+          },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "The last slide explains what sequencing means.",
+          es: "La última diapositiva explica qué significa secuenciar.",
+        },
+      },
     ],
   });
   const storyAct = await prisma.activity.findFirst({
@@ -389,7 +540,10 @@ async function main() {
   if (storyAct) {
     await prisma.activity.update({
       where: { id: storyAct.id },
-      data: { title: "Story: Meet Boost the Careful Planner", content: storyContent },
+      data: {
+        title: "Story: Meet Boost the Careful Planner",
+        content: storyContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -411,7 +565,11 @@ async function main() {
   if (gameAct) {
     await prisma.activity.update({
       where: { id: gameAct.id },
-      data: { id: "lost-steps", title: "Game: Boost's Lost Steps", content: gameContent },
+      data: {
+        id: "lost-steps",
+        title: "Game: Boost's Lost Steps",
+        content: gameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -478,17 +636,73 @@ async function main() {
   const rhymeStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.rhymo.s1" }, icon: "🚲", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.rhymo.s2" }, icon: "🎵", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.rhymo.s3" }, icon: "🐱", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.rhymo.s4" }, icon: "🏁", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.rhymo.s1" },
+        icon: "🚲",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.rhymo.s2" },
+        icon: "🎵",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.rhymo.s3" },
+        icon: "🐱",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.rhymo.s4" },
+        icon: "🏁",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.rhymo.q1.prompt" }, choices: [{ i18nKey: "content.rhymo.q1.c1" }, { i18nKey: "content.rhymo.q1.c2" }, { i18nKey: "content.rhymo.q1.c3" }, { i18nKey: "content.rhymo.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.rhymo.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.rhymo.q2.prompt" }, choices: [{ i18nKey: "content.rhymo.q2.c1" }, { i18nKey: "content.rhymo.q2.c2" }, { i18nKey: "content.rhymo.q2.c3" }, { i18nKey: "content.rhymo.q2.c4" }], answerIndex: 1, hint: { i18nKey: "content.rhymo.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.rhymo.q3.prompt" }, choices: [{ i18nKey: "content.rhymo.q3.c1" }, { i18nKey: "content.rhymo.q3.c2" }, { i18nKey: "content.rhymo.q3.c3" }, { i18nKey: "content.rhymo.q3.c4" }], answerIndex: 1, hint: { i18nKey: "content.rhymo.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.rhymo.q1.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q1.c1" },
+          { i18nKey: "content.rhymo.q1.c2" },
+          { i18nKey: "content.rhymo.q1.c3" },
+          { i18nKey: "content.rhymo.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.rhymo.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.rhymo.q2.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q2.c1" },
+          { i18nKey: "content.rhymo.q2.c2" },
+          { i18nKey: "content.rhymo.q2.c3" },
+          { i18nKey: "content.rhymo.q2.c4" },
+        ],
+        answerIndex: 1,
+        hint: { i18nKey: "content.rhymo.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.rhymo.q3.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q3.c1" },
+          { i18nKey: "content.rhymo.q3.c2" },
+          { i18nKey: "content.rhymo.q3.c3" },
+          { i18nKey: "content.rhymo.q3.c4" },
+        ],
+        answerIndex: 1,
+        hint: { i18nKey: "content.rhymo.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.rhymo.reviewKeyIdea" }, vocab: ["rhyme", "sound", "end"] },
+    review: {
+      keyIdea: { i18nKey: "content.rhymo.reviewKeyIdea" },
+      vocab: ["rhyme", "sound", "end"],
+    },
   });
   const rhymeStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2RhymeLesson.id, kind: INFO, order: 1 },
@@ -518,7 +732,11 @@ async function main() {
   if (rhymeGameAct) {
     await prisma.activity.update({
       where: { id: rhymeGameAct.id },
-      data: { id: "rhyme-ride", title: "Game: Rhyme & Ride", content: rhymeGameContent },
+      data: {
+        id: "rhyme-ride",
+        title: "Game: Rhyme & Ride",
+        content: rhymeGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -539,14 +757,16 @@ async function main() {
     where: { slug: "k2-stem-bounce-buds" },
     update: {
       title: "Bounce & Buds",
-      description: "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
+      description:
+        "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
       level: "K-2",
       published: true,
     },
     create: {
       slug: "k2-stem-bounce-buds",
       title: "Bounce & Buds",
-      description: "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
+      description:
+        "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
       level: "K-2",
       published: true,
     },
@@ -585,17 +805,73 @@ async function main() {
   const bounceStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.buddy.s1" }, icon: "🌿", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.buddy.s2" }, icon: "🧫", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.buddy.s3" }, icon: "🦠", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.buddy.s4" }, icon: "💻", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.buddy.s1" },
+        icon: "🌿",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.buddy.s2" },
+        icon: "🧫",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.buddy.s3" },
+        icon: "🦠",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.buddy.s4" },
+        icon: "💻",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.buddy.q1.prompt" }, choices: [{ i18nKey: "content.buddy.q1.c1" }, { i18nKey: "content.buddy.q1.c2" }, { i18nKey: "content.buddy.q1.c3" }, { i18nKey: "content.buddy.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.buddy.q2.prompt" }, choices: [{ i18nKey: "content.buddy.q2.c1" }, { i18nKey: "content.buddy.q2.c2" }, { i18nKey: "content.buddy.q2.c3" }, { i18nKey: "content.buddy.q2.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.buddy.q3.prompt" }, choices: [{ i18nKey: "content.buddy.q3.c1" }, { i18nKey: "content.buddy.q3.c2" }, { i18nKey: "content.buddy.q3.c3" }, { i18nKey: "content.buddy.q3.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.buddy.q1.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q1.c1" },
+          { i18nKey: "content.buddy.q1.c2" },
+          { i18nKey: "content.buddy.q1.c3" },
+          { i18nKey: "content.buddy.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.buddy.q2.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q2.c1" },
+          { i18nKey: "content.buddy.q2.c2" },
+          { i18nKey: "content.buddy.q2.c3" },
+          { i18nKey: "content.buddy.q2.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.buddy.q3.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q3.c1" },
+          { i18nKey: "content.buddy.q3.c2" },
+          { i18nKey: "content.buddy.q3.c3" },
+          { i18nKey: "content.buddy.q3.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.buddy.reviewKeyIdea" }, vocab: ["cell", "microbe", "root"] },
+    review: {
+      keyIdea: { i18nKey: "content.buddy.reviewKeyIdea" },
+      vocab: ["cell", "microbe", "root"],
+    },
   });
   const bounceStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2BounceLesson.id, kind: INFO, order: 1 },
@@ -626,7 +902,11 @@ async function main() {
   if (bounceGameAct) {
     await prisma.activity.update({
       where: { id: bounceGameAct.id },
-      data: { id: "bounce-buds", title: "Game: Bounce & Buds", content: bounceGameContent },
+      data: {
+        id: "bounce-buds",
+        title: "Game: Bounce & Buds",
+        content: bounceGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -693,17 +973,73 @@ async function main() {
   const gotchaStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.gearbot.s1" }, icon: "⚙️", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.gearbot.s2" }, icon: "📝", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.gearbot.s3" }, icon: "🛠️", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.gearbot.s4" }, icon: "🌟", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.gearbot.s1" },
+        icon: "⚙️",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.gearbot.s2" },
+        icon: "📝",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.gearbot.s3" },
+        icon: "🛠️",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.gearbot.s4" },
+        icon: "🌟",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.gearbot.q1.prompt" }, choices: [{ i18nKey: "content.gearbot.q1.c1" }, { i18nKey: "content.gearbot.q1.c2" }, { i18nKey: "content.gearbot.q1.c3" }, { i18nKey: "content.gearbot.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.gearbot.q2.prompt" }, choices: [{ i18nKey: "content.gearbot.q2.c1" }, { i18nKey: "content.gearbot.q2.c2" }, { i18nKey: "content.gearbot.q2.c3" }, { i18nKey: "content.gearbot.q2.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.gearbot.q3.prompt" }, choices: [{ i18nKey: "content.gearbot.q3.c1" }, { i18nKey: "content.gearbot.q3.c2" }, { i18nKey: "content.gearbot.q3.c3" }, { i18nKey: "content.gearbot.q3.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.gearbot.q1.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q1.c1" },
+          { i18nKey: "content.gearbot.q1.c2" },
+          { i18nKey: "content.gearbot.q1.c3" },
+          { i18nKey: "content.gearbot.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.gearbot.q2.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q2.c1" },
+          { i18nKey: "content.gearbot.q2.c2" },
+          { i18nKey: "content.gearbot.q2.c3" },
+          { i18nKey: "content.gearbot.q2.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.gearbot.q3.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q3.c1" },
+          { i18nKey: "content.gearbot.q3.c2" },
+          { i18nKey: "content.gearbot.q3.c3" },
+          { i18nKey: "content.gearbot.q3.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.gearbot.reviewKeyIdea" }, vocab: ["debug", "plan", "practice", "rule"] },
+    review: {
+      keyIdea: { i18nKey: "content.gearbot.reviewKeyIdea" },
+      vocab: ["debug", "plan", "practice", "rule"],
+    },
   });
   const gotchaStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2GotchaLesson.id, kind: INFO, order: 1 },
@@ -739,13 +1075,69 @@ async function main() {
       catchWindowX: 0.95,
     },
     rounds: [
-      { clueText: { i18nKey: "content.gotchaGame.r1.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r1.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r1.d1" }, { i18nKey: "content.gotchaGame.r1.d2" }], hint: { i18nKey: "content.gotchaGame.r1.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r2.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r2.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r2.d1" }, { i18nKey: "content.gotchaGame.r2.d2" }], hint: { i18nKey: "content.gotchaGame.r2.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r3.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r3.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r3.d1" }, { i18nKey: "content.gotchaGame.r3.d2" }], hint: { i18nKey: "content.gotchaGame.r3.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r4.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r4.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r4.d1" }, { i18nKey: "content.gotchaGame.r4.d2" }], hint: { i18nKey: "content.gotchaGame.r4.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r5.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r5.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r5.d1" }, { i18nKey: "content.gotchaGame.r5.d2" }], hint: { i18nKey: "content.gotchaGame.r5.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r6.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r6.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r6.d1" }, { i18nKey: "content.gotchaGame.r6.d2" }], hint: { i18nKey: "content.gotchaGame.r6.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r7.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r7.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r7.d1" }, { i18nKey: "content.gotchaGame.r7.d2" }], hint: { i18nKey: "content.gotchaGame.r7.hint" } },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r1.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r1.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r1.d1" },
+          { i18nKey: "content.gotchaGame.r1.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r1.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r2.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r2.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r2.d1" },
+          { i18nKey: "content.gotchaGame.r2.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r2.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r3.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r3.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r3.d1" },
+          { i18nKey: "content.gotchaGame.r3.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r3.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r4.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r4.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r4.d1" },
+          { i18nKey: "content.gotchaGame.r4.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r4.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r5.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r5.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r5.d1" },
+          { i18nKey: "content.gotchaGame.r5.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r5.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r6.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r6.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r6.d1" },
+          { i18nKey: "content.gotchaGame.r6.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r6.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r7.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r7.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r7.d1" },
+          { i18nKey: "content.gotchaGame.r7.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r7.hint" },
+      },
     ],
   });
 
@@ -756,7 +1148,11 @@ async function main() {
   if (gotchaGameAct) {
     await prisma.activity.update({
       where: { id: gotchaGameAct.id },
-      data: { id: "gotcha-gears", title: "Game: Gotcha Gears (Catch the Gear!)", content: gotchaGameContent },
+      data: {
+        id: "gotcha-gears",
+        title: "Game: Gotcha Gears (Catch the Gear!)",
+        content: gotchaGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -777,48 +1173,194 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   const k2TankModule = await prisma.module.upsert({
     where: { slug: "k2-stem-tank-trek" },
-    update: { title: "Tank Trek", description: "Guide a robot through mazes! 🤖🧩", level: "K-2", published: true },
-    create: { slug: "k2-stem-tank-trek", title: "Tank Trek", description: "Guide a robot through mazes! 🤖🧩", level: "K-2", published: true },
+    update: {
+      title: "Tank Trek",
+      description: "Guide a robot through mazes! 🤖🧩",
+      level: "K-2",
+      published: true,
+    },
+    create: {
+      slug: "k2-stem-tank-trek",
+      title: "Tank Trek",
+      description: "Guide a robot through mazes! 🤖🧩",
+      level: "K-2",
+      published: true,
+    },
   });
   console.log("Created module:", k2TankModule.slug);
 
-  let k2TankUnit = await prisma.unit.findFirst({ where: { moduleId: k2TankModule.id, title: "Unit 1: Robot Navigation" } });
+  let k2TankUnit = await prisma.unit.findFirst({
+    where: { moduleId: k2TankModule.id, title: "Unit 1: Robot Navigation" },
+  });
   if (!k2TankUnit) {
-    k2TankUnit = await prisma.unit.create({ data: { title: "Unit 1: Robot Navigation", order: 1, Module: { connect: { id: k2TankModule.id } }, teacher: { connect: { id: teacher.id } } } });
+    k2TankUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Robot Navigation",
+        order: 1,
+        Module: { connect: { id: k2TankModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
   }
 
-  let k2TankLesson = await prisma.lesson.findFirst({ where: { unitId: k2TankUnit.id, title: "Tank Trek" } });
+  let k2TankLesson = await prisma.lesson.findFirst({
+    where: { unitId: k2TankUnit.id, title: "Tank Trek" },
+  });
   if (!k2TankLesson) {
-    k2TankLesson = await prisma.lesson.create({ data: { title: "Tank Trek", order: 1, Unit: { connect: { id: k2TankUnit.id } } } });
+    k2TankLesson = await prisma.lesson.create({
+      data: {
+        title: "Tank Trek",
+        order: 1,
+        Unit: { connect: { id: k2TankUnit.id } },
+      },
+    });
   }
 
   const tankStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "tt-s1", text: { en: "Meet Bolt! Bolt listens to your code words to move safely through the maze.", es: "¡Conoce a Bolt! Bolt escucha tus palabras de código para moverse con seguridad por el laberinto." }, icon: "🤖" },
-      { id: "tt-s2", text: { en: "Use clear commands: Forward, Turn Left, Turn Right. Order matters!", es: "Usa comandos claros: Adelante, Girar Izquierda, Girar Derecha. ¡El orden importa!" }, icon: "🧭" },
-      { id: "tt-s3", text: { en: "Great robot coders test, fix, and try again. Short smart paths earn more stars!", es: "Los grandes programadores de robots prueban, corrigen e intentan otra vez. ¡Los caminos cortos e inteligentes ganan más estrellas!" }, icon: "⭐" },
+      {
+        id: "tt-s1",
+        text: {
+          en: "Meet Bolt! Bolt listens to your code words to move safely through the maze.",
+          es: "¡Conoce a Bolt! Bolt escucha tus palabras de código para moverse con seguridad por el laberinto.",
+        },
+        icon: "🤖",
+      },
+      {
+        id: "tt-s2",
+        text: {
+          en: "Use clear commands: Forward, Turn Left, Turn Right. Order matters!",
+          es: "Usa comandos claros: Adelante, Girar Izquierda, Girar Derecha. ¡El orden importa!",
+        },
+        icon: "🧭",
+      },
+      {
+        id: "tt-s3",
+        text: {
+          en: "Great robot coders test, fix, and try again. Short smart paths earn more stars!",
+          es: "Los grandes programadores de robots prueban, corrigen e intentan otra vez. ¡Los caminos cortos e inteligentes ganan más estrellas!",
+        },
+        icon: "⭐",
+      },
     ],
     questions: [
-      { id: "tt-q1", prompt: { en: "Which command makes Bolt move ahead one space?", es: "¿Qué comando hace que Bolt avance un espacio?" }, choices: [{ en: "Forward", es: "Adelante" }, { en: "Turn Left", es: "Girar Izquierda" }, { en: "Turn Right", es: "Girar Derecha" }, { en: "Stop and spin", es: "Parar y girar" }], answerIndex: 0, hint: { en: "Forward means move ahead.", es: "Adelante significa moverse al frente." } },
-      { id: "tt-q2", prompt: { en: "Two paths reach the goal. Which is more efficient?", es: "Dos caminos llegan a la meta. ¿Cuál es más eficiente?" }, choices: [{ en: "The path with fewer commands", es: "El camino con menos comandos" }, { en: "The path with more turns", es: "El camino con más giros" }, { en: "The longest path", es: "El camino más largo" }, { en: "Any path is always equal", es: "Cualquier camino siempre es igual" }], answerIndex: 0, hint: { en: "Efficient means doing the job in fewer steps.", es: "Eficiente significa hacer el trabajo con menos pasos." } },
-      { id: "tt-q3", prompt: { en: "Bolt bumped a wall. What should you do next?", es: "Bolt chocó con una pared. ¿Qué debes hacer después?" }, choices: [{ en: "Change one command and test again", es: "Cambiar un comando y probar otra vez" }, { en: "Keep the same plan forever", es: "Seguir el mismo plan para siempre" }, { en: "Press random buttons", es: "Presionar botones al azar" }, { en: "Quit the mission", es: "Salir de la misión" }], answerIndex: 0, hint: { en: "Debugging means fixing and retesting.", es: "Depurar significa corregir y volver a probar." } },
+      {
+        id: "tt-q1",
+        prompt: {
+          en: "Which command makes Bolt move ahead one space?",
+          es: "¿Qué comando hace que Bolt avance un espacio?",
+        },
+        choices: [
+          { en: "Forward", es: "Adelante" },
+          { en: "Turn Left", es: "Girar Izquierda" },
+          { en: "Turn Right", es: "Girar Derecha" },
+          { en: "Stop and spin", es: "Parar y girar" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Forward means move ahead.",
+          es: "Adelante significa moverse al frente.",
+        },
+      },
+      {
+        id: "tt-q2",
+        prompt: {
+          en: "Two paths reach the goal. Which is more efficient?",
+          es: "Dos caminos llegan a la meta. ¿Cuál es más eficiente?",
+        },
+        choices: [
+          {
+            en: "The path with fewer commands",
+            es: "El camino con menos comandos",
+          },
+          { en: "The path with more turns", es: "El camino con más giros" },
+          { en: "The longest path", es: "El camino más largo" },
+          {
+            en: "Any path is always equal",
+            es: "Cualquier camino siempre es igual",
+          },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Efficient means doing the job in fewer steps.",
+          es: "Eficiente significa hacer el trabajo con menos pasos.",
+        },
+      },
+      {
+        id: "tt-q3",
+        prompt: {
+          en: "Bolt bumped a wall. What should you do next?",
+          es: "Bolt chocó con una pared. ¿Qué debes hacer después?",
+        },
+        choices: [
+          {
+            en: "Change one command and test again",
+            es: "Cambiar un comando y probar otra vez",
+          },
+          {
+            en: "Keep the same plan forever",
+            es: "Seguir el mismo plan para siempre",
+          },
+          { en: "Press random buttons", es: "Presionar botones al azar" },
+          { en: "Quit the mission", es: "Salir de la misión" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Debugging means fixing and retesting.",
+          es: "Depurar significa corregir y volver a probar.",
+        },
+      },
     ],
   });
 
-  let tankStoryAct = await prisma.activity.findFirst({ where: { lessonId: k2TankLesson.id, kind: INFO, order: 1 } });
+  let tankStoryAct = await prisma.activity.findFirst({
+    where: { lessonId: k2TankLesson.id, kind: INFO, order: 1 },
+  });
   if (tankStoryAct) {
-    await prisma.activity.update({ where: { id: tankStoryAct.id }, data: { title: "Story: Meet Bolt", content: tankStoryContent } });
+    await prisma.activity.update({
+      where: { id: tankStoryAct.id },
+      data: { title: "Story: Meet Bolt", content: tankStoryContent },
+    });
   } else {
-    await prisma.activity.create({ data: { title: "Story: Meet Bolt", kind: INFO, order: 1, content: tankStoryContent, Lesson: { connect: { id: k2TankLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        title: "Story: Meet Bolt",
+        kind: INFO,
+        order: 1,
+        content: tankStoryContent,
+        Lesson: { connect: { id: k2TankLesson.id } },
+      },
+    });
   }
 
-  const tankGameContent = JSON.stringify({ gameKey: "tank_trek", chapters: [] });
-  let tankGameAct = await prisma.activity.findFirst({ where: { lessonId: k2TankLesson.id, kind: INTERACT, order: 2 } });
+  const tankGameContent = JSON.stringify({
+    gameKey: "tank_trek",
+    chapters: [],
+  });
+  let tankGameAct = await prisma.activity.findFirst({
+    where: { lessonId: k2TankLesson.id, kind: INTERACT, order: 2 },
+  });
   if (tankGameAct) {
-    await prisma.activity.update({ where: { id: tankGameAct.id }, data: { id: "tank-trek", title: "Game: Tank Trek", content: tankGameContent } });
+    await prisma.activity.update({
+      where: { id: tankGameAct.id },
+      data: {
+        id: "tank-trek",
+        title: "Game: Tank Trek",
+        content: tankGameContent,
+      },
+    });
   } else {
-    await prisma.activity.create({ data: { id: "tank-trek", title: "Game: Tank Trek", kind: INTERACT, order: 2, content: tankGameContent, Lesson: { connect: { id: k2TankLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        id: "tank-trek",
+        title: "Game: Tank Trek",
+        kind: INTERACT,
+        order: 2,
+        content: tankGameContent,
+        Lesson: { connect: { id: k2TankLesson.id } },
+      },
+    });
   }
   console.log("Seeded Tank Trek module + activities.");
 
@@ -827,48 +1369,188 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   const k2QuantumModule = await prisma.module.upsert({
     where: { slug: "k2-stem-quantum-quest" },
-    update: { title: "Quantum Quest", description: "Explore quantum puzzles in a space math adventure! 🚀✨", level: "K-2", published: true },
-    create: { slug: "k2-stem-quantum-quest", title: "Quantum Quest", description: "Explore quantum puzzles in a space math adventure! 🚀✨", level: "K-2", published: true },
+    update: {
+      title: "Quantum Quest",
+      description: "Explore quantum puzzles in a space math adventure! 🚀✨",
+      level: "K-2",
+      published: true,
+    },
+    create: {
+      slug: "k2-stem-quantum-quest",
+      title: "Quantum Quest",
+      description: "Explore quantum puzzles in a space math adventure! 🚀✨",
+      level: "K-2",
+      published: true,
+    },
   });
   console.log("Created module:", k2QuantumModule.slug);
 
-  let k2QuantumUnit = await prisma.unit.findFirst({ where: { moduleId: k2QuantumModule.id, title: "Unit 1: Star Math" } });
+  let k2QuantumUnit = await prisma.unit.findFirst({
+    where: { moduleId: k2QuantumModule.id, title: "Unit 1: Star Math" },
+  });
   if (!k2QuantumUnit) {
-    k2QuantumUnit = await prisma.unit.create({ data: { title: "Unit 1: Star Math", order: 1, Module: { connect: { id: k2QuantumModule.id } }, teacher: { connect: { id: teacher.id } } } });
+    k2QuantumUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Star Math",
+        order: 1,
+        Module: { connect: { id: k2QuantumModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
   }
 
-  let k2QuantumLesson = await prisma.lesson.findFirst({ where: { unitId: k2QuantumUnit.id, title: "Quantum Quest" } });
+  let k2QuantumLesson = await prisma.lesson.findFirst({
+    where: { unitId: k2QuantumUnit.id, title: "Quantum Quest" },
+  });
   if (!k2QuantumLesson) {
-    k2QuantumLesson = await prisma.lesson.create({ data: { title: "Quantum Quest", order: 1, Unit: { connect: { id: k2QuantumUnit.id } } } });
+    k2QuantumLesson = await prisma.lesson.create({
+      data: {
+        title: "Quantum Quest",
+        order: 1,
+        Unit: { connect: { id: k2QuantumUnit.id } },
+      },
+    });
   }
 
   const quantumStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "qq-s1", text: { en: "Welcome, Space Explorer! Your mission is to spot number patterns and true clues in the stars.", es: "¡Bienvenido, Explorador Espacial! Tu misión es encontrar patrones de números y pistas verdaderas en las estrellas." }, icon: "🚀" },
-      { id: "qq-s2", text: { en: "Look carefully at every choice. Use evidence: count, compare, and notice what repeats.", es: "Mira con atención cada opción. Usa evidencia: cuenta, compara y nota lo que se repite." }, icon: "🔍" },
-      { id: "qq-s3", text: { en: "Each correct answer builds your streak power. Careful thinking keeps your mission safe!", es: "Cada respuesta correcta aumenta tu racha. ¡Pensar con cuidado mantiene tu misión segura!" }, icon: "🌟" },
+      {
+        id: "qq-s1",
+        text: {
+          en: "Welcome, Space Explorer! Your mission is to spot number patterns and true clues in the stars.",
+          es: "¡Bienvenido, Explorador Espacial! Tu misión es encontrar patrones de números y pistas verdaderas en las estrellas.",
+        },
+        icon: "🚀",
+      },
+      {
+        id: "qq-s2",
+        text: {
+          en: "Look carefully at every choice. Use evidence: count, compare, and notice what repeats.",
+          es: "Mira con atención cada opción. Usa evidencia: cuenta, compara y nota lo que se repite.",
+        },
+        icon: "🔍",
+      },
+      {
+        id: "qq-s3",
+        text: {
+          en: "Each correct answer builds your streak power. Careful thinking keeps your mission safe!",
+          es: "Cada respuesta correcta aumenta tu racha. ¡Pensar con cuidado mantiene tu misión segura!",
+        },
+        icon: "🌟",
+      },
     ],
     questions: [
-      { id: "qq-q1", prompt: { en: "Which pattern comes next: 2, 4, 6, __?", es: "¿Qué patrón sigue: 2, 4, 6, __?" }, choices: [{ en: "8", es: "8" }, { en: "7", es: "7" }, { en: "5", es: "5" }, { en: "10", es: "10" }], answerIndex: 0, hint: { en: "The pattern adds 2 each time.", es: "El patrón suma 2 cada vez." } },
-      { id: "qq-q2", prompt: { en: "You count 3 stars, then 2 more. How many stars now?", es: "Cuentas 3 estrellas y luego 2 más. ¿Cuántas estrellas hay ahora?" }, choices: [{ en: "4", es: "4" }, { en: "5", es: "5" }, { en: "6", es: "6" }, { en: "3", es: "3" }], answerIndex: 1, hint: { en: "Count on: 3, 4, 5.", es: "Cuenta hacia adelante: 3, 4, 5." } },
-      { id: "qq-q3", prompt: { en: "Which answer shows careful evidence?", es: "¿Qué respuesta muestra evidencia cuidadosa?" }, choices: [{ en: "Pick the biggest number quickly", es: "Elegir el número más grande rápido" }, { en: "Guess before you look", es: "Adivinar antes de mirar" }, { en: "Check the pattern, then choose", es: "Revisar el patrón y luego elegir" }, { en: "Tap any star", es: "Tocar cualquier estrella" }], answerIndex: 2, hint: { en: "Scientists observe first.", es: "Los científicos observan primero." } },
+      {
+        id: "qq-q1",
+        prompt: {
+          en: "Which pattern comes next: 2, 4, 6, __?",
+          es: "¿Qué patrón sigue: 2, 4, 6, __?",
+        },
+        choices: [
+          { en: "8", es: "8" },
+          { en: "7", es: "7" },
+          { en: "5", es: "5" },
+          { en: "10", es: "10" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "The pattern adds 2 each time.",
+          es: "El patrón suma 2 cada vez.",
+        },
+      },
+      {
+        id: "qq-q2",
+        prompt: {
+          en: "You count 3 stars, then 2 more. How many stars now?",
+          es: "Cuentas 3 estrellas y luego 2 más. ¿Cuántas estrellas hay ahora?",
+        },
+        choices: [
+          { en: "4", es: "4" },
+          { en: "5", es: "5" },
+          { en: "6", es: "6" },
+          { en: "3", es: "3" },
+        ],
+        answerIndex: 1,
+        hint: {
+          en: "Count on: 3, 4, 5.",
+          es: "Cuenta hacia adelante: 3, 4, 5.",
+        },
+      },
+      {
+        id: "qq-q3",
+        prompt: {
+          en: "Which answer shows careful evidence?",
+          es: "¿Qué respuesta muestra evidencia cuidadosa?",
+        },
+        choices: [
+          {
+            en: "Pick the biggest number quickly",
+            es: "Elegir el número más grande rápido",
+          },
+          { en: "Guess before you look", es: "Adivinar antes de mirar" },
+          {
+            en: "Check the pattern, then choose",
+            es: "Revisar el patrón y luego elegir",
+          },
+          { en: "Tap any star", es: "Tocar cualquier estrella" },
+        ],
+        answerIndex: 2,
+        hint: {
+          en: "Scientists observe first.",
+          es: "Los científicos observan primero.",
+        },
+      },
     ],
   });
 
-  let quantumStoryAct = await prisma.activity.findFirst({ where: { lessonId: k2QuantumLesson.id, kind: INFO, order: 1 } });
+  let quantumStoryAct = await prisma.activity.findFirst({
+    where: { lessonId: k2QuantumLesson.id, kind: INFO, order: 1 },
+  });
   if (quantumStoryAct) {
-    await prisma.activity.update({ where: { id: quantumStoryAct.id }, data: { title: "Story: Space Explorer", content: quantumStoryContent } });
+    await prisma.activity.update({
+      where: { id: quantumStoryAct.id },
+      data: { title: "Story: Space Explorer", content: quantumStoryContent },
+    });
   } else {
-    await prisma.activity.create({ data: { title: "Story: Space Explorer", kind: INFO, order: 1, content: quantumStoryContent, Lesson: { connect: { id: k2QuantumLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        title: "Story: Space Explorer",
+        kind: INFO,
+        order: 1,
+        content: quantumStoryContent,
+        Lesson: { connect: { id: k2QuantumLesson.id } },
+      },
+    });
   }
 
-  const quantumGameContent = JSON.stringify({ gameKey: "quantum_quest", sectors: [] });
-  let quantumGameAct = await prisma.activity.findFirst({ where: { lessonId: k2QuantumLesson.id, kind: INTERACT, order: 2 } });
+  const quantumGameContent = JSON.stringify({
+    gameKey: "quantum_quest",
+    sectors: [],
+  });
+  let quantumGameAct = await prisma.activity.findFirst({
+    where: { lessonId: k2QuantumLesson.id, kind: INTERACT, order: 2 },
+  });
   if (quantumGameAct) {
-    await prisma.activity.update({ where: { id: quantumGameAct.id }, data: { id: "quantum-quest", title: "Game: Quantum Quest", content: quantumGameContent } });
+    await prisma.activity.update({
+      where: { id: quantumGameAct.id },
+      data: {
+        id: "quantum-quest",
+        title: "Game: Quantum Quest",
+        content: quantumGameContent,
+      },
+    });
   } else {
-    await prisma.activity.create({ data: { id: "quantum-quest", title: "Game: Quantum Quest", kind: INTERACT, order: 2, content: quantumGameContent, Lesson: { connect: { id: k2QuantumLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        id: "quantum-quest",
+        title: "Game: Quantum Quest",
+        kind: INTERACT,
+        order: 2,
+        content: quantumGameContent,
+        Lesson: { connect: { id: k2QuantumLesson.id } },
+      },
+    });
   }
   console.log("Seeded Quantum Quest module + activities.");
 
@@ -876,17 +1558,47 @@ async function main() {
   // Test Explorer — Set 1 completion records
   // ═══════════════════════════════════════════════════════════════════════════
   const set1Activities = [
-    { activityId: "bounce-buds", moduleSlug: "k2-stem-bounce-buds", timeSpentS: 180, daysAgo: 5 },
-    { activityId: "gotcha-gears", moduleSlug: "k2-stem-gotcha-gears", timeSpentS: 210, daysAgo: 4 },
-    { activityId: "rhyme-ride", moduleSlug: "k2-stem-rhyme-ride", timeSpentS: 240, daysAgo: 3 },
-    { activityId: "tank-trek", moduleSlug: "k2-stem-tank-trek", timeSpentS: 195, daysAgo: 2 },
-    { activityId: "quantum-quest", moduleSlug: "k2-stem-quantum-quest", timeSpentS: 220, daysAgo: 1 },
+    {
+      activityId: "bounce-buds",
+      moduleSlug: "k2-stem-bounce-buds",
+      timeSpentS: 180,
+      daysAgo: 5,
+    },
+    {
+      activityId: "gotcha-gears",
+      moduleSlug: "k2-stem-gotcha-gears",
+      timeSpentS: 210,
+      daysAgo: 4,
+    },
+    {
+      activityId: "rhyme-ride",
+      moduleSlug: "k2-stem-rhyme-ride",
+      timeSpentS: 240,
+      daysAgo: 3,
+    },
+    {
+      activityId: "tank-trek",
+      moduleSlug: "k2-stem-tank-trek",
+      timeSpentS: 195,
+      daysAgo: 2,
+    },
+    {
+      activityId: "quantum-quest",
+      moduleSlug: "k2-stem-quantum-quest",
+      timeSpentS: 220,
+      daysAgo: 1,
+    },
   ];
 
   for (const sa of set1Activities) {
     const completedAt = new Date(Date.now() - sa.daysAgo * 86400000);
     await prisma.progress.upsert({
-      where: { studentId_activityId: { studentId: explorer.id, activityId: sa.activityId } },
+      where: {
+        studentId_activityId: {
+          studentId: explorer.id,
+          activityId: sa.activityId,
+        },
+      },
       create: {
         studentId: explorer.id,
         activityId: sa.activityId,
@@ -900,16 +1612,48 @@ async function main() {
 
   // Game personal bests for explorer
   const explorerBests = [
-    { gameKey: "buddy_garden_sort", bestScore: 45, lastScore: 45, bestStreak: 4, bestRoundsCompleted: 8 },
-    { gameKey: "gotcha_gears_unity", bestScore: 80, lastScore: 60, bestStreak: 3, bestRoundsCompleted: 7 },
-    { gameKey: "boost_path_planner", bestScore: 35, lastScore: 35, bestStreak: 2, bestRoundsCompleted: 3 },
-    { gameKey: "rhymo_rhyme_rocket", bestScore: 120, lastScore: 90, bestStreak: 5, bestRoundsCompleted: 15 },
-    { gameKey: "tank_trek", bestScore: 16, lastScore: 14, bestStreak: 3, bestRoundsCompleted: 7 }, // star-sum units (7 levels x 3 max = 21); the old 55 was fabricated and unearnable
+    {
+      gameKey: "buddy_garden_sort",
+      bestScore: 45,
+      lastScore: 45,
+      bestStreak: 4,
+      bestRoundsCompleted: 8,
+    },
+    {
+      gameKey: "gotcha_gears_unity",
+      bestScore: 80,
+      lastScore: 60,
+      bestStreak: 3,
+      bestRoundsCompleted: 7,
+    },
+    {
+      gameKey: "boost_path_planner",
+      bestScore: 35,
+      lastScore: 35,
+      bestStreak: 2,
+      bestRoundsCompleted: 3,
+    },
+    {
+      gameKey: "rhymo_rhyme_rocket",
+      bestScore: 120,
+      lastScore: 90,
+      bestStreak: 5,
+      bestRoundsCompleted: 15,
+    },
+    {
+      gameKey: "tank_trek",
+      bestScore: 16,
+      lastScore: 14,
+      bestStreak: 3,
+      bestRoundsCompleted: 7,
+    }, // star-sum units (7 levels x 3 max = 21); the old 55 was fabricated and unearnable
   ];
 
   for (const gb of explorerBests) {
     await prisma.gamePersonalBest.upsert({
-      where: { studentId_gameKey: { studentId: explorer.id, gameKey: gb.gameKey } },
+      where: {
+        studentId_gameKey: { studentId: explorer.id, gameKey: gb.gameKey },
+      },
       create: { studentId: explorer.id, ...gb, playCount: 3 },
       update: gb,
     });
@@ -931,18 +1675,112 @@ async function main() {
       story: {
         title: "Story: Maze Explorer",
         slides: [
-          { id: "mm-s1", text: { en: "Spark the helper bot is lost in the idea maze! Glowing orbs are scattered everywhere, but sneaky sweepers are patrolling the paths. Spark needs YOUR help to collect every orb and find the exit.", es: "¡Spark el robot ayudante está perdido en el laberinto de ideas! Hay esferas brillantes por todas partes, pero los barredores patrullan los caminos. ¡Spark necesita TU ayuda para recoger cada esfera y encontrar la salida!" }, icon: "🗺️" },
-          { id: "mm-s2", text: { en: "But here's the trick — Spark can't just run in! The sweepers move in patterns. Watch them carefully before you move. The smartest path isn't always the shortest one.", es: "Pero hay un truco — ¡Spark no puede solo correr! Los barredores se mueven en patrones. Obsérvalos antes de moverte. El camino más inteligente no siempre es el más corto." }, icon: "🤔" },
-          { id: "mm-s3", text: { en: "Ready? Guide Spark through the maze. Collect all the orbs. Avoid the sweepers. Think before you move!", es: "¿Listo? Guía a Spark por el laberinto. Recoge todas las esferas. Evita los barredores. ¡Piensa antes de moverte!" }, icon: "⭐" },
+          {
+            id: "mm-s1",
+            text: {
+              en: "Spark the helper bot is lost in the idea maze! Glowing orbs are scattered everywhere, but sneaky sweepers are patrolling the paths. Spark needs YOUR help to collect every orb and find the exit.",
+              es: "¡Spark el robot ayudante está perdido en el laberinto de ideas! Hay esferas brillantes por todas partes, pero los barredores patrullan los caminos. ¡Spark necesita TU ayuda para recoger cada esfera y encontrar la salida!",
+            },
+            icon: "🗺️",
+          },
+          {
+            id: "mm-s2",
+            text: {
+              en: "But here's the trick — Spark can't just run in! The sweepers move in patterns. Watch them carefully before you move. The smartest path isn't always the shortest one.",
+              es: "Pero hay un truco — ¡Spark no puede solo correr! Los barredores se mueven en patrones. Obsérvalos antes de moverte. El camino más inteligente no siempre es el más corto.",
+            },
+            icon: "🤔",
+          },
+          {
+            id: "mm-s3",
+            text: {
+              en: "Ready? Guide Spark through the maze. Collect all the orbs. Avoid the sweepers. Think before you move!",
+              es: "¿Listo? Guía a Spark por el laberinto. Recoge todas las esferas. Evita los barredores. ¡Piensa antes de moverte!",
+            },
+            icon: "⭐",
+          },
         ],
         questions: [
-          { id: "mm-q1", prompt: { en: "What should you do before moving in a maze?", es: "¿Qué debes hacer antes de moverte en un laberinto?" }, choices: [{ en: "Plan a path", es: "Planificar un camino" }, { en: "Run fast", es: "Correr rápido" }, { en: "Close your eyes", es: "Cerrar los ojos" }, { en: "Ask for directions", es: "Pedir direcciones" }], answerIndex: 0 },
+          {
+            id: "mm-q1",
+            prompt: {
+              en: "What should you do before moving in a maze?",
+              es: "¿Qué debes hacer antes de moverte en un laberinto?",
+            },
+            choices: [
+              { en: "Plan a path", es: "Planificar un camino" },
+              { en: "Run fast", es: "Correr rápido" },
+              { en: "Close your eyes", es: "Cerrar los ojos" },
+              { en: "Ask for directions", es: "Pedir direcciones" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "mmz-q1", prompt: { en: "Before moving through the maze, what should you do first?", es: "Antes de moverte en el laberinto, ¿qué debes hacer primero?" }, choices: [{ en: "Run as fast as you can", es: "Correr lo más rápido posible" }, { en: "Watch the sweeper's pattern", es: "Observar el patrón del barredor" }, { en: "Close your eyes and guess", es: "Cerrar los ojos y adivinar" }, { en: "Pick the shortest path", es: "Elegir el camino más corto" }], answerIndex: 1 },
-        { id: "mmz-q2", prompt: { en: "A sweeper moves left, right, left, right. What does it do next?", es: "Un barredor se mueve izquierda, derecha, izquierda, derecha. ¿Qué hace después?" }, choices: [{ en: "Stop", es: "Parar" }, { en: "Move up", es: "Ir arriba" }, { en: "Move left", es: "Ir a la izquierda" }, { en: "Disappear", es: "Desaparecer" }], answerIndex: 2 },
-        { id: "mmz-q3", prompt: { en: "Which is the smartest path?", es: "¿Cuál es el camino más inteligente?" }, choices: [{ en: "The shortest path past a sweeper", es: "El camino más corto pasando un barredor" }, { en: "A longer path that avoids sweepers", es: "Un camino más largo que evita barredores" }, { en: "Standing still forever", es: "Quedarse quieto para siempre" }, { en: "The path with the most turns", es: "El camino con más giros" }], answerIndex: 1 },
+        {
+          id: "mmz-q1",
+          prompt: {
+            en: "Before moving through the maze, what should you do first?",
+            es: "Antes de moverte en el laberinto, ¿qué debes hacer primero?",
+          },
+          choices: [
+            {
+              en: "Run as fast as you can",
+              es: "Correr lo más rápido posible",
+            },
+            {
+              en: "Watch the sweeper's pattern",
+              es: "Observar el patrón del barredor",
+            },
+            {
+              en: "Close your eyes and guess",
+              es: "Cerrar los ojos y adivinar",
+            },
+            { en: "Pick the shortest path", es: "Elegir el camino más corto" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "mmz-q2",
+          prompt: {
+            en: "A sweeper moves left, right, left, right. What does it do next?",
+            es: "Un barredor se mueve izquierda, derecha, izquierda, derecha. ¿Qué hace después?",
+          },
+          choices: [
+            { en: "Stop", es: "Parar" },
+            { en: "Move up", es: "Ir arriba" },
+            { en: "Move left", es: "Ir a la izquierda" },
+            { en: "Disappear", es: "Desaparecer" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "mmz-q3",
+          prompt: {
+            en: "Which is the smartest path?",
+            es: "¿Cuál es el camino más inteligente?",
+          },
+          choices: [
+            {
+              en: "The shortest path past a sweeper",
+              es: "El camino más corto pasando un barredor",
+            },
+            {
+              en: "A longer path that avoids sweepers",
+              es: "Un camino más largo que evita barredores",
+            },
+            {
+              en: "Standing still forever",
+              es: "Quedarse quieto para siempre",
+            },
+            {
+              en: "The path with the most turns",
+              es: "El camino con más giros",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -955,18 +1793,106 @@ async function main() {
       story: {
         title: "Story: Body Lab",
         slides: [
-          { id: "mmi-s1", text: { en: "Welcome to the Motion Lab! Today you're the scientist AND the athlete. You'll run, jump, and throw — then measure how you did.", es: "¡Bienvenido al Laboratorio de Movimiento! Hoy eres el científico Y el atleta. Correrás, saltarás y lanzarás — luego medirás cómo te fue." }, icon: "🏃" },
-          { id: "mmi-s2", text: { en: "But here's what makes a real scientist — after you measure, you get to IMPROVE. Pick one coaching tip, try again, and see if your numbers go up.", es: "Pero esto es lo que hace a un verdadero científico — después de medir, puedes MEJORAR. Elige un consejo, inténtalo de nuevo y mira si tus números suben." }, icon: "📏" },
-          { id: "mmi-s3", text: { en: "Ready to test your body and your brain? Let's go!", es: "¿Listo para probar tu cuerpo y tu cerebro? ¡Vamos!" }, icon: "💪" },
+          {
+            id: "mmi-s1",
+            text: {
+              en: "Welcome to the Motion Lab! Today you're the scientist AND the athlete. You'll run, jump, and throw — then measure how you did.",
+              es: "¡Bienvenido al Laboratorio de Movimiento! Hoy eres el científico Y el atleta. Correrás, saltarás y lanzarás — luego medirás cómo te fue.",
+            },
+            icon: "🏃",
+          },
+          {
+            id: "mmi-s2",
+            text: {
+              en: "But here's what makes a real scientist — after you measure, you get to IMPROVE. Pick one coaching tip, try again, and see if your numbers go up.",
+              es: "Pero esto es lo que hace a un verdadero científico — después de medir, puedes MEJORAR. Elige un consejo, inténtalo de nuevo y mira si tus números suben.",
+            },
+            icon: "📏",
+          },
+          {
+            id: "mmi-s3",
+            text: {
+              en: "Ready to test your body and your brain? Let's go!",
+              es: "¿Listo para probar tu cuerpo y tu cerebro? ¡Vamos!",
+            },
+            icon: "💪",
+          },
         ],
         questions: [
-          { id: "mmi-q1", prompt: { en: "How do you know you got better at something?", es: "¿Cómo sabes que mejoraste en algo?" }, choices: [{ en: "Measure and compare", es: "Medir y comparar" }, { en: "Guess", es: "Adivinar" }, { en: "Ask a fish", es: "Preguntar a un pez" }, { en: "Just feel it", es: "Solo sentirlo" }], answerIndex: 0 },
+          {
+            id: "mmi-q1",
+            prompt: {
+              en: "How do you know you got better at something?",
+              es: "¿Cómo sabes que mejoraste en algo?",
+            },
+            choices: [
+              { en: "Measure and compare", es: "Medir y comparar" },
+              { en: "Guess", es: "Adivinar" },
+              { en: "Ask a fish", es: "Preguntar a un pez" },
+              { en: "Just feel it", es: "Solo sentirlo" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "mmv-q1", prompt: { en: "What should you do after your first try?", es: "¿Qué debes hacer después de tu primer intento?" }, choices: [{ en: "Give up", es: "Rendirse" }, { en: "Try the exact same thing again", es: "Intentar exactamente lo mismo" }, { en: "Look at your results and pick one thing to change", es: "Mirar tus resultados y elegir una cosa para cambiar" }, { en: "Change everything at once", es: "Cambiar todo a la vez" }], answerIndex: 2 },
-        { id: "mmv-q2", prompt: { en: "Which body part helps the most with jumping?", es: "¿Qué parte del cuerpo ayuda más a saltar?" }, choices: [{ en: "Your arms", es: "Tus brazos" }, { en: "Your legs", es: "Tus piernas" }, { en: "Your ears", es: "Tus orejas" }, { en: "Your neck", es: "Tu cuello" }], answerIndex: 1 },
-        { id: "mmv-q3", prompt: { en: "You threw the ball 10 feet. Then you used a tip and threw it 14 feet. What happened?", es: "Lanzaste la pelota 10 pies. Luego usaste un consejo y la lanzaste 14 pies. ¿Qué pasó?" }, choices: [{ en: "Nothing changed", es: "Nada cambió" }, { en: "The tip helped you throw farther", es: "El consejo te ayudó a lanzar más lejos" }, { en: "You should try a different tip", es: "Deberías probar otro consejo" }, { en: "Throwing doesn't use your arms", es: "Lanzar no usa tus brazos" }], answerIndex: 1 },
+        {
+          id: "mmv-q1",
+          prompt: {
+            en: "What should you do after your first try?",
+            es: "¿Qué debes hacer después de tu primer intento?",
+          },
+          choices: [
+            { en: "Give up", es: "Rendirse" },
+            {
+              en: "Try the exact same thing again",
+              es: "Intentar exactamente lo mismo",
+            },
+            {
+              en: "Look at your results and pick one thing to change",
+              es: "Mirar tus resultados y elegir una cosa para cambiar",
+            },
+            { en: "Change everything at once", es: "Cambiar todo a la vez" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "mmv-q2",
+          prompt: {
+            en: "Which body part helps the most with jumping?",
+            es: "¿Qué parte del cuerpo ayuda más a saltar?",
+          },
+          choices: [
+            { en: "Your arms", es: "Tus brazos" },
+            { en: "Your legs", es: "Tus piernas" },
+            { en: "Your ears", es: "Tus orejas" },
+            { en: "Your neck", es: "Tu cuello" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "mmv-q3",
+          prompt: {
+            en: "You threw the ball 10 feet. Then you used a tip and threw it 14 feet. What happened?",
+            es: "Lanzaste la pelota 10 pies. Luego usaste un consejo y la lanzaste 14 pies. ¿Qué pasó?",
+          },
+          choices: [
+            { en: "Nothing changed", es: "Nada cambió" },
+            {
+              en: "The tip helped you throw farther",
+              es: "El consejo te ayudó a lanzar más lejos",
+            },
+            {
+              en: "You should try a different tip",
+              es: "Deberías probar otro consejo",
+            },
+            {
+              en: "Throwing doesn't use your arms",
+              es: "Lanzar no usa tus brazos",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -979,18 +1905,110 @@ async function main() {
       story: {
         title: "Story: Pattern Patrol",
         slides: [
-          { id: "ss-s1", text: { en: "Light drops are falling. Catch them in the right lane.", es: "Caen gotas de luz. Atrápalas en el carril correcto." }, icon: "🌌" },
-          { id: "ss-s2", text: { en: "Watch the pattern: blue, gold, blue, gold...", es: "Mira el patrón: azul, dorado, azul, dorado..." }, icon: "🔍" },
-          { id: "ss-s3", text: { en: "If a light is mystery, tap Scan first.", es: "Si una luz es misterio, toca Escanear primero." }, icon: "🛡️" },
+          {
+            id: "ss-s1",
+            text: {
+              en: "Light drops are falling. Catch them in the right lane.",
+              es: "Caen gotas de luz. Atrápalas en el carril correcto.",
+            },
+            icon: "🌌",
+          },
+          {
+            id: "ss-s2",
+            text: {
+              en: "Watch the pattern: blue, gold, blue, gold...",
+              es: "Mira el patrón: azul, dorado, azul, dorado...",
+            },
+            icon: "🔍",
+          },
+          {
+            id: "ss-s3",
+            text: {
+              en: "If a light is mystery, tap Scan first.",
+              es: "Si una luz es misterio, toca Escanear primero.",
+            },
+            icon: "🛡️",
+          },
         ],
         questions: [
-          { id: "ss-q1", prompt: { en: "What is a pattern?", es: "¿Qué es un patrón?" }, choices: [{ en: "Something that repeats", es: "Algo que se repite" }, { en: "A random mess", es: "Un desorden" }, { en: "A color", es: "Un color" }, { en: "A loud sound", es: "Un sonido fuerte" }], answerIndex: 0, hint: { en: "Look for what repeats.", es: "Busca lo que se repite." } },
+          {
+            id: "ss-q1",
+            prompt: { en: "What is a pattern?", es: "¿Qué es un patrón?" },
+            choices: [
+              { en: "Something that repeats", es: "Algo que se repite" },
+              { en: "A random mess", es: "Un desorden" },
+              { en: "A color", es: "Un color" },
+              { en: "A loud sound", es: "Un sonido fuerte" },
+            ],
+            answerIndex: 0,
+            hint: {
+              en: "Look for what repeats.",
+              es: "Busca lo que se repite.",
+            },
+          },
         ],
       },
       quiz: [
-        { id: "ss-qz1", prompt: { en: "Blue, gold, blue, gold, blue. What comes next?", es: "Azul, dorado, azul, dorado, azul. ¿Qué sigue?" }, choices: [{ en: "Blue", es: "Azul" }, { en: "Gold", es: "Dorado" }, { en: "Red", es: "Rojo" }, { en: "Green", es: "Verde" }], answerIndex: 1, hint: { en: "Say the pattern out loud.", es: "Di el patrón en voz alta." } },
-        { id: "ss-qz2", prompt: { en: "You see a mystery light. What should you do?", es: "Ves una luz misteriosa. ¿Qué debes hacer?" }, choices: [{ en: "Guess fast", es: "Adivinar rápido" }, { en: "Tap Scan first", es: "Tocar Escanear primero" }, { en: "Run away", es: "Huir" }, { en: "Skip your turn", es: "Saltar tu turno" }], answerIndex: 1, hint: { en: "Scan helps you check before choosing.", es: "Escanear te ayuda a revisar antes de elegir." } },
-        { id: "ss-qz3", prompt: { en: "Why watch before you choose?", es: "¿Por qué mirar antes de elegir?" }, choices: [{ en: "To predict the next drop", es: "Para predecir la próxima gota" }, { en: "To make it harder", es: "Para hacerlo más difícil" }, { en: "Because patterns do not matter", es: "Porque los patrones no importan" }, { en: "To lose points", es: "Para perder puntos" }], answerIndex: 0, hint: { en: "Watching helps your brain plan.", es: "Mirar ayuda a tu cerebro a planear." } },
+        {
+          id: "ss-qz1",
+          prompt: {
+            en: "Blue, gold, blue, gold, blue. What comes next?",
+            es: "Azul, dorado, azul, dorado, azul. ¿Qué sigue?",
+          },
+          choices: [
+            { en: "Blue", es: "Azul" },
+            { en: "Gold", es: "Dorado" },
+            { en: "Red", es: "Rojo" },
+            { en: "Green", es: "Verde" },
+          ],
+          answerIndex: 1,
+          hint: {
+            en: "Say the pattern out loud.",
+            es: "Di el patrón en voz alta.",
+          },
+        },
+        {
+          id: "ss-qz2",
+          prompt: {
+            en: "You see a mystery light. What should you do?",
+            es: "Ves una luz misteriosa. ¿Qué debes hacer?",
+          },
+          choices: [
+            { en: "Guess fast", es: "Adivinar rápido" },
+            { en: "Tap Scan first", es: "Tocar Escanear primero" },
+            { en: "Run away", es: "Huir" },
+            { en: "Skip your turn", es: "Saltar tu turno" },
+          ],
+          answerIndex: 1,
+          hint: {
+            en: "Scan helps you check before choosing.",
+            es: "Escanear te ayuda a revisar antes de elegir.",
+          },
+        },
+        {
+          id: "ss-qz3",
+          prompt: {
+            en: "Why watch before you choose?",
+            es: "¿Por qué mirar antes de elegir?",
+          },
+          choices: [
+            {
+              en: "To predict the next drop",
+              es: "Para predecir la próxima gota",
+            },
+            { en: "To make it harder", es: "Para hacerlo más difícil" },
+            {
+              en: "Because patterns do not matter",
+              es: "Porque los patrones no importan",
+            },
+            { en: "To lose points", es: "Para perder puntos" },
+          ],
+          answerIndex: 0,
+          hint: {
+            en: "Watching helps your brain plan.",
+            es: "Mirar ayuda a tu cerebro a planear.",
+          },
+        },
       ],
     },
     {
@@ -1003,18 +2021,100 @@ async function main() {
       story: {
         title: "Story: Signal School",
         slides: [
-          { id: "fl-s1", text: { en: "You're driving the science delivery cart today! The lab needs these supplies FAST — but the road is full of obstacles. Cones, puddles, and blocked lanes are everywhere.", es: "¡Hoy conduces el carrito de entregas del laboratorio! El laboratorio necesita estos materiales RÁPIDO — pero el camino está lleno de obstáculos. Conos, charcos y carriles bloqueados por todas partes." }, icon: "🚦" },
-          { id: "fl-s2", text: { en: "Follow the road signals: green arrow means GO, yellow means GET READY, red X means AVOID. The safest driver wins — not the fastest!", es: "Sigue las señales del camino: flecha verde significa AVANZA, amarillo significa PREPÁRATE, X roja significa EVITA. ¡El conductor más seguro gana — no el más rápido!" }, icon: "🤔" },
-          { id: "fl-s3", text: { en: "Watch ahead, read the signs, and deliver those supplies safely. Let's roll!", es: "Mira adelante, lee las señales y entrega los materiales con seguridad. ¡Vamos!" }, icon: "⏱️" },
+          {
+            id: "fl-s1",
+            text: {
+              en: "You're driving the science delivery cart today! The lab needs these supplies FAST — but the road is full of obstacles. Cones, puddles, and blocked lanes are everywhere.",
+              es: "¡Hoy conduces el carrito de entregas del laboratorio! El laboratorio necesita estos materiales RÁPIDO — pero el camino está lleno de obstáculos. Conos, charcos y carriles bloqueados por todas partes.",
+            },
+            icon: "🚦",
+          },
+          {
+            id: "fl-s2",
+            text: {
+              en: "Follow the road signals: green arrow means GO, yellow means GET READY, red X means AVOID. The safest driver wins — not the fastest!",
+              es: "Sigue las señales del camino: flecha verde significa AVANZA, amarillo significa PREPÁRATE, X roja significa EVITA. ¡El conductor más seguro gana — no el más rápido!",
+            },
+            icon: "🤔",
+          },
+          {
+            id: "fl-s3",
+            text: {
+              en: "Watch ahead, read the signs, and deliver those supplies safely. Let's roll!",
+              es: "Mira adelante, lee las señales y entrega los materiales con seguridad. ¡Vamos!",
+            },
+            icon: "⏱️",
+          },
         ],
         questions: [
-          { id: "fl-q1", prompt: { en: "What does a green signal mean?", es: "¿Qué significa una señal verde?" }, choices: [{ en: "Go", es: "Avanzar" }, { en: "Stop", es: "Parar" }, { en: "Sleep", es: "Dormir" }, { en: "Wait", es: "Esperar" }], answerIndex: 0 },
+          {
+            id: "fl-q1",
+            prompt: {
+              en: "What does a green signal mean?",
+              es: "¿Qué significa una señal verde?",
+            },
+            choices: [
+              { en: "Go", es: "Avanzar" },
+              { en: "Stop", es: "Parar" },
+              { en: "Sleep", es: "Dormir" },
+              { en: "Wait", es: "Esperar" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "fl-qz1", prompt: { en: "You see a yellow road sign. What does it mean?", es: "Ves una señal amarilla. ¿Qué significa?" }, choices: [{ en: "Speed up", es: "Acelerar" }, { en: "Stop immediately", es: "Parar inmediatamente" }, { en: "Get ready — something is about to change", es: "Prepárate — algo está a punto de cambiar" }, { en: "Close your eyes", es: "Cerrar los ojos" }], answerIndex: 2 },
-        { id: "fl-qz2", prompt: { en: "What matters most when driving the delivery cart?", es: "¿Qué es lo más importante al conducir el carrito de entregas?" }, choices: [{ en: "Going as fast as possible", es: "Ir lo más rápido posible" }, { en: "Getting there safely", es: "Llegar con seguridad" }, { en: "Crashing into every cone", es: "Chocarse con cada cono" }, { en: "Ignoring the signs", es: "Ignorar las señales" }], answerIndex: 1 },
-        { id: "fl-qz3", prompt: { en: "There's a boost pad in a lane with a red X. What should you do?", es: "Hay un impulso en un carril con una X roja. ¿Qué debes hacer?" }, choices: [{ en: "Go for the boost", es: "Ir por el impulso" }, { en: "Avoid that lane — red X means danger", es: "Evitar ese carril — X roja significa peligro" }, { en: "Stop the cart", es: "Parar el carrito" }, { en: "Switch to a random lane", es: "Cambiar a un carril aleatorio" }], answerIndex: 1 },
+        {
+          id: "fl-qz1",
+          prompt: {
+            en: "You see a yellow road sign. What does it mean?",
+            es: "Ves una señal amarilla. ¿Qué significa?",
+          },
+          choices: [
+            { en: "Speed up", es: "Acelerar" },
+            { en: "Stop immediately", es: "Parar inmediatamente" },
+            {
+              en: "Get ready — something is about to change",
+              es: "Prepárate — algo está a punto de cambiar",
+            },
+            { en: "Close your eyes", es: "Cerrar los ojos" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "fl-qz2",
+          prompt: {
+            en: "What matters most when driving the delivery cart?",
+            es: "¿Qué es lo más importante al conducir el carrito de entregas?",
+          },
+          choices: [
+            { en: "Going as fast as possible", es: "Ir lo más rápido posible" },
+            { en: "Getting there safely", es: "Llegar con seguridad" },
+            { en: "Crashing into every cone", es: "Chocarse con cada cono" },
+            { en: "Ignoring the signs", es: "Ignorar las señales" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "fl-qz3",
+          prompt: {
+            en: "There's a boost pad in a lane with a red X. What should you do?",
+            es: "Hay un impulso en un carril con una X roja. ¿Qué debes hacer?",
+          },
+          choices: [
+            { en: "Go for the boost", es: "Ir por el impulso" },
+            {
+              en: "Avoid that lane — red X means danger",
+              es: "Evitar ese carril — X roja significa peligro",
+            },
+            { en: "Stop the cart", es: "Parar el carrito" },
+            {
+              en: "Switch to a random lane",
+              es: "Cambiar a un carril aleatorio",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -1027,19 +2127,126 @@ async function main() {
       story: {
         title: "Story: Race Lab",
         slides: [
-          { id: "qtr-s1", text: { en: "Welcome to the engineering garage! Today you'll build, test, and improve your racer. But here's the rule: you can only change ONE thing at a time.", es: "¡Bienvenido al garaje de ingeniería! Hoy construirás, probarás y mejorarás tu corredor. Pero hay una regla: solo puedes cambiar UNA cosa a la vez." }, icon: "🏎️" },
-          { id: "qtr-s2", text: { en: "First, do a practice lap. Then look at your results — time, bumps, smoothness. Pick ONE upgrade: better tires, a speed boost, or steadier steering. Then race again!", es: "Primero, haz una vuelta de práctica. Luego mira tus resultados — tiempo, golpes, suavidad. Elige UNA mejora: mejores neumáticos, turbo de velocidad o dirección más estable. ¡Luego corre de nuevo!" }, icon: "🔧" },
-          { id: "qtr-s3", text: { en: "Real scientists test one change at a time. That's how you know what actually worked. Ready to qualify, tune, and race?", es: "Los científicos reales prueban un cambio a la vez. Así sabes qué realmente funcionó. ¿Listo para probar, ajustar y competir?" }, icon: "🧪" },
+          {
+            id: "qtr-s1",
+            text: {
+              en: "Welcome to the engineering garage! Today you'll build, test, and improve your racer. But here's the rule: you can only change ONE thing at a time.",
+              es: "¡Bienvenido al garaje de ingeniería! Hoy construirás, probarás y mejorarás tu corredor. Pero hay una regla: solo puedes cambiar UNA cosa a la vez.",
+            },
+            icon: "🏎️",
+          },
+          {
+            id: "qtr-s2",
+            text: {
+              en: "First, do a practice lap. Then look at your results — time, bumps, smoothness. Pick ONE upgrade: better tires, a speed boost, or steadier steering. Then race again!",
+              es: "Primero, haz una vuelta de práctica. Luego mira tus resultados — tiempo, golpes, suavidad. Elige UNA mejora: mejores neumáticos, turbo de velocidad o dirección más estable. ¡Luego corre de nuevo!",
+            },
+            icon: "🔧",
+          },
+          {
+            id: "qtr-s3",
+            text: {
+              en: "Real scientists test one change at a time. That's how you know what actually worked. Ready to qualify, tune, and race?",
+              es: "Los científicos reales prueban un cambio a la vez. Así sabes qué realmente funcionó. ¿Listo para probar, ajustar y competir?",
+            },
+            icon: "🧪",
+          },
         ],
         questions: [
-          { id: "qtr-q1", prompt: { en: "To make a fair test, how many things should you change at a time?", es: "Para hacer una prueba justa, ¿cuántas cosas debes cambiar a la vez?" }, choices: [{ en: "One", es: "Una" }, { en: "All of them", es: "Todas" }, { en: "None", es: "Ninguna" }, { en: "Three", es: "Tres" }], answerIndex: 0 },
+          {
+            id: "qtr-q1",
+            prompt: {
+              en: "To make a fair test, how many things should you change at a time?",
+              es: "Para hacer una prueba justa, ¿cuántas cosas debes cambiar a la vez?",
+            },
+            choices: [
+              { en: "One", es: "Una" },
+              { en: "All of them", es: "Todas" },
+              { en: "None", es: "Ninguna" },
+              { en: "Three", es: "Tres" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "qtr-qz1", prompt: { en: "How many things should you change at a time when tuning?", es: "¿Cuántas cosas debes cambiar a la vez al ajustar?" }, choices: [{ en: "As many as possible", es: "Todas las posibles" }, { en: "Two", es: "Dos" }, { en: "One", es: "Una" }, { en: "None", es: "Ninguna" }], answerIndex: 2 },
-        { id: "qtr-qz2", prompt: { en: "Your first lap had 5 bumps. You added Grip Tires and your second lap had 2 bumps. What happened?", es: "Tu primera vuelta tuvo 5 golpes. Agregaste Neumáticos de Agarre y tu segunda vuelta tuvo 2 golpes. ¿Qué pasó?" }, choices: [{ en: "Nothing changed", es: "Nada cambió" }, { en: "Grip Tires helped you bump less", es: "Los neumáticos de agarre te ayudaron a golpear menos" }, { en: "The track got easier", es: "La pista se hizo más fácil" }, { en: "Bumps don't matter", es: "Los golpes no importan" }], answerIndex: 1 },
-        { id: "qtr-qz3", prompt: { en: "Why do engineers change only one thing at a time?", es: "¿Por qué los ingenieros cambian solo una cosa a la vez?" }, choices: [{ en: "Because they're slow", es: "Porque son lentos" }, { en: "So they know which change made the difference", es: "Para saber qué cambio hizo la diferencia" }, { en: "Because two changes would break everything", es: "Porque dos cambios romperían todo" }, { en: "They don't — they change everything", es: "No lo hacen — cambian todo" }], answerIndex: 1 },
-        { id: "qtr-qz4", prompt: { en: "You picked Speed Boost but bumped into more walls. What does that tell you?", es: "Elegiste Turbo de Velocidad pero chocaste con más paredes. ¿Qué te dice eso?" }, choices: [{ en: "Speed Boost made it harder to control", es: "El Turbo hizo más difícil de controlar" }, { en: "Speed Boost doesn't work", es: "El Turbo no funciona" }, { en: "You should always pick Speed Boost", es: "Siempre debes elegir Turbo" }, { en: "Bumps help you go faster", es: "Los golpes te ayudan a ir más rápido" }], answerIndex: 0 },
+        {
+          id: "qtr-qz1",
+          prompt: {
+            en: "How many things should you change at a time when tuning?",
+            es: "¿Cuántas cosas debes cambiar a la vez al ajustar?",
+          },
+          choices: [
+            { en: "As many as possible", es: "Todas las posibles" },
+            { en: "Two", es: "Dos" },
+            { en: "One", es: "Una" },
+            { en: "None", es: "Ninguna" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "qtr-qz2",
+          prompt: {
+            en: "Your first lap had 5 bumps. You added Grip Tires and your second lap had 2 bumps. What happened?",
+            es: "Tu primera vuelta tuvo 5 golpes. Agregaste Neumáticos de Agarre y tu segunda vuelta tuvo 2 golpes. ¿Qué pasó?",
+          },
+          choices: [
+            { en: "Nothing changed", es: "Nada cambió" },
+            {
+              en: "Grip Tires helped you bump less",
+              es: "Los neumáticos de agarre te ayudaron a golpear menos",
+            },
+            { en: "The track got easier", es: "La pista se hizo más fácil" },
+            { en: "Bumps don't matter", es: "Los golpes no importan" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "qtr-qz3",
+          prompt: {
+            en: "Why do engineers change only one thing at a time?",
+            es: "¿Por qué los ingenieros cambian solo una cosa a la vez?",
+          },
+          choices: [
+            { en: "Because they're slow", es: "Porque son lentos" },
+            {
+              en: "So they know which change made the difference",
+              es: "Para saber qué cambio hizo la diferencia",
+            },
+            {
+              en: "Because two changes would break everything",
+              es: "Porque dos cambios romperían todo",
+            },
+            {
+              en: "They don't — they change everything",
+              es: "No lo hacen — cambian todo",
+            },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "qtr-qz4",
+          prompt: {
+            en: "You picked Speed Boost but bumped into more walls. What does that tell you?",
+            es: "Elegiste Turbo de Velocidad pero chocaste con más paredes. ¿Qué te dice eso?",
+          },
+          choices: [
+            {
+              en: "Speed Boost made it harder to control",
+              es: "El Turbo hizo más difícil de controlar",
+            },
+            { en: "Speed Boost doesn't work", es: "El Turbo no funciona" },
+            {
+              en: "You should always pick Speed Boost",
+              es: "Siempre debes elegir Turbo",
+            },
+            {
+              en: "Bumps help you go faster",
+              es: "Los golpes te ayudan a ir más rápido",
+            },
+          ],
+          answerIndex: 0,
+        },
       ],
     },
   ];
@@ -1047,24 +2254,56 @@ async function main() {
   for (const s2 of set2Modules) {
     const mod = await prisma.module.upsert({
       where: { slug: s2.slug },
-      update: { title: s2.title, description: s2.description, level: "K-2", published: true },
-      create: { slug: s2.slug, title: s2.title, description: s2.description, level: "K-2", published: true },
+      update: {
+        title: s2.title,
+        description: s2.description,
+        level: "K-2",
+        published: true,
+      },
+      create: {
+        slug: s2.slug,
+        title: s2.title,
+        description: s2.description,
+        level: "K-2",
+        published: true,
+      },
     });
 
     // Get or create unit — use first unit of this module (not by title, which may have changed)
-    let s2Unit = await prisma.unit.findFirst({ where: { moduleId: mod.id }, orderBy: { order: "asc" } });
+    let s2Unit = await prisma.unit.findFirst({
+      where: { moduleId: mod.id },
+      orderBy: { order: "asc" },
+    });
     if (!s2Unit) {
-      s2Unit = await prisma.unit.create({ data: { title: "Unit 1", order: 1, Module: { connect: { id: mod.id } }, teacher: { connect: { id: teacher.id } } } });
+      s2Unit = await prisma.unit.create({
+        data: {
+          title: "Unit 1",
+          order: 1,
+          Module: { connect: { id: mod.id } },
+          teacher: { connect: { id: teacher.id } },
+        },
+      });
     }
 
     // Get or create lesson — use first lesson of this unit
-    let s2Lesson = await prisma.lesson.findFirst({ where: { unitId: s2Unit.id }, orderBy: { order: "asc" } });
+    let s2Lesson = await prisma.lesson.findFirst({
+      where: { unitId: s2Unit.id },
+      orderBy: { order: "asc" },
+    });
     if (!s2Lesson) {
-      s2Lesson = await prisma.lesson.create({ data: { title: s2.title, order: 1, Unit: { connect: { id: s2Unit.id } } } });
+      s2Lesson = await prisma.lesson.create({
+        data: {
+          title: s2.title,
+          order: 1,
+          Unit: { connect: { id: s2Unit.id } },
+        },
+      });
     }
 
     // Clean up duplicate lessons (from previous seed runs with different titles)
-    const allLessons = await prisma.lesson.findMany({ where: { unitId: s2Unit.id } });
+    const allLessons = await prisma.lesson.findMany({
+      where: { unitId: s2Unit.id },
+    });
     for (const dup of allLessons) {
       if (dup.id !== s2Lesson.id) {
         await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
@@ -1073,7 +2312,10 @@ async function main() {
     }
 
     // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
-    const existingActs = await prisma.activity.findMany({ where: { lessonId: s2Lesson.id }, orderBy: { order: "asc" } });
+    const existingActs = await prisma.activity.findMany({
+      where: { lessonId: s2Lesson.id },
+      orderBy: { order: "asc" },
+    });
     for (const act of existingActs) {
       if (act.order > 3) {
         await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
@@ -1085,23 +2327,57 @@ async function main() {
       type: "story_quiz",
       slides: s2.story.slides,
       questions: s2.story.questions,
-      review: { keyIdea: { en: s2.description }, vocab: [s2.strand.toLowerCase()] },
+      review: {
+        keyIdea: { en: s2.description },
+        vocab: [s2.strand.toLowerCase()],
+      },
     });
 
-    let storyAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, kind: INFO, order: 1 } });
+    let storyAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, kind: INFO, order: 1 },
+    });
     if (storyAct) {
-      await prisma.activity.update({ where: { id: storyAct.id }, data: { title: s2.story.title, content: storyContent } });
+      await prisma.activity.update({
+        where: { id: storyAct.id },
+        data: { title: s2.story.title, content: storyContent },
+      });
     } else {
-      await prisma.activity.create({ data: { title: s2.story.title, kind: INFO, order: 1, content: storyContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          title: s2.story.title,
+          kind: INFO,
+          order: 1,
+          content: storyContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     // Activity 2: Game (INTERACT)
     const gameContent = JSON.stringify({ gameKey: s2.gameKey });
-    let gameAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, kind: INTERACT, order: 2 } });
+    let gameAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, kind: INTERACT, order: 2 },
+    });
     if (gameAct) {
-      await prisma.activity.update({ where: { id: gameAct.id }, data: { id: s2.activityId, title: `Game: ${s2.title}`, content: gameContent } });
+      await prisma.activity.update({
+        where: { id: gameAct.id },
+        data: {
+          id: s2.activityId,
+          title: `Game: ${s2.title}`,
+          content: gameContent,
+        },
+      });
     } else {
-      await prisma.activity.create({ data: { id: s2.activityId, title: `Game: ${s2.title}`, kind: INTERACT, order: 2, content: gameContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          id: s2.activityId,
+          title: `Game: ${s2.title}`,
+          kind: INTERACT,
+          order: 2,
+          content: gameContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     // Activity 3: Quiz (INFO with quiz questions)
@@ -1110,14 +2386,313 @@ async function main() {
       slides: [],
       questions: s2.quiz ?? [],
     });
-    let quizAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, order: 3 } });
+    let quizAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, order: 3 },
+    });
     if (quizAct) {
-      await prisma.activity.update({ where: { id: quizAct.id }, data: { title: `Quiz: ${s2.title}`, kind: INFO, content: quizContent } });
+      await prisma.activity.update({
+        where: { id: quizAct.id },
+        data: { title: `Quiz: ${s2.title}`, kind: INFO, content: quizContent },
+      });
     } else {
-      await prisma.activity.create({ data: { title: `Quiz: ${s2.title}`, kind: INFO, order: 3, content: quizContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          title: `Quiz: ${s2.title}`,
+          kind: INFO,
+          order: 3,
+          content: quizContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     console.log("Seeded Set 2 module:", s2.slug, "(story + game + quiz)");
+  }
+
+  // ---------------------------------------------------------------------
+  // SET 3 — Mastery ("mastery through making"; game 1 only, GATED from
+  // students via HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts — the
+  // module is seeded + published so ungating is a one-line frontend change).
+  // ---------------------------------------------------------------------
+  const set3Modules = [
+    {
+      slug: "k2-stem-track-maker",
+      title: "Boost Track Builder",
+      description: "Build your own motorcycle track, then ride it! 🏍️🛠️",
+      activityId: "track-maker",
+      gameKey: "track_maker",
+      strand: "Quantum",
+      story: {
+        title: "Story: Boost's New Wheels",
+        slides: [
+          {
+            id: "tm-s1",
+            text: {
+              en: "Boost just got a shiny motorcycle — vroom! But there's a problem: there's no track to ride it on. Guess who gets to build one? YOU!",
+              es: "¡Boost tiene una moto nueva y brillante — brum! Pero hay un problema: no hay pista para montarla. ¿Adivina quién va a construir una? ¡TÚ!",
+            },
+            icon: "🏍️",
+          },
+          {
+            id: "tm-s2",
+            text: {
+              en: "Here's Boost's builder tip: bikes love straights, but curves are tricky. Go too fast into a sharp curve and — whoaaa — spin-out! Good builders think about speed.",
+              es: "El consejo de Boost: a las motos les encantan las rectas, pero las curvas son difíciles. Si entras muy rápido a una curva cerrada — ¡uuuy — trompo! Los buenos constructores piensan en la velocidad.",
+            },
+            icon: "🛠️",
+          },
+          {
+            id: "tm-s3",
+            text: {
+              en: "Build your track, ride it, and make it better each time. Every wobble teaches you something. Ready, builder?",
+              es: "Construye tu pista, móntala y mejórala cada vez. Cada tambaleo te enseña algo. ¿Listo, constructor?",
+            },
+            icon: "⭐",
+          },
+        ],
+        questions: [
+          {
+            id: "tm-q1",
+            prompt: {
+              en: "What happens if the bike goes too fast into a sharp curve?",
+              es: "¿Qué pasa si la moto entra muy rápido a una curva cerrada?",
+            },
+            choices: [
+              { en: "It spins out", es: "Da un trompo" },
+              { en: "It flies away", es: "Sale volando" },
+              { en: "Nothing happens", es: "No pasa nada" },
+              { en: "It gets bigger", es: "Se hace más grande" },
+            ],
+            answerIndex: 0,
+          },
+        ],
+      },
+      quiz: [
+        {
+          id: "tmz-q1",
+          prompt: {
+            en: "The bike keeps spinning out on your sharp curve. What could help?",
+            es: "La moto sigue dando trompos en tu curva cerrada. ¿Qué podría ayudar?",
+          },
+          choices: [
+            {
+              en: "Slow down before the curve",
+              es: "Frenar antes de la curva",
+            },
+            {
+              en: "Put a boost pad right before it",
+              es: "Poner un acelerador justo antes",
+            },
+            { en: "Ride faster", es: "Ir más rápido" },
+            { en: "Close your eyes", es: "Cerrar los ojos" },
+          ],
+          answerIndex: 0,
+        },
+        {
+          id: "tmz-q2",
+          prompt: {
+            en: "Your ride didn't go how you wanted. What does a good builder do?",
+            es: "Tu paseo no salió como querías. ¿Qué hace un buen constructor?",
+          },
+          choices: [
+            {
+              en: "Change the track and try again",
+              es: "Cambiar la pista y probar otra vez",
+            },
+            {
+              en: "Stop building forever",
+              es: "Dejar de construir para siempre",
+            },
+            { en: "Blame the bike", es: "Culpar a la moto" },
+            { en: "Delete everything", es: "Borrar todo" },
+          ],
+          answerIndex: 0,
+        },
+        {
+          id: "tmz-q3",
+          prompt: {
+            en: "What does a boost pad do?",
+            es: "¿Qué hace un acelerador?",
+          },
+          choices: [
+            {
+              en: "Makes the bike zoom fast",
+              es: "Hace que la moto vaya súper rápido",
+            },
+            { en: "Stops the bike", es: "Detiene la moto" },
+            { en: "Paints the bike", es: "Pinta la moto" },
+            { en: "Makes the track longer", es: "Alarga la pista" },
+          ],
+          answerIndex: 0,
+        },
+      ],
+    },
+  ];
+
+  for (const s3 of set3Modules) {
+    const mod = await prisma.module.upsert({
+      where: { slug: s3.slug },
+      update: {
+        title: s3.title,
+        description: s3.description,
+        level: "K-2",
+        published: true,
+      },
+      create: {
+        slug: s3.slug,
+        title: s3.title,
+        description: s3.description,
+        level: "K-2",
+        published: true,
+      },
+    });
+
+    // Get or create unit — use first unit of this module (not by title, which may have changed)
+    let s3Unit = await prisma.unit.findFirst({
+      where: { moduleId: mod.id },
+      orderBy: { order: "asc" },
+    });
+    if (!s3Unit) {
+      s3Unit = await prisma.unit.create({
+        data: {
+          title: "Unit 1",
+          order: 1,
+          Module: { connect: { id: mod.id } },
+          teacher: { connect: { id: teacher.id } },
+        },
+      });
+    }
+
+    // Get or create lesson — use first lesson of this unit
+    let s3Lesson = await prisma.lesson.findFirst({
+      where: { unitId: s3Unit.id },
+      orderBy: { order: "asc" },
+    });
+    if (!s3Lesson) {
+      s3Lesson = await prisma.lesson.create({
+        data: {
+          title: s3.title,
+          order: 1,
+          Unit: { connect: { id: s3Unit.id } },
+        },
+      });
+    }
+
+    // Clean up duplicate lessons (from previous seed runs with different titles)
+    const allS3Lessons = await prisma.lesson.findMany({
+      where: { unitId: s3Unit.id },
+    });
+    for (const dup of allS3Lessons) {
+      if (dup.id !== s3Lesson.id) {
+        await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
+        await prisma.lesson.delete({ where: { id: dup.id } }).catch(() => {});
+      }
+    }
+
+    // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
+    const existingS3Acts = await prisma.activity.findMany({
+      where: { lessonId: s3Lesson.id },
+      orderBy: { order: "asc" },
+    });
+    for (const act of existingS3Acts) {
+      if (act.order > 3) {
+        await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
+      }
+    }
+
+    // Activity 1: Story (INFO)
+    const s3StoryContent = JSON.stringify({
+      type: "story_quiz",
+      slides: s3.story.slides,
+      questions: s3.story.questions,
+      review: {
+        keyIdea: { en: s3.description },
+        vocab: [s3.strand.toLowerCase()],
+      },
+    });
+
+    let s3StoryAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, kind: INFO, order: 1 },
+    });
+    if (s3StoryAct) {
+      await prisma.activity.update({
+        where: { id: s3StoryAct.id },
+        data: { title: s3.story.title, content: s3StoryContent },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          title: s3.story.title,
+          kind: INFO,
+          order: 1,
+          content: s3StoryContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    // Activity 2: Game (INTERACT)
+    const s3GameContent = JSON.stringify({ gameKey: s3.gameKey });
+    let s3GameAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, kind: INTERACT, order: 2 },
+    });
+    if (s3GameAct) {
+      await prisma.activity.update({
+        where: { id: s3GameAct.id },
+        data: {
+          id: s3.activityId,
+          title: `Game: ${s3.title}`,
+          content: s3GameContent,
+        },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          id: s3.activityId,
+          title: `Game: ${s3.title}`,
+          kind: INTERACT,
+          order: 2,
+          content: s3GameContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    // Activity 3: Quiz (INFO with quiz questions)
+    const s3QuizContent = JSON.stringify({
+      type: "story_quiz",
+      slides: [],
+      questions: s3.quiz ?? [],
+    });
+    let s3QuizAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, order: 3 },
+    });
+    if (s3QuizAct) {
+      await prisma.activity.update({
+        where: { id: s3QuizAct.id },
+        data: {
+          title: `Quiz: ${s3.title}`,
+          kind: INFO,
+          content: s3QuizContent,
+        },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          title: `Quiz: ${s3.title}`,
+          kind: INFO,
+          order: 3,
+          content: s3QuizContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    console.log(
+      "Seeded Set 3 module:",
+      s3.slug,
+      "(story + game + quiz — gated)",
+    );
   }
 
   console.log("Seeding units...");
@@ -1173,25 +2748,28 @@ async function main() {
     where: { lessonId: lesson.id, title: "Build a Bot" },
   });
   if (buildBot) {
-    await prisma.activity.delete({ where: { id: buildBot.id } }).catch(() => {});
+    await prisma.activity
+      .delete({ where: { id: buildBot.id } })
+      .catch(() => {});
     console.log("Cleaned up removed Build-a-Bot activity.");
   }
   console.log("Seeded activities.");
-
 
   // ── Grade 3-5 first playable module: Data Dash: Sort & Discover ──
   const g35DataDashModule = await prisma.module.upsert({
     where: { slug: "g35-data-dash-sort-discover" },
     update: {
       title: "Data Dash: Sort & Discover",
-      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      description:
+        "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
       level: "G3-5",
       published: true,
     },
     create: {
       slug: "g35-data-dash-sort-discover",
       title: "Data Dash: Sort & Discover",
-      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      description:
+        "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
       level: "G3-5",
       published: true,
     },
@@ -1199,7 +2777,10 @@ async function main() {
   console.log("Created module:", g35DataDashModule.slug);
 
   let g35DataDashUnit = await prisma.unit.findFirst({
-    where: { moduleId: g35DataDashModule.id, title: "Unit 1: Greenhouse Data Lab" },
+    where: {
+      moduleId: g35DataDashModule.id,
+      title: "Unit 1: Greenhouse Data Lab",
+    },
   });
   if (!g35DataDashUnit) {
     g35DataDashUnit = await prisma.unit.create({
@@ -1213,7 +2794,10 @@ async function main() {
   }
 
   let g35DataDashLesson = await prisma.lesson.findFirst({
-    where: { unitId: g35DataDashUnit.id, title: "Lesson 1: Sort, Infer, Explain" },
+    where: {
+      unitId: g35DataDashUnit.id,
+      title: "Lesson 1: Sort, Infer, Explain",
+    },
   });
   if (!g35DataDashLesson) {
     g35DataDashLesson = await prisma.lesson.create({
@@ -1264,64 +2848,148 @@ async function main() {
     questions: [
       {
         id: "dd-q1",
-        prompt: { en: "Which choice is a classification rule (not just one observation)?", es: "¿Qué opción es una regla de clasificación (no solo una observación)?" },
+        prompt: {
+          en: "Which choice is a classification rule (not just one observation)?",
+          es: "¿Qué opción es una regla de clasificación (no solo una observación)?",
+        },
         choices: [
-          { en: "Group plants by seed type", es: "Agrupar plantas por tipo de semilla" },
-          { en: "This fern needs high water", es: "Este helecho necesita mucha agua" },
-          { en: "Plant bed A has three plants", es: "La cama de plantas A tiene tres plantas" },
-          { en: "Card 4 has the prettiest flowers", es: "La tarjeta 4 tiene las flores más bonitas" }
+          {
+            en: "Group plants by seed type",
+            es: "Agrupar plantas por tipo de semilla",
+          },
+          {
+            en: "This fern needs high water",
+            es: "Este helecho necesita mucha agua",
+          },
+          {
+            en: "Plant bed A has three plants",
+            es: "La cama de plantas A tiene tres plantas",
+          },
+          {
+            en: "Card 4 has the prettiest flowers",
+            es: "La tarjeta 4 tiene las flores más bonitas",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "A rule can be used on every card.", es: "Una regla puede usarse en cada tarjeta." }
+        hint: {
+          en: "A rule can be used on every card.",
+          es: "Una regla puede usarse en cada tarjeta.",
+        },
       },
       {
         id: "dd-q2",
-        prompt: { en: "If two cards both have cone seeds, what is true?", es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?" },
+        prompt: {
+          en: "If two cards both have cone seeds, what is true?",
+          es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?",
+        },
         choices: [
           { en: "They match on seed type", es: "Coinciden en tipo de semilla" },
-          { en: "They must be in the same plant bed", es: "Deben estar en la misma cama de plantas" },
-          { en: "They must need the same water", es: "Deben necesitar la misma agua" },
-          { en: "They must be the same color", es: "Deben ser del mismo color" }
+          {
+            en: "They must be in the same plant bed",
+            es: "Deben estar en la misma cama de plantas",
+          },
+          {
+            en: "They must need the same water",
+            es: "Deben necesitar la misma agua",
+          },
+          {
+            en: "They must be the same color",
+            es: "Deben ser del mismo color",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Look only at the named attribute.", es: "Mira solo el atributo nombrado." }
+        hint: {
+          en: "Look only at the named attribute.",
+          es: "Mira solo el atributo nombrado.",
+        },
       },
       {
         id: "dd-q3",
-        prompt: { en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?", es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?" },
+        prompt: {
+          en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?",
+          es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?",
+        },
         choices: [
-          { en: "Most plants need full sunlight", es: "La mayoría de las plantas necesitan luz solar completa" },
-          { en: "All plants need shade", es: "Todas las plantas necesitan sombra" },
-          { en: "No plants need partial sunlight", es: "Ninguna planta necesita luz solar parcial" },
-          { en: "Plants prefer shade over sunlight", es: "Las plantas prefieren la sombra al sol" }
+          {
+            en: "Most plants need full sunlight",
+            es: "La mayoría de las plantas necesitan luz solar completa",
+          },
+          {
+            en: "All plants need shade",
+            es: "Todas las plantas necesitan sombra",
+          },
+          {
+            en: "No plants need partial sunlight",
+            es: "Ninguna planta necesita luz solar parcial",
+          },
+          {
+            en: "Plants prefer shade over sunlight",
+            es: "Las plantas prefieren la sombra al sol",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Choose the claim that matches the largest count.", es: "Elige la afirmación que coincide con el mayor conteo." }
+        hint: {
+          en: "Choose the claim that matches the largest count.",
+          es: "Elige la afirmación que coincide con el mayor conteo.",
+        },
       },
       {
         id: "dd-q4",
-        prompt: { en: "What is the strongest evidence for your claim?", es: "¿Cuál es la evidencia más fuerte para tu afirmación?" },
+        prompt: {
+          en: "What is the strongest evidence for your claim?",
+          es: "¿Cuál es la evidencia más fuerte para tu afirmación?",
+        },
         choices: [
-          { en: "The full-sun bar is tallest", es: "La barra de sol completo es la más alta" },
-          { en: "I like full-sun plants", es: "Me gustan las plantas de sol completo" },
-          { en: "My friend chose that answer", es: "Mi amigo eligió esa respuesta" },
-          { en: "It just felt like the right answer", es: "Sentí que era la respuesta correcta" }
+          {
+            en: "The full-sun bar is tallest",
+            es: "La barra de sol completo es la más alta",
+          },
+          {
+            en: "I like full-sun plants",
+            es: "Me gustan las plantas de sol completo",
+          },
+          {
+            en: "My friend chose that answer",
+            es: "Mi amigo eligió esa respuesta",
+          },
+          {
+            en: "It just felt like the right answer",
+            es: "Sentí que era la respuesta correcta",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Evidence comes from measured data.", es: "La evidencia proviene de datos medidos." }
+        hint: {
+          en: "Evidence comes from measured data.",
+          es: "La evidencia proviene de datos medidos.",
+        },
       },
       {
         id: "dd-q5",
-        prompt: { en: "Why is multi-attribute sorting useful?", es: "¿Por qué es útil clasificar por múltiples atributos?" },
+        prompt: {
+          en: "Why is multi-attribute sorting useful?",
+          es: "¿Por qué es útil clasificar por múltiples atributos?",
+        },
         choices: [
-          { en: "It helps find deeper patterns and better explanations", es: "Ayuda a encontrar patrones más profundos y mejores explicaciones" },
+          {
+            en: "It helps find deeper patterns and better explanations",
+            es: "Ayuda a encontrar patrones más profundos y mejores explicaciones",
+          },
           { en: "It makes data random", es: "Hace los datos aleatorios" },
-          { en: "It removes the need for evidence", es: "Elimina la necesidad de evidencia" },
-          { en: "It makes sorting faster than using one attribute", es: "Hace que clasificar sea más rápido que usar un atributo" }
+          {
+            en: "It removes the need for evidence",
+            es: "Elimina la necesidad de evidencia",
+          },
+          {
+            en: "It makes sorting faster than using one attribute",
+            es: "Hace que clasificar sea más rápido que usar un atributo",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "More than one attribute can reveal hidden structure.", es: "Más de un atributo puede revelar estructura oculta." }
-      }
+        hint: {
+          en: "More than one attribute can reveal hidden structure.",
+          es: "Más de un atributo puede revelar estructura oculta.",
+        },
+      },
     ],
   });
 
@@ -1384,167 +3052,355 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   console.log("Seeding module families and variants...");
   try {
+    const familyDefs = [
+      {
+        key: "quantum_quest",
+        title: "Quantum Foundations",
+        iconEmoji: "⚛️",
+        k2: {
+          title: "Quantum Quest",
+          subtitle: "Explore quantum puzzles in a space math adventure!",
+          moduleSlug: "k2-stem-quantum-quest",
+        },
+        g3_5: {
+          title: "Quantum Mission: Pattern Lab",
+          subtitle: "Model quantum patterns and test outcomes!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 270,
+              topic: "probability, patterns, observation, and evidence",
+              vocabulary: [
+                "quantum",
+                "pattern",
+                "probability",
+                "outcome",
+                "evidence",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "pattern-identification",
+                "prediction",
+                "evidence-choice",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: ["observe", "predict", "test"],
+              mechanics: [
+                "state-toggle",
+                "outcome-tracker",
+                "pattern-matcher",
+                "hint-ladder",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "mission-control", progressType: "ring" },
+          },
+        },
+      },
+      {
+        key: "motion",
+        title: "Forces & Motion",
+        iconEmoji: "🚀",
+        k2: {
+          title: "Rhyme & Ride",
+          subtitle: "Ride through worlds and catch rhymes!",
+          moduleSlug: "k2-stem-rhyme-ride",
+        },
+        g3_5: {
+          title: "Motion Mission: Force Lab",
+          subtitle: "Predict, test, and master forces!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 260,
+              topic: "force, friction, mass, prediction",
+              vocabulary: [
+                "force",
+                "friction",
+                "mass",
+                "acceleration",
+                "prediction",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: ["prediction", "comparison", "variable-identification"],
+            },
+            game: {
+              rounds: 3,
+              phases: ["predict", "test", "adjust-variables"],
+              mechanics: [
+                "force-slider",
+                "surface-selector",
+                "target-practice",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "lab", progressType: "bar" },
+          },
+        },
+      },
+      {
+        key: "sorting",
+        title: "Sorting & Classification",
+        iconEmoji: "📊",
+        k2: {
+          title: "Bounce & Buds",
+          subtitle: "Bounce through the right gate!",
+          moduleSlug: "k2-stem-bounce-buds",
+        },
+        g3_5: {
+          title: "Data Dash: Sort & Discover",
+          subtitle: "Classify data and find hidden patterns!",
+          contentConfig: {
+            theme: "dashboard",
+            reading: {
+              wordCount: 240,
+              topic: "classification, organizing data, finding patterns",
+              vocabulary: ["classify", "attribute", "pattern", "data", "graph"],
+            },
+            questions: {
+              count: 6,
+              types: ["multi-attribute-sort", "hidden-rule", "chart-reading"],
+            },
+            game: {
+              rounds: 3,
+              phases: ["sort-by-attribute", "infer-rule", "read-chart"],
+              mechanics: ["drag-sort", "rule-builder", "bar-chart"],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "mission", progressType: "ring" },
+          },
+        },
+      },
+      {
+        key: "plant_variables",
+        title: "Plants & Fair Tests",
+        iconEmoji: "🌱",
+        k2: {
+          title: "Gotcha Gears",
+          subtitle: "Catch the right gear!",
+          moduleSlug: "k2-stem-gotcha-gears",
+        },
+        g3_5: {
+          title: "Variable Quest: Fair Test Lab",
+          subtitle: "Design experiments and test your ideas!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 270,
+              topic:
+                "fair tests, changing one variable, evidence-based conclusions",
+              vocabulary: [
+                "variable",
+                "control",
+                "hypothesis",
+                "evidence",
+                "conclusion",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "fair-test-check",
+                "variable-identification",
+                "conclusion-choice",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: [
+                "setup-experiment",
+                "observe-results",
+                "evaluate-fairness",
+              ],
+              mechanics: ["variable-lock", "lab-notebook", "sentence-stems"],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "lab", progressType: "bar" },
+          },
+        },
+      },
+      {
+        key: "bridge",
+        title: "Engineering & Design",
+        iconEmoji: "🏗️",
+        k2: {
+          title: "Tank Trek",
+          subtitle: "Guide a robot through mazes!",
+          moduleSlug: "k2-stem-tank-trek",
+        },
+        g3_5: {
+          title: "Design Under Pressure: Bridge Lab",
+          subtitle: "Build, test, and redesign structures!",
+          contentConfig: {
+            theme: "blueprint",
+            reading: {
+              wordCount: 260,
+              topic: "stability, triangles, constraints, redesign",
+              vocabulary: [
+                "stability",
+                "triangle",
+                "constraint",
+                "load",
+                "redesign",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "weak-point-identification",
+                "material-choice",
+                "design-comparison",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: ["build", "load-test", "redesign"],
+              mechanics: [
+                "weak-point-highlight",
+                "starter-blueprint",
+                "budget-constraint",
+                "before-after-compare",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "blueprint", progressType: "ring" },
+          },
+        },
+      },
+    ];
 
-  const familyDefs = [
-    {
-      key: "quantum_quest",
-      title: "Quantum Foundations",
-      iconEmoji: "⚛️",
-      k2: { title: "Quantum Quest", subtitle: "Explore quantum puzzles in a space math adventure!", moduleSlug: "k2-stem-quantum-quest" },
-      g3_5: {
-        title: "Quantum Mission: Pattern Lab",
-        subtitle: "Model quantum patterns and test outcomes!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 270, topic: "probability, patterns, observation, and evidence", vocabulary: ["quantum", "pattern", "probability", "outcome", "evidence"] },
-          questions: { count: 5, types: ["pattern-identification", "prediction", "evidence-choice"] },
-          game: { rounds: 3, phases: ["observe", "predict", "test"], mechanics: ["state-toggle", "outcome-tracker", "pattern-matcher", "hint-ladder"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "mission-control", progressType: "ring" },
-        },
-      },
-    },
-    {
-      key: "motion",
-      title: "Forces & Motion",
-      iconEmoji: "🚀",
-      k2: { title: "Rhyme & Ride", subtitle: "Ride through worlds and catch rhymes!", moduleSlug: "k2-stem-rhyme-ride" },
-      g3_5: {
-        title: "Motion Mission: Force Lab",
-        subtitle: "Predict, test, and master forces!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 260, topic: "force, friction, mass, prediction", vocabulary: ["force", "friction", "mass", "acceleration", "prediction"] },
-          questions: { count: 5, types: ["prediction", "comparison", "variable-identification"] },
-          game: { rounds: 3, phases: ["predict", "test", "adjust-variables"], mechanics: ["force-slider", "surface-selector", "target-practice"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "lab", progressType: "bar" },
-        },
-      },
-    },
-    {
-      key: "sorting",
-      title: "Sorting & Classification",
-      iconEmoji: "📊",
-      k2: { title: "Bounce & Buds", subtitle: "Bounce through the right gate!", moduleSlug: "k2-stem-bounce-buds" },
-      g3_5: {
-        title: "Data Dash: Sort & Discover",
-        subtitle: "Classify data and find hidden patterns!",
-        contentConfig: {
-          theme: "dashboard",
-          reading: { wordCount: 240, topic: "classification, organizing data, finding patterns", vocabulary: ["classify", "attribute", "pattern", "data", "graph"] },
-          questions: { count: 6, types: ["multi-attribute-sort", "hidden-rule", "chart-reading"] },
-          game: { rounds: 3, phases: ["sort-by-attribute", "infer-rule", "read-chart"], mechanics: ["drag-sort", "rule-builder", "bar-chart"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "mission", progressType: "ring" },
-        },
-      },
-    },
-    {
-      key: "plant_variables",
-      title: "Plants & Fair Tests",
-      iconEmoji: "🌱",
-      k2: { title: "Gotcha Gears", subtitle: "Catch the right gear!", moduleSlug: "k2-stem-gotcha-gears" },
-      g3_5: {
-        title: "Variable Quest: Fair Test Lab",
-        subtitle: "Design experiments and test your ideas!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 270, topic: "fair tests, changing one variable, evidence-based conclusions", vocabulary: ["variable", "control", "hypothesis", "evidence", "conclusion"] },
-          questions: { count: 5, types: ["fair-test-check", "variable-identification", "conclusion-choice"] },
-          game: { rounds: 3, phases: ["setup-experiment", "observe-results", "evaluate-fairness"], mechanics: ["variable-lock", "lab-notebook", "sentence-stems"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "lab", progressType: "bar" },
-        },
-      },
-    },
-    {
-      key: "bridge",
-      title: "Engineering & Design",
-      iconEmoji: "🏗️",
-      k2: { title: "Tank Trek", subtitle: "Guide a robot through mazes!", moduleSlug: "k2-stem-tank-trek" },
-      g3_5: {
-        title: "Design Under Pressure: Bridge Lab",
-        subtitle: "Build, test, and redesign structures!",
-        contentConfig: {
-          theme: "blueprint",
-          reading: { wordCount: 260, topic: "stability, triangles, constraints, redesign", vocabulary: ["stability", "triangle", "constraint", "load", "redesign"] },
-          questions: { count: 5, types: ["weak-point-identification", "material-choice", "design-comparison"] },
-          game: { rounds: 3, phases: ["build", "load-test", "redesign"], mechanics: ["weak-point-highlight", "starter-blueprint", "budget-constraint", "before-after-compare"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "blueprint", progressType: "ring" },
-        },
-      },
-    },
-  ];
+    for (const fd of familyDefs) {
+      const family = await prisma.moduleFamily.upsert({
+        where: { key: fd.key },
+        create: { key: fd.key, title: fd.title, iconEmoji: fd.iconEmoji },
+        update: { title: fd.title, iconEmoji: fd.iconEmoji },
+      });
 
-  for (const fd of familyDefs) {
-    const family = await prisma.moduleFamily.upsert({
-      where: { key: fd.key },
-      create: { key: fd.key, title: fd.title, iconEmoji: fd.iconEmoji },
-      update: { title: fd.title, iconEmoji: fd.iconEmoji },
-    });
+      // K-2 variant (links to existing module)
+      await prisma.moduleVariant.upsert({
+        where: {
+          familyId_band_version: {
+            familyId: family.id,
+            band: "k2",
+            version: "1.0",
+          },
+        },
+        create: {
+          familyId: family.id,
+          band: "k2",
+          version: "1.0",
+          title: fd.k2.title,
+          subtitle: fd.k2.subtitle,
+          status: "active",
+          moduleSlug: fd.k2.moduleSlug,
+        },
+        update: {
+          title: fd.k2.title,
+          subtitle: fd.k2.subtitle,
+          moduleSlug: fd.k2.moduleSlug,
+        },
+      });
 
-    // K-2 variant (links to existing module)
-    await prisma.moduleVariant.upsert({
-      where: { familyId_band_version: { familyId: family.id, band: "k2", version: "1.0" } },
+      // G3-5 variant (new upper-elementary content)
+      await prisma.moduleVariant.upsert({
+        where: {
+          familyId_band_version: {
+            familyId: family.id,
+            band: "g3_5",
+            version: "1.0",
+          },
+        },
+        create: {
+          familyId: family.id,
+          band: "g3_5",
+          version: "1.0",
+          title: fd.g3_5.title,
+          subtitle: fd.g3_5.subtitle,
+          status: "active",
+          contentConfig: fd.g3_5.contentConfig,
+        },
+        update: {
+          title: fd.g3_5.title,
+          subtitle: fd.g3_5.subtitle,
+          contentConfig: fd.g3_5.contentConfig,
+        },
+      });
+
+      console.log(`  Seeded family "${fd.key}" with k2 + g3_5 variants`);
+    }
+
+    // Seed a demo g3_5 class if teacher exists
+    const demoClass = await prisma.course.upsert({
+      where: { joinCode: "UPPER35" },
       create: {
-        familyId: family.id,
-        band: "k2",
-        version: "1.0",
-        title: fd.k2.title,
-        subtitle: fd.k2.subtitle,
-        status: "active",
-        moduleSlug: fd.k2.moduleSlug,
+        name: "Grade 3-5 STEM Demo",
+        joinCode: "UPPER35",
+        teacherId: teacher.id,
+        gradeBand: "g3_5",
       },
-      update: { title: fd.k2.title, subtitle: fd.k2.subtitle, moduleSlug: fd.k2.moduleSlug },
+      update: { gradeBand: "g3_5" },
     });
+    console.log("Seeded demo g3_5 class:", demoClass.name);
 
-    // G3-5 variant (new upper-elementary content)
-    await prisma.moduleVariant.upsert({
-      where: { familyId_band_version: { familyId: family.id, band: "g3_5", version: "1.0" } },
-      create: {
-        familyId: family.id,
-        band: "g3_5",
-        version: "1.0",
-        title: fd.g3_5.title,
-        subtitle: fd.g3_5.subtitle,
-        status: "active",
-        contentConfig: fd.g3_5.contentConfig,
-      },
-      update: { title: fd.g3_5.title, subtitle: fd.g3_5.subtitle, contentConfig: fd.g3_5.contentConfig },
+    // Auto-assign all g3_5 variants to the demo class
+    const g35Variants = await prisma.moduleVariant.findMany({
+      where: { band: "g3_5", status: "active" },
     });
+    for (let i = 0; i < g35Variants.length; i++) {
+      await prisma.classModuleAssignment.upsert({
+        where: {
+          courseId_moduleVariantId: {
+            courseId: demoClass.id,
+            moduleVariantId: g35Variants[i].id,
+          },
+        },
+        create: {
+          courseId: demoClass.id,
+          moduleVariantId: g35Variants[i].id,
+          orderIndex: i,
+        },
+        update: { orderIndex: i },
+      });
+    }
+    console.log(`  Assigned ${g35Variants.length} g3_5 variants to demo class`);
 
-    console.log(`  Seeded family "${fd.key}" with k2 + g3_5 variants`);
-  }
-
-  // Seed a demo g3_5 class if teacher exists
-  const demoClass = await prisma.course.upsert({
-    where: { joinCode: "UPPER35" },
-    create: {
-      name: "Grade 3-5 STEM Demo",
-      joinCode: "UPPER35",
-      teacherId: teacher.id,
-      gradeBand: "g3_5",
-    },
-    update: { gradeBand: "g3_5" },
-  });
-  console.log("Seeded demo g3_5 class:", demoClass.name);
-
-  // Auto-assign all g3_5 variants to the demo class
-  const g35Variants = await prisma.moduleVariant.findMany({ where: { band: "g3_5", status: "active" } });
-  for (let i = 0; i < g35Variants.length; i++) {
-    await prisma.classModuleAssignment.upsert({
-      where: { courseId_moduleVariantId: { courseId: demoClass.id, moduleVariantId: g35Variants[i].id } },
-      create: { courseId: demoClass.id, moduleVariantId: g35Variants[i].id, orderIndex: i },
-      update: { orderIndex: i },
-    });
-  }
-  console.log(`  Assigned ${g35Variants.length} g3_5 variants to demo class`);
-
-  console.log("Module families and variants seeded.");
+    console.log("Module families and variants seeded.");
   } catch (e) {
-    console.warn("Module families seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Module families seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1553,413 +3409,537 @@ async function main() {
   console.log("Seeding Pathways data...");
 
   try {
-  // Facilitator
-  const facilitatorHash = await bcrypt.hash("pathway123", 10);
-  let facilitator = await prisma.user.findUnique({ where: { email: "facilitator@test.com" } });
-  if (!facilitator) {
-    facilitator = await prisma.user.create({
-      data: {
-        name: "Coach Davis",
-        email: "facilitator@test.com",
-        password: facilitatorHash,
-        role: "teacher",
-        userType: "pathways",
-      },
+    // Facilitator
+    const facilitatorHash = await bcrypt.hash("pathway123", 10);
+    let facilitator = await prisma.user.findUnique({
+      where: { email: "facilitator@test.com" },
     });
-  } else {
-    facilitator = await prisma.user.update({
-      where: { id: facilitator.id },
-      data: { password: facilitatorHash, userType: "pathways" },
-    });
-  }
-  console.log("Seeded facilitator:", facilitator.email);
-
-  // Marcus — Launch band, partial progress
-  const marcusHash = await bcrypt.hash("marcus123", 10);
-  let marcus = await prisma.user.findUnique({ where: { email: "marcus@test.com" } });
-  if (!marcus) {
-    marcus = await prisma.user.create({
-      data: {
-        name: "Marcus",
-        email: "marcus@test.com",
-        password: marcusHash,
-        role: "student",
-        userType: "pathways",
-        ageBand: "launch",
-        birthYear: 2009,
-      },
-    });
-  } else {
-    marcus = await prisma.user.update({
-      where: { id: marcus.id },
-      data: { password: marcusHash, userType: "pathways", ageBand: "launch", birthYear: 2009 },
-    });
-  }
-  console.log("Seeded Marcus:", marcus.email);
-
-  // Aisha — Explorer band, fresh
-  const aishaHash = await bcrypt.hash("aisha123", 10);
-  let aisha = await prisma.user.findUnique({ where: { email: "aisha@test.com" } });
-  if (!aisha) {
-    aisha = await prisma.user.create({
-      data: {
-        name: "Aisha",
-        email: "aisha@test.com",
-        password: aishaHash,
-        role: "student",
-        userType: "pathways",
-        ageBand: "explorer",
-        birthYear: 2011,
-      },
-    });
-  } else {
-    aisha = await prisma.user.update({
-      where: { id: aisha.id },
-      data: { password: aishaHash, userType: "pathways", ageBand: "explorer", birthYear: 2011 },
-    });
-  }
-  console.log("Seeded Aisha:", aisha.email);
-
-  // ── Active cohort: ETO Spring 2026 ──
-  const cohort = await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2026" },
-    create: {
-      name: "ETO Spring 2026 — Cyber Cohort",
-      band: "launch",
-      sitePartner: "Escape The Odds — South Side",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2026",
-      status: "active",
-      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
-      maxEnrollment: 12,
-      startDate: new Date("2026-03-02"),
-      endDate: new Date("2026-04-13"),
-      notes: [
-        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
-        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
-        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
-      ],
-    },
-    update: {
-      facilitatorId: facilitator.id,
-      status: "active",
-      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
-      maxEnrollment: 12,
-      startDate: new Date("2026-03-02"),
-      endDate: new Date("2026-04-13"),
-      sitePartner: "Escape The Odds — South Side",
-      notes: [
-        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
-        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
-        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
-      ],
-    },
-  });
-
-  // Enroll Marcus and Aisha
-  for (const u of [marcus, aisha]) {
-    await prisma.pathwayEnrollment.upsert({
-      where: { userId_cohortId: { userId: u.id, cohortId: cohort.id } },
-      create: { userId: u.id, cohortId: cohort.id },
-      update: {},
-    });
-  }
-
-  // Marcus's Cyber Launch milestones (partial progress).
-  // Section-level fields, homework responses, and time spent are filled in so
-  // Coach Davis's facilitator view shows real-looking work, not empty rows.
-  // upsert update block re-applies these every seed run — important when the
-  // section-progress migration lands on top of existing rows.
-  const MARCUS_HOMEWORK = {
-    "cyber-foundations":
-      "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
-    "digital-safety-sim":
-      "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
-    "network-basics":
-      "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
-  };
-  const marcusMilestones = [
-    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7, timeSpent: 62 },
-    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5, timeSpent: 58 },
-    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3, timeSpent: 65 },
-    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
-  ];
-
-  // Clear any drifted Cyber Launch milestone state before re-seeding the
-  // canonical 4 rows. Without this, live demo usage that touches modules
-  // outside the seed array accumulates rows that the upsert-only loop
-  // never cleans up — Marcus drifted from "3 done + 1 in flight" to
-  // "1 done + 5 in flight" over the past two weeks. (See diagnostic
-  // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
-  await prisma.pathwayMilestone.deleteMany({
-    where: { userId: marcus.id, trackSlug: "cyber-launch" },
-  });
-
-  for (const m of marcusMilestones) {
-    const isDone = m.status === "completed";
-    const isInProgress = m.status === "in_progress";
-    const fullFields = {
-      status: m.status,
-      score: m.score,
-      completedAt: isDone ? new Date(Date.now() - m.daysAgo * 86400000) : null,
-      hookCompleted: isDone || isInProgress,
-      readingCompleted: isDone || isInProgress,
-      lessonCompleted: isDone || isInProgress,
-      practiceCompleted: isDone,
-      homeworkSubmitted: isDone,
-      homeworkResponse: isDone ? MARCUS_HOMEWORK[m.moduleSlug] ?? null : null,
-      quizCompleted: isDone,
-      quizScore: isDone ? m.score : null,
-      timeSpentMinutes: m.timeSpent,
-    };
-    await prisma.pathwayMilestone.create({
-      data: {
-        userId: marcus.id,
-        trackSlug: "cyber-launch",
-        moduleSlug: m.moduleSlug,
-        ...fullFields,
-      },
-    });
-  }
-  console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
-
-  // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
-  const endedCohort = await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2025F" },
-    create: {
-      name: "ETO Fall 2025 — Pilot Cohort",
-      band: "launch",
-      sitePartner: "Escape The Odds — West Side",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2025F",
-      status: "ended",
-      description: "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
-      maxEnrollment: 8,
-      startDate: new Date("2025-10-06"),
-      endDate: new Date("2025-11-17"),
-      notes: [
-        { text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.", author: "Coach Davis", ts: new Date("2025-11-20").toISOString() },
-      ],
-    },
-    update: { facilitatorId: facilitator.id, status: "ended" },
-  });
-
-  // Fictional graduates of the Fall 2025 pilot
-  const graduates = [
-    { name: "Jasmine", email: "grad-jasmine@brightboost.local", scores: [88, 92, 81, 79, 85, 100, 90] },
-    { name: "DeShawn", email: "grad-deshawn@brightboost.local", scores: [82, 95, 87, 84, 91, 100, 95] },
-    { name: "Reina", email: "grad-reina@brightboost.local", scores: [76, 88, 92, 89, 78, 100, 87] },
-  ];
-  const moduleSlugs = ["cyber-foundations", "digital-safety-sim", "network-basics", "threat-detective", "career-map", "cisco-netacad-link", "capstone-security-plan"];
-  const gradHash = await bcrypt.hash("graduate", 10);
-  for (const g of graduates) {
-    let gu = await prisma.user.findUnique({ where: { email: g.email } });
-    if (!gu) {
-      gu = await prisma.user.create({
+    if (!facilitator) {
+      facilitator = await prisma.user.create({
         data: {
-          name: g.name,
-          email: g.email,
-          password: gradHash,
+          name: "Coach Davis",
+          email: "facilitator@test.com",
+          password: facilitatorHash,
+          role: "teacher",
+          userType: "pathways",
+        },
+      });
+    } else {
+      facilitator = await prisma.user.update({
+        where: { id: facilitator.id },
+        data: { password: facilitatorHash, userType: "pathways" },
+      });
+    }
+    console.log("Seeded facilitator:", facilitator.email);
+
+    // Marcus — Launch band, partial progress
+    const marcusHash = await bcrypt.hash("marcus123", 10);
+    let marcus = await prisma.user.findUnique({
+      where: { email: "marcus@test.com" },
+    });
+    if (!marcus) {
+      marcus = await prisma.user.create({
+        data: {
+          name: "Marcus",
+          email: "marcus@test.com",
+          password: marcusHash,
           role: "student",
           userType: "pathways",
           ageBand: "launch",
-          birthYear: 2008,
+          birthYear: 2009,
+        },
+      });
+    } else {
+      marcus = await prisma.user.update({
+        where: { id: marcus.id },
+        data: {
+          password: marcusHash,
+          userType: "pathways",
+          ageBand: "launch",
+          birthYear: 2009,
         },
       });
     }
-    await prisma.pathwayEnrollment.upsert({
-      where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
-      create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
-      update: { status: "completed" },
+    console.log("Seeded Marcus:", marcus.email);
+
+    // Aisha — Explorer band, fresh
+    const aishaHash = await bcrypt.hash("aisha123", 10);
+    let aisha = await prisma.user.findUnique({
+      where: { email: "aisha@test.com" },
     });
-    // Realistic completion milestones (each module completed during the Fall pilot).
-    // Section-level fields filled in so the facilitator outcomes report shows
-    // 6-of-6 sections done per module, not "completed but 0 sections".
-    for (let i = 0; i < moduleSlugs.length; i++) {
-      const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
-      const fullFields = {
+    if (!aisha) {
+      aisha = await prisma.user.create({
+        data: {
+          name: "Aisha",
+          email: "aisha@test.com",
+          password: aishaHash,
+          role: "student",
+          userType: "pathways",
+          ageBand: "explorer",
+          birthYear: 2011,
+        },
+      });
+    } else {
+      aisha = await prisma.user.update({
+        where: { id: aisha.id },
+        data: {
+          password: aishaHash,
+          userType: "pathways",
+          ageBand: "explorer",
+          birthYear: 2011,
+        },
+      });
+    }
+    console.log("Seeded Aisha:", aisha.email);
+
+    // ── Active cohort: ETO Spring 2026 ──
+    const cohort = await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2026" },
+      create: {
+        name: "ETO Spring 2026 — Cyber Cohort",
+        band: "launch",
+        sitePartner: "Escape The Odds — South Side",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2026",
+        status: "active",
+        description:
+          "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+        maxEnrollment: 12,
+        startDate: new Date("2026-03-02"),
+        endDate: new Date("2026-04-13"),
+        notes: [
+          {
+            text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-08").toISOString(),
+          },
+          {
+            text: "Aisha needs more individual time on Network Basics.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-10").toISOString(),
+          },
+          {
+            text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-12").toISOString(),
+          },
+        ],
+      },
+      update: {
+        facilitatorId: facilitator.id,
+        status: "active",
+        description:
+          "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+        maxEnrollment: 12,
+        startDate: new Date("2026-03-02"),
+        endDate: new Date("2026-04-13"),
+        sitePartner: "Escape The Odds — South Side",
+        notes: [
+          {
+            text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-08").toISOString(),
+          },
+          {
+            text: "Aisha needs more individual time on Network Basics.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-10").toISOString(),
+          },
+          {
+            text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-12").toISOString(),
+          },
+        ],
+      },
+    });
+
+    // Enroll Marcus and Aisha
+    for (const u of [marcus, aisha]) {
+      await prisma.pathwayEnrollment.upsert({
+        where: { userId_cohortId: { userId: u.id, cohortId: cohort.id } },
+        create: { userId: u.id, cohortId: cohort.id },
+        update: {},
+      });
+    }
+
+    // Marcus's Cyber Launch milestones (partial progress).
+    // Section-level fields, homework responses, and time spent are filled in so
+    // Coach Davis's facilitator view shows real-looking work, not empty rows.
+    // upsert update block re-applies these every seed run — important when the
+    // section-progress migration lands on top of existing rows.
+    const MARCUS_HOMEWORK = {
+      "cyber-foundations":
+        "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
+      "digital-safety-sim":
+        "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
+      "network-basics":
+        "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
+    };
+    const marcusMilestones = [
+      {
+        moduleSlug: "cyber-foundations",
         status: "completed",
-        score: g.scores[i],
-        completedAt: completedDate,
-        hookCompleted: true,
-        readingCompleted: true,
-        lessonCompleted: true,
-        practiceCompleted: true,
-        homeworkSubmitted: true,
-        homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
-        quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
-        quizScore: moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
-        timeSpentMinutes: 55 + ((i * 7) % 20),
+        score: 85,
+        daysAgo: 7,
+        timeSpent: 62,
+      },
+      {
+        moduleSlug: "digital-safety-sim",
+        status: "completed",
+        score: 90,
+        daysAgo: 5,
+        timeSpent: 58,
+      },
+      {
+        moduleSlug: "network-basics",
+        status: "completed",
+        score: 78,
+        daysAgo: 3,
+        timeSpent: 65,
+      },
+      {
+        moduleSlug: "threat-detective",
+        status: "in_progress",
+        score: null,
+        daysAgo: 1,
+        timeSpent: 28,
+      },
+    ];
+
+    // Clear any drifted Cyber Launch milestone state before re-seeding the
+    // canonical 4 rows. Without this, live demo usage that touches modules
+    // outside the seed array accumulates rows that the upsert-only loop
+    // never cleans up — Marcus drifted from "3 done + 1 in flight" to
+    // "1 done + 5 in flight" over the past two weeks. (See diagnostic
+    // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
+    await prisma.pathwayMilestone.deleteMany({
+      where: { userId: marcus.id, trackSlug: "cyber-launch" },
+    });
+
+    for (const m of marcusMilestones) {
+      const isDone = m.status === "completed";
+      const isInProgress = m.status === "in_progress";
+      const fullFields = {
+        status: m.status,
+        score: m.score,
+        completedAt: isDone
+          ? new Date(Date.now() - m.daysAgo * 86400000)
+          : null,
+        hookCompleted: isDone || isInProgress,
+        readingCompleted: isDone || isInProgress,
+        lessonCompleted: isDone || isInProgress,
+        practiceCompleted: isDone,
+        homeworkSubmitted: isDone,
+        homeworkResponse: isDone
+          ? (MARCUS_HOMEWORK[m.moduleSlug] ?? null)
+          : null,
+        quizCompleted: isDone,
+        quizScore: isDone ? m.score : null,
+        timeSpentMinutes: m.timeSpent,
       };
-      await prisma.pathwayMilestone.upsert({
-        where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
-        create: {
-          userId: gu.id,
+      await prisma.pathwayMilestone.create({
+        data: {
+          userId: marcus.id,
           trackSlug: "cyber-launch",
-          moduleSlug: moduleSlugs[i],
+          moduleSlug: m.moduleSlug,
           ...fullFields,
         },
-        update: fullFields,
       });
     }
-  }
+    console.log(
+      "Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)",
+    );
 
-  // ── Draft cohort: ETO Summer 2026 — Planning ──
-  await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2026S" },
-    create: {
-      name: "ETO Summer 2026 — Planning",
-      band: "mixed",
-      sitePartner: "Escape The Odds — TBD",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2026S",
-      status: "draft",
-      description: "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
-      maxEnrollment: 16,
-      startDate: new Date("2026-06-15"),
-      endDate: new Date("2026-07-27"),
-      notes: [],
-    },
-    update: { facilitatorId: facilitator.id, status: "draft" },
-  });
-
-  console.log("Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.");
-
-  // ─── Onboarding seed for demo accounts ───────────────────────────────────
-  // Marcus and Coach Davis show up to demos as already-onboarded so the
-  // welcome flow doesn't re-trigger every time the DB is re-seeded. Aisha
-  // is intentionally LEFT OUT — she's the "fresh-user" demo and should
-  // walk through the welcome flow when someone hits her account.
-  console.log("Seeding Pathways onboarding for demo accounts...");
-  const onboardingDemoData = [
-    {
-      email: "marcus@test.com",
-      avatarSlug: "analyst",
-      missionStatement:
-        "I want to build a real career in cybersecurity and help my community stay safe online.",
-      dailyGoalLevel: "medium",
-      // Demo intent: every fresh demo should see the toolbox intro fire on
-      // first CTF visit. Live sessions used to leave this `true`, breaking
-      // the demo story on the next showing. (Diagnostic finding L3.)
-      toolboxIntroSeen: false,
-    },
-    {
-      email: "facilitator@test.com",
-      avatarSlug: "guardian",
-      missionStatement:
-        "I want to help my students see themselves in this work and build real pathways forward.",
-      dailyGoalLevel: "heavy",
-      toolboxIntroSeen: false,
-    },
-  ];
-
-  for (const data of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email: data.email } });
-    if (!user) {
-      console.log(`  Skipping ${data.email} — user not found`);
-      continue;
-    }
-    const payload = {
-      avatarChosen: true,
-      avatarSlug: data.avatarSlug,
-      skillsTourViewed: true,
-      skillsTourSkipped: false,
-      missionStatement: data.missionStatement,
-      dailyGoalLevel: data.dailyGoalLevel,
-      toolboxIntroSeen: data.toolboxIntroSeen,
-      completedAt: new Date(),
-    };
-    await prisma.pathwayOnboarding.upsert({
-      where: { userId: user.id },
-      update: payload,
-      create: { userId: user.id, ...payload },
-    });
-    console.log(`  Seeded onboarding for ${data.email}: ${data.avatarSlug}`);
-  }
-
-  // Award the Getting Started badge so those accounts reflect the
-  // completed-onboarding state in their badge collection. XP for the
-  // badge will be picked up by the gamification backfill (which runs
-  // after this seed in predeploy.sh).
-  for (const { email } of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) continue;
-    await prisma.pathwayBadge.upsert({
-      where: { userId_slug: { userId: user.id, slug: "getting_started" } },
-      update: {},
+    // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
+    const endedCohort = await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2025F" },
       create: {
-        userId: user.id,
-        slug: "getting_started",
-        metadata: { backfilled: true, source: "seed" },
+        name: "ETO Fall 2025 — Pilot Cohort",
+        band: "launch",
+        sitePartner: "Escape The Odds — West Side",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2025F",
+        status: "ended",
+        description:
+          "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
+        maxEnrollment: 8,
+        startDate: new Date("2025-10-06"),
+        endDate: new Date("2025-11-17"),
+        notes: [
+          {
+            text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.",
+            author: "Coach Davis",
+            ts: new Date("2025-11-20").toISOString(),
+          },
+        ],
       },
+      update: { facilitatorId: facilitator.id, status: "ended" },
     });
-  }
-  console.log("  Awarded Getting Started badge to demo accounts");
 
-  // ─── Daily goals for today (demo accounts) ──────────────────────────────
-  // Without a row for "today", the home page goal card briefly renders an
-  // empty/skeleton state until the lazy server-side creation fires. Pre-
-  // seeding here means demos always open to a fully-rendered goal card.
-  // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
-  // should hit the lazy creation path so we can show that flow.
-  //
-  // NOTE: this mirrors getDailyGoalTargets() in
-  // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
-  // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
-  // off them at runtime to credit progress.
-  function getDailyGoalTargets(level) {
-    const effective = level || "medium";
-    if (effective === "light") {
+    // Fictional graduates of the Fall 2025 pilot
+    const graduates = [
+      {
+        name: "Jasmine",
+        email: "grad-jasmine@brightboost.local",
+        scores: [88, 92, 81, 79, 85, 100, 90],
+      },
+      {
+        name: "DeShawn",
+        email: "grad-deshawn@brightboost.local",
+        scores: [82, 95, 87, 84, 91, 100, 95],
+      },
+      {
+        name: "Reina",
+        email: "grad-reina@brightboost.local",
+        scores: [76, 88, 92, 89, 78, 100, 87],
+      },
+    ];
+    const moduleSlugs = [
+      "cyber-foundations",
+      "digital-safety-sim",
+      "network-basics",
+      "threat-detective",
+      "career-map",
+      "cisco-netacad-link",
+      "capstone-security-plan",
+    ];
+    const gradHash = await bcrypt.hash("graduate", 10);
+    for (const g of graduates) {
+      let gu = await prisma.user.findUnique({ where: { email: g.email } });
+      if (!gu) {
+        gu = await prisma.user.create({
+          data: {
+            name: g.name,
+            email: g.email,
+            password: gradHash,
+            role: "student",
+            userType: "pathways",
+            ageBand: "launch",
+            birthYear: 2008,
+          },
+        });
+      }
+      await prisma.pathwayEnrollment.upsert({
+        where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
+        create: {
+          userId: gu.id,
+          cohortId: endedCohort.id,
+          status: "completed",
+        },
+        update: { status: "completed" },
+      });
+      // Realistic completion milestones (each module completed during the Fall pilot).
+      // Section-level fields filled in so the facilitator outcomes report shows
+      // 6-of-6 sections done per module, not "completed but 0 sections".
+      for (let i = 0; i < moduleSlugs.length; i++) {
+        const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+        const fullFields = {
+          status: "completed",
+          score: g.scores[i],
+          completedAt: completedDate,
+          hookCompleted: true,
+          readingCompleted: true,
+          lessonCompleted: true,
+          practiceCompleted: true,
+          homeworkSubmitted: true,
+          homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
+          quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
+          quizScore:
+            moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
+          timeSpentMinutes: 55 + ((i * 7) % 20),
+        };
+        await prisma.pathwayMilestone.upsert({
+          where: {
+            userId_trackSlug_moduleSlug: {
+              userId: gu.id,
+              trackSlug: "cyber-launch",
+              moduleSlug: moduleSlugs[i],
+            },
+          },
+          create: {
+            userId: gu.id,
+            trackSlug: "cyber-launch",
+            moduleSlug: moduleSlugs[i],
+            ...fullFields,
+          },
+          update: fullFields,
+        });
+      }
+    }
+
+    // ── Draft cohort: ETO Summer 2026 — Planning ──
+    await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2026S" },
+      create: {
+        name: "ETO Summer 2026 — Planning",
+        band: "mixed",
+        sitePartner: "Escape The Odds — TBD",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2026S",
+        status: "draft",
+        description:
+          "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
+        maxEnrollment: 16,
+        startDate: new Date("2026-06-15"),
+        endDate: new Date("2026-07-27"),
+        notes: [],
+      },
+      update: { facilitatorId: facilitator.id, status: "draft" },
+    });
+
+    console.log(
+      "Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.",
+    );
+
+    // ─── Onboarding seed for demo accounts ───────────────────────────────────
+    // Marcus and Coach Davis show up to demos as already-onboarded so the
+    // welcome flow doesn't re-trigger every time the DB is re-seeded. Aisha
+    // is intentionally LEFT OUT — she's the "fresh-user" demo and should
+    // walk through the welcome flow when someone hits her account.
+    console.log("Seeding Pathways onboarding for demo accounts...");
+    const onboardingDemoData = [
+      {
+        email: "marcus@test.com",
+        avatarSlug: "analyst",
+        missionStatement:
+          "I want to build a real career in cybersecurity and help my community stay safe online.",
+        dailyGoalLevel: "medium",
+        // Demo intent: every fresh demo should see the toolbox intro fire on
+        // first CTF visit. Live sessions used to leave this `true`, breaking
+        // the demo story on the next showing. (Diagnostic finding L3.)
+        toolboxIntroSeen: false,
+      },
+      {
+        email: "facilitator@test.com",
+        avatarSlug: "guardian",
+        missionStatement:
+          "I want to help my students see themselves in this work and build real pathways forward.",
+        dailyGoalLevel: "heavy",
+        toolboxIntroSeen: false,
+      },
+    ];
+
+    for (const data of onboardingDemoData) {
+      const user = await prisma.user.findUnique({
+        where: { email: data.email },
+      });
+      if (!user) {
+        console.log(`  Skipping ${data.email} — user not found`);
+        continue;
+      }
+      const payload = {
+        avatarChosen: true,
+        avatarSlug: data.avatarSlug,
+        skillsTourViewed: true,
+        skillsTourSkipped: false,
+        missionStatement: data.missionStatement,
+        dailyGoalLevel: data.dailyGoalLevel,
+        toolboxIntroSeen: data.toolboxIntroSeen,
+        completedAt: new Date(),
+      };
+      await prisma.pathwayOnboarding.upsert({
+        where: { userId: user.id },
+        update: payload,
+        create: { userId: user.id, ...payload },
+      });
+      console.log(`  Seeded onboarding for ${data.email}: ${data.avatarSlug}`);
+    }
+
+    // Award the Getting Started badge so those accounts reflect the
+    // completed-onboarding state in their badge collection. XP for the
+    // badge will be picked up by the gamification backfill (which runs
+    // after this seed in predeploy.sh).
+    for (const { email } of onboardingDemoData) {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) continue;
+      await prisma.pathwayBadge.upsert({
+        where: { userId_slug: { userId: user.id, slug: "getting_started" } },
+        update: {},
+        create: {
+          userId: user.id,
+          slug: "getting_started",
+          metadata: { backfilled: true, source: "seed" },
+        },
+      });
+    }
+    console.log("  Awarded Getting Started badge to demo accounts");
+
+    // ─── Daily goals for today (demo accounts) ──────────────────────────────
+    // Without a row for "today", the home page goal card briefly renders an
+    // empty/skeleton state until the lazy server-side creation fires. Pre-
+    // seeding here means demos always open to a fully-rendered goal card.
+    // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
+    // should hit the lazy creation path so we can show that flow.
+    //
+    // NOTE: this mirrors getDailyGoalTargets() in
+    // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
+    // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
+    // off them at runtime to credit progress.
+    function getDailyGoalTargets(level) {
+      const effective = level || "medium";
+      if (effective === "light") {
+        return [
+          { slug: "complete_section", label: "Complete 1 section", target: 1 },
+          { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+        ];
+      }
+      if (effective === "heavy") {
+        return [
+          { slug: "complete_section", label: "Complete 2 sections", target: 2 },
+          { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
+          {
+            slug: "try_lab_or_quiz",
+            label: "Try 1 lab or challenge",
+            target: 1,
+          },
+        ];
+      }
       return [
         { slug: "complete_section", label: "Complete 1 section", target: 1 },
-        { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+        { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
+        { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
       ];
     }
-    if (effective === "heavy") {
-      return [
-        { slug: "complete_section", label: "Complete 2 sections", target: 2 },
-        { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
-        { slug: "try_lab_or_quiz", label: "Try 1 lab or challenge", target: 1 },
-      ];
+
+    const todayUtc = new Date();
+    todayUtc.setUTCHours(0, 0, 0, 0);
+
+    for (const data of onboardingDemoData) {
+      const user = await prisma.user.findUnique({
+        where: { email: data.email },
+      });
+      if (!user) continue;
+      const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
+        ...t,
+        current: 0,
+        completed: false,
+      }));
+      await prisma.pathwayDailyGoal.upsert({
+        where: { userId_date: { userId: user.id, date: todayUtc } },
+        // Don't clobber progress someone already accrued today; just ensure
+        // a row exists with the right shape.
+        update: {},
+        create: {
+          userId: user.id,
+          date: todayUtc,
+          goals,
+          allComplete: false,
+          bonusAwarded: false,
+        },
+      });
     }
-    return [
-      { slug: "complete_section", label: "Complete 1 section", target: 1 },
-      { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
-      { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
-    ];
-  }
-
-  const todayUtc = new Date();
-  todayUtc.setUTCHours(0, 0, 0, 0);
-
-  for (const data of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email: data.email } });
-    if (!user) continue;
-    const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
-      ...t,
-      current: 0,
-      completed: false,
-    }));
-    await prisma.pathwayDailyGoal.upsert({
-      where: { userId_date: { userId: user.id, date: todayUtc } },
-      // Don't clobber progress someone already accrued today; just ensure
-      // a row exists with the right shape.
-      update: {},
-      create: {
-        userId: user.id,
-        date: todayUtc,
-        goals,
-        allComplete: false,
-        bonusAwarded: false,
-      },
-    });
-  }
-  console.log("  Seeded daily goals for demo accounts (today, by goal level)");
+    console.log(
+      "  Seeded daily goals for demo accounts (today, by goal level)",
+    );
   } catch (e) {
-    console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Pathways seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1968,8 +3948,9 @@ async function main() {
   console.log("Seeding A/B experiments...");
   try {
     const creator =
-      (await prisma.user.findUnique({ where: { email: "facilitator@test.com" } })) ||
-      (await prisma.user.findFirst({ where: { role: "teacher" } }));
+      (await prisma.user.findUnique({
+        where: { email: "facilitator@test.com" },
+      })) || (await prisma.user.findFirst({ where: { role: "teacher" } }));
 
     if (creator) {
       await prisma.experiment.upsert({
@@ -1991,7 +3972,10 @@ async function main() {
       console.warn("No teacher user found — skipping experiment seed.");
     }
   } catch (e) {
-    console.warn("Experiment seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Experiment seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 }
 

--- a/backend/src/routes/creations.test.ts
+++ b/backend/src/routes/creations.test.ts
@@ -211,6 +211,72 @@ describe("Creations routes", () => {
       expect(res.status).toBe(422);
       expect(prismaMock.creation.create).not.toHaveBeenCalled();
     });
+
+    // ── race_track (Set 3 · Boost Track Builder) ──
+
+    it("lets an enrolled kid save a rideable race_track (201)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+      prismaMock.creation.create.mockResolvedValue({
+        ...dbCreation,
+        type: "race_track",
+        title: "Turbo Loop",
+        content: validRaceTrack,
+      });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "race_track",
+          content: validRaceTrack,
+        });
+
+      expect(res.status).toBe(201);
+      expect(prismaMock.creation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ title: "Turbo Loop" }),
+        }),
+      );
+    });
+
+    it("rejects race_track content with unknown keys (422 — strict parse, #668 closed)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "race_track",
+          content: { ...validRaceTrack, smuggled: "extra key" },
+        });
+
+      expect(res.status).toBe(422);
+      expect(prismaMock.creation.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a race_track that is not rideable start→finish (422)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "race_track",
+          content: {
+            ...validRaceTrack,
+            pieces: [
+              { x: 1, y: 3, type: "start", rot: 0 },
+              { x: 6, y: 6, type: "finish", rot: 0 },
+            ],
+          },
+        });
+
+      expect(res.status).toBe(422);
+      expect(prismaMock.creation.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("PATCH /api/creations/:id", () => {
@@ -336,6 +402,31 @@ describe("Creations routes", () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveLength(1);
+    });
+
+    it("ships content ONLY for race_track items (thumbnail payload)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+      prismaMock.creation.findMany.mockResolvedValue([
+        dbCreation,
+        {
+          ...dbCreation,
+          id: "creation-2",
+          type: "race_track",
+          title: "Turbo Loop",
+          content: { ...validRaceTrack, internalNote: "never expose" },
+        },
+      ]);
+
+      const res = await request(app)
+        .get(`/api/creations?courseId=${COURSE}`)
+        .set(asStudent(KID));
+
+      expect(res.status).toBe(200);
+      const dash = res.body.find((c: { id: string }) => c.id === "creation-1");
+      const track = res.body.find((c: { id: string }) => c.id === "creation-2");
+      expect(dash.content).toBeUndefined(); // other types stay lean
+      expect(track.content).toEqual(validRaceTrack); // card can draw the thumbnail
+      expect(track.content).not.toHaveProperty("internalNote");
     });
 
     it("forbids a non-member (403)", async () => {

--- a/backend/src/routes/creations.ts
+++ b/backend/src/routes/creations.ts
@@ -23,6 +23,7 @@ import { serializeCreationContent } from "../services/creationContentSerializer"
 //     identity is exposed as a first name only — never email.
 
 const router = Router();
+const GALLERY_CONTENT_TYPES = new Set(["race_track"]);
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -292,7 +293,18 @@ router.get("/creations", requireAuth, async (req: Request, res: Response) => {
     orderBy: { updatedAt: "desc" },
   });
 
-  return res.json(creations.map(toDTO));
+  // Thumbnail-bearing creation types need their small layout payload in the
+  // gallery. Project it through the same type-aware read boundary as the
+  // single-creation endpoint so manually inserted fields never leak.
+  return res.json(
+    creations.map((creation) => {
+      const dto = toDTO(creation);
+      if (!GALLERY_CONTENT_TYPES.has(creation.type)) return dto;
+
+      const content = serializeCreationContent(creation.type, creation.content);
+      return content === null ? dto : { ...dto, content };
+    }),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/creationContent.ts
+++ b/backend/src/services/creationContent.ts
@@ -12,15 +12,16 @@
 // correct answer) — see the marked extension point below.
 
 import { validateDataDashChallenge } from "./dataDashChallenge";
+import { deriveRaceTrackTitle, validateRaceTrack } from "./raceTrack";
 
-export const CREATION_TYPES = ["data_dash_challenge"] as const;
+export const CREATION_TYPES = ["data_dash_challenge", "race_track"] as const;
 export type CreationType = (typeof CREATION_TYPES)[number];
 
 const dataDashSortRuleLabels: Record<string, string> = {
   sunlightNeed: "Sunlight need",
   waterNeed: "Water need",
   leafType: "Leaf type",
-}
+};
 
 export function isCreationType(value: unknown): value is CreationType {
   return (
@@ -29,14 +30,10 @@ export function isCreationType(value: unknown): value is CreationType {
   );
 }
 
-export type ContentValidation =
-  | { ok: true }
-  | { ok: false; error: string };
+export type ContentValidation = { ok: true } | { ok: false; error: string };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && !Array.isArray(value)
-  );
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -60,6 +57,11 @@ export function validateCreationContent(
       // moderate — only to verify the challenge is actually winnable.
       return validateDataDashChallenge(content);
 
+    case "race_track":
+      // Strict-parsed (zod .strict() at every level — unknown keys rejected)
+      // plus a start→finish rideability guard so every shared track is playable.
+      return validateRaceTrack(content);
+
     default:
       // Exhaustiveness guard — a new CreationType must declare its rules here.
       return { ok: false, error: `unsupported creation type: ${type}` };
@@ -72,18 +74,22 @@ export function deriveCreationTitle(
 ): string | null {
   if (!isPlainObject(content)) return null;
 
-  switch(type) {
+  switch (type) {
     case "data_dash_challenge": {
       const challenge = content as {
         sortRule?: string;
       };
 
-      const label = dataDashSortRuleLabels[challenge.sortRule ?? ""]
-      
+      const label = dataDashSortRuleLabels[challenge.sortRule ?? ""];
+
       return label ? `Sort by ${label}` : null;
     }
 
-    default: 
+    case "race_track":
+      // The kid's chosen name from the structured name-kit (schema-bounded).
+      return deriveRaceTrackTitle(content);
+
+    default:
       return null;
   }
 }

--- a/backend/src/services/raceTrack.test.ts
+++ b/backend/src/services/raceTrack.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import { deriveRaceTrackTitle, validateRaceTrack } from "./raceTrack";
+
+const valid = () => ({
+  v: 1,
+  name: "Super Loop",
+  grid: { w: 8, h: 8 },
+  pieces: [
+    { x: 1, y: 3, type: "start", rot: 0 },
+    { x: 2, y: 3, type: "straight", rot: 0 },
+    { x: 3, y: 3, type: "finish", rot: 0 },
+  ],
+});
+
+const seededStarSprint = {
+  v: 1,
+  name: "Star Sprint",
+  grid: { w: 6, h: 6 },
+  pieces: [
+    { x: 0, y: 1, type: "start", rot: 0 },
+    { x: 1, y: 1, type: "straight", rot: 0 },
+    { x: 2, y: 1, type: "gentleCurve", rot: 180 },
+    { x: 2, y: 2, type: "straight", rot: 90 },
+    { x: 2, y: 3, type: "gentleCurve", rot: 0 },
+    { x: 3, y: 3, type: "boost", rot: 0 },
+    { x: 4, y: 3, type: "finish", rot: 0 },
+  ],
+};
+
+describe("validateRaceTrack — schema", () => {
+  it("accepts a minimal rideable track", () => {
+    expect(validateRaceTrack(valid())).toEqual({ ok: true });
+  });
+
+  it("accepts the deterministic STARS1 gallery fixture", () => {
+    expect(validateRaceTrack(seededStarSprint)).toEqual({ ok: true });
+  });
+
+  it("rejects non-object content", () => {
+    expect(validateRaceTrack("nope").ok).toBe(false);
+    expect(validateRaceTrack(null).ok).toBe(false);
+    expect(validateRaceTrack([valid()]).ok).toBe(false);
+  });
+
+  it("rejects an unsupported version", () => {
+    expect(validateRaceTrack({ ...valid(), v: 2 }).ok).toBe(false);
+  });
+
+  it("rejects a missing or empty name", () => {
+    const { name: _name, ...noName } = valid();
+    expect(validateRaceTrack(noName).ok).toBe(false);
+    expect(validateRaceTrack({ ...valid(), name: "" }).ok).toBe(false);
+  });
+
+  it("rejects a name over 24 chars", () => {
+    expect(validateRaceTrack({ ...valid(), name: "x".repeat(25) }).ok).toBe(
+      false,
+    );
+  });
+
+  it("rejects grid sizes outside 4..12", () => {
+    expect(validateRaceTrack({ ...valid(), grid: { w: 3, h: 8 } }).ok).toBe(
+      false,
+    );
+    expect(validateRaceTrack({ ...valid(), grid: { w: 8, h: 13 } }).ok).toBe(
+      false,
+    );
+  });
+
+  it("rejects too few pieces", () => {
+    expect(
+      validateRaceTrack({
+        ...valid(),
+        pieces: [{ x: 1, y: 3, type: "start", rot: 0 }],
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown piece type and bad rotation", () => {
+    const t = valid();
+    t.pieces[1] = { ...t.pieces[1], type: "rocket" as never };
+    expect(validateRaceTrack(t).ok).toBe(false);
+    const r = valid();
+    r.pieces[1] = { ...r.pieces[1], rot: 45 as never };
+    expect(validateRaceTrack(r).ok).toBe(false);
+  });
+
+  // ── Closed-content boundary: unknown keys are REJECTED ──
+
+  it("STRICT: rejects unknown keys at the root level", () => {
+    const r = validateRaceTrack({ ...valid(), evilExtra: "smuggled" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("evilExtra");
+  });
+
+  it("STRICT: rejects unknown keys inside grid", () => {
+    expect(
+      validateRaceTrack({ ...valid(), grid: { w: 8, h: 8, depth: 2 } }).ok,
+    ).toBe(false);
+  });
+
+  it("STRICT: rejects unknown keys inside a piece", () => {
+    const t = valid();
+    t.pieces[1] = { ...t.pieces[1], freeText: "hi class!" } as never;
+    expect(validateRaceTrack(t).ok).toBe(false);
+  });
+});
+
+describe("validateRaceTrack — rideability guard", () => {
+  it("rejects a piece outside the declared grid", () => {
+    const t = valid();
+    t.grid = { w: 4, h: 4 };
+    t.pieces.push({ x: 6, y: 6, type: "straight", rot: 0 });
+    expect(validateRaceTrack(t).ok).toBe(false);
+  });
+
+  it("rejects two pieces on the same cell", () => {
+    const t = valid();
+    t.pieces.push({ x: 2, y: 3, type: "straight", rot: 0 });
+    expect(validateRaceTrack(t).ok).toBe(false);
+  });
+
+  it("rejects a track with no start / multiple starts", () => {
+    const noStart = valid();
+    noStart.pieces[0] = { ...noStart.pieces[0], type: "straight" };
+    expect(validateRaceTrack(noStart).ok).toBe(false);
+
+    const twoStarts = valid();
+    twoStarts.pieces.push({ x: 5, y: 5, type: "start", rot: 0 });
+    expect(validateRaceTrack(twoStarts).ok).toBe(false);
+  });
+
+  it("rejects a track with no finish", () => {
+    const t = valid();
+    t.pieces[2] = { ...t.pieces[2], type: "straight" };
+    expect(validateRaceTrack(t).ok).toBe(false);
+  });
+
+  it("rejects a dangling road (start's road never reaches the finish)", () => {
+    const t = valid();
+    // Move the finish away from the road so the walk falls off the end.
+    t.pieces[2] = { x: 6, y: 6, type: "finish", rot: 0 };
+    const r = validateRaceTrack(t);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("not rideable");
+  });
+
+  it("rejects pieces that touch but do not connect (wrong-way join)", () => {
+    const t = valid();
+    // A N–S straight cannot accept an entry from the west.
+    t.pieces[1] = { ...t.pieces[1], rot: 90 };
+    expect(validateRaceTrack(t).ok).toBe(false);
+  });
+
+  it("accepts a track that rides through curves and a boost", () => {
+    const t = {
+      v: 1,
+      name: "Curvy Rally",
+      grid: { w: 8, h: 8 },
+      pieces: [
+        { x: 1, y: 2, type: "start", rot: 0 },
+        { x: 2, y: 2, type: "boost", rot: 0 },
+        { x: 3, y: 2, type: "gentleCurve", rot: 180 }, // W↔S: enter W, exit S
+        { x: 3, y: 3, type: "sharpCurve", rot: 0 }, // N↔E: enter N, exit E
+        { x: 4, y: 3, type: "finish", rot: 0 },
+      ],
+    };
+    expect(validateRaceTrack(t)).toEqual({ ok: true });
+  });
+
+  it("allows decoration pieces off the ridden path", () => {
+    // A disconnected extra piece doesn't break the start→finish ride.
+    const t = valid();
+    t.pieces.push({ x: 6, y: 6, type: "straight", rot: 0 });
+    expect(validateRaceTrack(t)).toEqual({ ok: true });
+  });
+});
+
+describe("deriveRaceTrackTitle", () => {
+  it("returns the kid's chosen name, trimmed", () => {
+    expect(deriveRaceTrackTitle({ ...valid(), name: "  Zippy Trail " })).toBe(
+      "Zippy Trail",
+    );
+  });
+
+  it("returns null for missing/blank/non-string names", () => {
+    expect(deriveRaceTrackTitle({})).toBeNull();
+    expect(deriveRaceTrackTitle({ name: "   " })).toBeNull();
+    expect(deriveRaceTrackTitle({ name: 7 })).toBeNull();
+    expect(deriveRaceTrackTitle(null)).toBeNull();
+  });
+});

--- a/backend/src/services/raceTrack.ts
+++ b/backend/src/services/raceTrack.ts
@@ -1,0 +1,205 @@
+/**
+ * race_track content validator — the security boundary for Boost Track
+ * Builder creations (Set 3 · game 1).
+ *
+ * STRICT-PARSED FROM DAY ONE: every object level uses zod `.strict()`, so
+ * unknown/extra JSON keys are REJECTED, not stored. Data Dash now enforces
+ * the same closed-content boundary; new creation types must preserve it.
+ *
+ * Frontend mirror (instant author-time feedback): keep the schema and the
+ * rideability rules in sync with `src/components/games/trackMakerModel.ts`,
+ * the same way Data Dash mirrors its card pool across the boundary.
+ */
+import { z } from "zod";
+import type { ContentValidation } from "./creationContent";
+
+export const RACE_TRACK_PIECE_TYPES = [
+  "start",
+  "straight",
+  "gentleCurve",
+  "sharpCurve",
+  "boost",
+  "finish",
+] as const;
+type PieceType = (typeof RACE_TRACK_PIECE_TYPES)[number];
+
+const GRID_MIN = 4;
+const GRID_MAX = 12;
+const PIECES_MIN = 2;
+const PIECES_MAX = 64;
+const NAME_MAX = 24;
+
+const pieceSchema = z
+  .object({
+    x: z
+      .number()
+      .int()
+      .min(0)
+      .max(GRID_MAX - 1),
+    y: z
+      .number()
+      .int()
+      .min(0)
+      .max(GRID_MAX - 1),
+    type: z.enum(RACE_TRACK_PIECE_TYPES),
+    rot: z.union([z.literal(0), z.literal(90), z.literal(180), z.literal(270)]),
+  })
+  .strict();
+
+const raceTrackSchema = z
+  .object({
+    v: z.literal(1),
+    name: z.string().min(1).max(NAME_MAX),
+    grid: z
+      .object({
+        w: z.number().int().min(GRID_MIN).max(GRID_MAX),
+        h: z.number().int().min(GRID_MIN).max(GRID_MAX),
+      })
+      .strict(),
+    pieces: z.array(pieceSchema).min(PIECES_MIN).max(PIECES_MAX),
+  })
+  .strict();
+
+type RaceTrack = z.infer<typeof raceTrackSchema>;
+type Piece = RaceTrack["pieces"][number];
+
+// ── Connectivity (must match the frontend model) ───────────────────────────
+
+type Dir = "N" | "E" | "S" | "W";
+const DIRS: Dir[] = ["N", "E", "S", "W"];
+const DELTA: Record<Dir, [number, number]> = {
+  N: [0, -1],
+  E: [1, 0],
+  S: [0, 1],
+  W: [-1, 0],
+};
+const OPPOSITE: Record<Dir, Dir> = { N: "S", E: "W", S: "N", W: "E" };
+
+function rotateDir(d: Dir, rot: number): Dir {
+  return DIRS[(DIRS.indexOf(d) + rot / 90) % 4];
+}
+
+function pieceConnections(piece: Piece): Dir[] {
+  switch (piece.type as PieceType) {
+    case "straight":
+    case "boost":
+      return piece.rot % 180 === 0 ? ["W", "E"] : ["N", "S"];
+    case "gentleCurve":
+    case "sharpCurve":
+      return [rotateDir("N", piece.rot), rotateDir("E", piece.rot)];
+    case "start":
+      return [rotateDir("E", piece.rot)];
+    case "finish":
+      return ["N", "E", "S", "W"];
+  }
+}
+
+/**
+ * Rideability guard: the walk from the start's exit must reach a finish.
+ * A track that passes this can always be ridden by a classmate — the same
+ * "peers can never open a broken creation" guarantee Data Dash's
+ * solvability guard provides.
+ */
+function isRideable(
+  track: RaceTrack,
+): { ok: true } | { ok: false; error: string } {
+  const byCell = new Map<string, Piece>();
+  for (const p of track.pieces) byCell.set(`${p.x},${p.y}`, p);
+
+  const start = track.pieces.find((p) => p.type === "start") as Piece;
+  const visited = new Set<string>([`${start.x},${start.y}`]);
+  let cur = start;
+  let dir = pieceConnections(start)[0];
+
+  for (let step = 0; step <= track.pieces.length; step++) {
+    const [dx, dy] = DELTA[dir];
+    const nx = cur.x + dx;
+    const ny = cur.y + dy;
+    if (nx < 0 || ny < 0 || nx >= track.grid.w || ny >= track.grid.h) {
+      return {
+        ok: false,
+        error: "track is not rideable: the road leaves the grid",
+      };
+    }
+    const next = byCell.get(`${nx},${ny}`);
+    if (!next) {
+      return {
+        ok: false,
+        error: "track is not rideable: the road ends before a finish",
+      };
+    }
+    if (next.type === "finish") return { ok: true };
+    const entry = OPPOSITE[dir];
+    const conns = pieceConnections(next);
+    if (next.type === "start" || !conns.includes(entry)) {
+      return {
+        ok: false,
+        error: "track is not rideable: pieces do not connect",
+      };
+    }
+    if (visited.has(`${nx},${ny}`)) {
+      return {
+        ok: false,
+        error: "track is not rideable: the road loops without a finish",
+      };
+    }
+    visited.add(`${nx},${ny}`);
+    const exit = conns.find((c) => c !== entry);
+    if (!exit) {
+      return {
+        ok: false,
+        error: "track is not rideable: pieces do not connect",
+      };
+    }
+    cur = next;
+    dir = exit;
+  }
+  return {
+    ok: false,
+    error: "track is not rideable: the road loops without a finish",
+  };
+}
+
+// ── The validator ───────────────────────────────────────────────────────────
+
+export function validateRaceTrack(content: unknown): ContentValidation {
+  const parsed = raceTrackSchema.safeParse(content);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue.path.join(".") || "content";
+    return { ok: false, error: `${path}: ${issue.message}` };
+  }
+  const track = parsed.data;
+
+  const seen = new Set<string>();
+  for (const p of track.pieces) {
+    if (p.x >= track.grid.w || p.y >= track.grid.h) {
+      return { ok: false, error: "piece outside the grid" };
+    }
+    const key = `${p.x},${p.y}`;
+    if (seen.has(key)) {
+      return { ok: false, error: "two pieces on the same cell" };
+    }
+    seen.add(key);
+  }
+
+  const starts = track.pieces.filter((p) => p.type === "start").length;
+  if (starts === 0) return { ok: false, error: "track needs a start" };
+  if (starts > 1) return { ok: false, error: "track can only have one start" };
+  if (!track.pieces.some((p) => p.type === "finish")) {
+    return { ok: false, error: "track needs a finish flag" };
+  }
+
+  const rideable = isRideable(track);
+  if (!rideable.ok) return rideable;
+
+  return { ok: true };
+}
+
+/** Server-authoritative title for a race_track creation: the kid's chosen
+ *  name from the structured name-kit (already length-bounded by the schema). */
+export function deriveRaceTrackTitle(content: unknown): string | null {
+  if (typeof content !== "object" || content === null) return null;
+  const name = (content as { name?: unknown }).name;
+  return typeof name === "string" && name.trim() ? name.trim() : null;
+}

--- a/docs/games/set3-track-maker-design.md
+++ b/docs/games/set3-track-maker-design.md
@@ -1,0 +1,240 @@
+# Set 3 · Game 1 — Track Maker & Rider (design doc)
+
+> Status: **design — pending approval.** No game code is written yet.
+> Lands against #676 (Set 3 "Mastery": creation-first set). Bar: `docs/design-principles.md`.
+> Audience: K–2 primary (K–8 aware). Persists the kid's track as a `Creation` (`type: "race_track"`).
+
+Set 3's identity is **mastery through making**: in Sets 1–2 kids _played_ our games; in Set 3 they
+_make the thing_. This is Set 3's first game — a build-your-own motorcycle track that the child then
+rides. The arcade _feel_ we're after is leaning a bike into curves and reading speed against the road.
+That feel is the only inspiration: **no third-party name, logo, art, music, or likeness appears anywhere**
+in this game — the concept, code, and copy are original.
+
+---
+
+## 1. Concept (one paragraph)
+
+A child lays out a motorcycle track from a small palette of road pieces — straights, gentle curves,
+sharp curves, boost pads, and a finish flag — then rides it. The bike drives itself; the only challenge
+comes from **the track the child designed**: take a sharp curve too fast and the bike wobbles and
+spins out — not a loss, but information about their own design. They edit, re-ride, name their track,
+and share it to the group gallery, where classmates ride it too. The loop is _predict → build → ride →
+see what your design does → tweak → share_.
+
+---
+
+## 2. Spiral mapping (every stage → a concrete UI moment)
+
+Per `docs/design-principles.md §1`, the activity must move through **Imagine → Create → Play → Share →
+Reflect** and loop back. Concrete moments:
+
+| Stage       | Concrete UI moment                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Imagine** | Opening card, icon-first, one line: _"What kind of track will you build — loopy, zoomy, twisty?"_ A single "Start building" button. No blank void: a **starter segment** (start marker + one straight + finish flag) is already on the grid.                                                                                                                                                                                                |
+| **Create**  | Tap-to-place build grid. Palette (below) as large icon buttons; tap a piece, tap a cell to drop it; tap a placed piece to rotate, long-press/✕ to remove. Current track **name shown in the top bar**. A **"Show me ideas" pattern-book** button opens example shapes to browse and copy.                                                                                                                                                   |
+| **Play**    | Tap **"Ride!"** → the bike auto-advances along the path. **One input** (proposed: _press-and-hold to lean/slow through curves; release to speed up on straights_). Physics-lite: each piece has a safe-entry speed; too fast into a sharp curve → **wobble → spin-out → friendly beat**, bike backs up to just before that curve. **No lives, no game-over, no lost progress.** A spin-out is feedback on their design, never a fail state. |
+| **Share**   | Back on the build screen, **"Save"** stores the track in place; **"Share to gallery"** sets status → `SHARED`/`COMPLETE`. The track appears as a card in the existing group gallery (`GroupGallery.tsx`); classmates open it and **ride it** (read-only) via the creation player.                                                                                                                                                           |
+| **Reflect** | After a ride, **one wondering question**, curious never corrective: _"Which part of your track was the trickiest to ride? What would you change?"_ No score verdict, no "you passed." This is a **separate moment from Save/name** (see §4).                                                                                                                                                                                                |
+
+Remixing a peer's track (open theirs → "Make my own version") loops back to **Imagine** — a stretch goal,
+not v1.
+
+**Who rides?** Proposed: **Boost** (the platform's existing robot mascot, already the on-screen character
+in Boost Path Planner) rides the bike — keeps Set 3 visually consistent with the rest of the app. Open
+question in §9.
+
+---
+
+## 3. Low floor, high ceiling, wide walls — the scaffolding (designed deliberately)
+
+`docs/design-principles.md §3` is explicit: _"K–2 is more structured… The floor here is deliberately
+supported — a starter template, a guided first step, a constrained set of choices — never a blank,
+unguided void… Structure early, openness later. Both ends must exist."_ This is the section built to
+that bar. The following are stated as **requirements**, drawn from recent maker-game review lessons:
+
+**3a. Guided K–2 start — a supported floor, not a blank canvas.**
+
+- The grid opens with a **starter segment already placed**: `start → straight → finish`. The child is
+  never staring at nothing; they extend a track that already rides.
+- The palette is **constrained at first**: only `straight`, `gentle curve`, `finish` are available.
+  `sharp curve` and `boost pad` are **locked** until the child has ridden a rideable track at least once.
+
+**3b. Unlocks must announce themselves (scaffolding, not a silent change).**
+
+- When a piece unlocks, it is **announced**: a small celebratory beat — _"You earned the Sharp Curve! Tap
+  to try it."_ — with the new palette button popping in (`bounce-in` from `game-effects.css`). A silently
+  appearing button reads as a bug; an announced one reads as growth. This announce-beat is a hard
+  requirement, not polish.
+
+**3c. A pattern-book / manual of example shapes (low floor via examples, ceiling preserved).**
+
+- A **"Show me ideas"** panel presents a handful of **example track shapes** (e.g. "The Big Loop," "The
+  Zig-Zag," "The Speedway") the child can browse and **build from**. Examples show _possibility_, never
+  dictate a single solution — the assembly is always theirs, so the ceiling stays open. This is the low
+  floor delivered through worked examples rather than through removing choice.
+
+**3d. Soft, escalating per-band targets (suggestions, never requirements).**
+
+- Gentle, opt-in challenges that rise: _"Can you build a track with 2 curves the bike survives?"_ →
+  _"…with a boost pad before a straight?"_ → _"…a track with a loop?"_ Framed as _"try this"_, never
+  gated. Meeting one earns a warm acknowledgement; ignoring it costs nothing.
+
+**Ceiling & wide walls.** The grid, free piece placement, rotation, and (later) a larger `g3_5` grid with
+more pieces give room to grow. Many valid tracks — loopy, long, minimal, tricky — are all "right." No one
+correct track exists.
+
+---
+
+## 4. The save model (specified up front — not improvised)
+
+Naming/saving and reflecting are **different beats**; conflating them confuses kids. Spec:
+
+- **Explicit Save** saves the **current** track _in place_. First save = `POST /creations` (new row);
+  every later save = `PATCH /creations/:id` on the **same row** (the backend PATCH is an in-place UPDATE,
+  author-only). **Rename never forks a new draft** — renaming PATCHes the same row's title/name.
+- **Autosave on navigate-away.** If the child leaves the build screen with unsaved changes, autosave
+  fires (POST if new, PATCH if existing) so **nothing is lost**. A quiet "Saved ✓" beat, no modal.
+- **Current track title is always visible** on the build screen (top bar), so "which track am I editing?"
+  is never ambiguous.
+- **Duplicate-name guard.** If the chosen name matches another of the child's tracks in the same course,
+  **auto-suffix** a number ("Big Loop" → "Big Loop 2") — a non-blocking, K-2-friendly default rather than
+  an error the child has to resolve. (Alternative: a gentle message. Open question §9.)
+- **Naming UX (recommended): a structured name-kit, not free text.** The child taps an adjective chip +
+  a noun chip (e.g. _Super_ + _Loop_ → "Super Loop"), optionally an emoji. This matches the existing
+  creative-loop precedent (authoring uses _structured choices only, no free text_ — see `CreateChallenge.tsx`),
+  and it sidesteps the moderation cost of K-2 kids typing arbitrary text that classmates then see. The
+  chosen name lives in `content.name` and is echoed by the server's `deriveCreationTitle("race_track", …)`
+  so the server stays authoritative over the stored title. Rename = re-pick from the kit. (Free-text-with-filter
+  is possible but carries a moderation cost — open question §9.)
+- **Save/name is a build-screen action; Reflect is a post-ride wondering prompt.** They never share a
+  screen or a button.
+
+---
+
+## 5. The mastery / STEM frame (what a 5–7-year-old actually learns)
+
+By riding their own track, a child discovers **cause and effect** — more speed into a sharp curve makes
+the bike spin out — which pushes them to **plan a sequence and lay out space** deliberately: put a straight
+or a gentle curve before a sharp one so the ride survives. And because a spin-out is safe and re-editable,
+they practice the core engineering habit of **iterate-and-improve**: the track is a hypothesis, the ride is
+the test, the tweak is the revision.
+
+---
+
+## 6. Track validator spec (strict-parsed from day one)
+
+Lives beside the Data Dash validator, in `backend/src/services/` (new `raceTrack.ts`), wired into the
+`validateCreationContent` dispatch in `creationContent.ts`. **Content schema is strict-parsed with zod
+`.strict()` on every object level from day one** — unknown/extra JSON keys are **rejected**, not stored.
+
+> ⚠️ This deliberately **diverges** from the Data Dash validator, which is manual and (per #668) does
+> **not** reject unknown keys — extra keys sail through and persist. The `race_track` validator must cite
+> #668 in a code comment explaining why it uses `.strict()` and does not copy Data Dash's key-tolerance.
+
+Proposed content shape (final field names settled in Phase B):
+
+```jsonc
+{
+  "v": 1,
+  "name": "Super Loop", // 1–24 chars, from the name-kit
+  "grid": { "w": 8, "h": 8 }, // each 4..12 (size bounds)
+  "pieces": [
+    // 2..64 pieces
+    { "x": 0, "y": 3, "type": "start", "rot": 0 },
+    { "x": 1, "y": 3, "type": "straight", "rot": 0 },
+    { "x": 2, "y": 3, "type": "gentleCurve", "rot": 90 },
+    { "x": 2, "y": 4, "type": "finish", "rot": 0 },
+  ],
+}
+```
+
+**Rideability / solvability guard** (analogous to Data Dash's solvability guard, adapted):
+
+- exactly **one `start`** and **≥ 1 `finish`**;
+- every piece **within grid bounds**; **no two pieces on the same cell**;
+- the path is **connected start → finish** — walking each piece's entry/exit by its rotation reaches a
+  finish (a broken/dangling track is rejected with a kid-friendly reason surfaced client-side);
+- **size bounds** respected (min/max piece count, grid 4..12).
+
+The frontend gets a mirror validator (`src/components/games/*Authoring.ts`) for instant author-time
+feedback; the backend validator is the security boundary and re-checks on every save.
+
+---
+
+## 7. Slot, naming, and identifiers
+
+**Slot.** Takes the **`set3-game-1`** placeholder in `STEM_SET_3_IDS` (`src/constants/stemSets.ts`).
+Note a second Set 3 candidate — a **machine-programming game** — is in design by a teammate; it can take
+`set3-game-2`, and slots 3–5 remain open. I only claim slot 1 and leave the rest untouched.
+
+**Identifiers** (following the three-name convention — game key `snake`, activity ID `kebab`, module slug
+`k2-stem-<kebab>`):
+
+| Layer                                | Value                 |
+| ------------------------------------ | --------------------- |
+| Activity ID (replaces `set3-game-1`) | `track-maker`         |
+| Game key (`gameRegistry.ts` + seed)  | `track_maker`         |
+| Module slug (seed)                   | `k2-stem-track-maker` |
+| Creation type (allowlist)            | `race_track`          |
+| Component                            | `TrackMakerGame.tsx`  |
+
+**Original name proposals (you pick one before Phase B):**
+
+1. **Boost Track Builder** — platform-consistent (Boost is the rider), says exactly what it is. _(my lean)_
+2. **Loop & Lean** — evokes the curve-leaning feel; short, alliterative, original.
+3. **Ramp Rider** — punchy, evokes boost pads/ramps and riding; original.
+
+None reference any third-party title. Whichever you choose becomes the UI title; the internal identifiers
+above stay stable regardless.
+
+---
+
+## 8. Principles self-audit (`docs/design-principles.md`)
+
+| Principle                                                      | Verdict                                                                                                                                                                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. Spiral is the spine** (Imagine→Create→Play→Share→Reflect) | ✅ All five stages mapped to concrete moments (§2), with Share via the real gallery and a distinct Reflect beat.                                                                                                           |
+| **2. Creators, not consumers**                                 | ✅ The child _builds_ the track; the entire challenge is their own design. They walk away with something they made and can share.                                                                                          |
+| **3. Low floor, high ceiling, wide walls (banded)**            | ✅ Supported floor: starter segment + constrained palette + pattern-book. Rising ceiling: unlocks, escalating soft targets, larger `g3_5` grid (later). Wide walls: many valid tracks (§3).                                |
+| **4. Playground, not playpen**                                 | ✅ Spin-outs are safe "mischief," re-editable, never a game-over. Voice is curious ("what would you change?"), never corrective.                                                                                           |
+| **5. Measure creation, not completion**                        | ✅ Signals tracked: rides taken, tweaks made, tracks shared (`gameSpecific` telemetry). Stars reward creation depth (rideable track + iterations + soft targets), **not** speed. **No leaderboards, no kid-vs-kid times.** |
+| **6. Adult is a guide, not a proctor**                         | ✅ Adults only _encourage_ (existing "give a boost" counter). No grading of tracks.                                                                                                                                        |
+| **7. Screen use, not screen time**                             | ✅ Active making + iterating, not passive watching.                                                                                                                                                                        |
+| **8. Localizable from day one**                                | ✅ Every string keyed (`t()` + `defaultValue`); EN + ES written in v1; vi/zh-CN English placeholders. Content strings via `pickLocale`.                                                                                    |
+
+**Platform wiring (no invention).** Built on `GameShell` exactly as existing games; completion reports the
+standard five-field `GameResult` (`gameKey`, integer `score`/`total`, `streakMax`, `roundsCompleted`) →
+`completeActivity` → XP/progress, byte-compatible with the existing contract. `score`/`total` measure
+**creation milestones** (built a rideable track, rode it, met soft targets), keeping stars non-competitive.
+Maker detail (rides, tweaks) rides in `gameSpecific` — but note the server currently **strips
+`gameSpecific`** (#672), so v1 does **not** depend on its persistence; the durable artifact is the
+`Creation` row. Set-completion/unlock mirrors the Set 1→Set 2 pattern (new `isSet2Complete`/`isSet3Locked`
+helpers in `stemSets.ts`).
+
+**Hard constraints honored.** Zero new Prisma migrations, zero `schema.prisma` changes — the track is a
+`Creation` (`type: "race_track"`) with layout in the existing `content: Json`. `db-check` stays meaningful
+(green); a red db-check on this PR would signal a real violation and stop the work.
+
+---
+
+## 9. Open questions (for you)
+
+1. **Name** — pick 1 of the 3 in §7 (Boost Track Builder / Loop & Lean / Ramp Rider).
+2. **Rider** — confirm **Boost** rides (platform-consistent), or prefer a generic unnamed bike/rider?
+3. **Play input** — **press-and-hold-to-lean** (my proposal, maps to the leaning feel) vs. simpler
+   **single-tap-to-brake**? Both are one-input and touch+mouse friendly.
+4. **Naming UX** — **structured name-kit** (recommended; no free text, no moderation cost) vs.
+   free-text-with-filter?
+5. **Duplicate name** — **auto-suffix** (recommended) vs. gentle message?
+6. **Peer rides recorded?** — Data Dash treats peer plays as _for fun, not progress_. Recommend the same
+   for track rides (rides don't post progress). OK?
+7. **Grade banding** — ship **K-2 first**, add the `g3_5` (bigger grid/more pieces) overlay in a later pass
+   (mirroring how Rhyme & Ride staged its band)? Or band in v1?
+8. **Visibility** (Phase C decision, flagged early) — when wired, make it student-visible immediately, or
+   gate it until Set 3 has more games / leads sign off?
+
+---
+
+_Build order after approval: Phase B (component + unit-tested rules & strict validator) → Phase C
+(integrate: `stemSets`, registry, seed both trees, `race_track` allowlist + gallery card) → Phase D
+(verify + prove the no-schema constraint) → Phase E (PR against #676). No merge without your go._

--- a/docs/intern-credentials.md
+++ b/docs/intern-credentials.md
@@ -11,32 +11,34 @@ All accounts are seeded in `prisma/seed.cjs` with bcrypt-hashed passwords. The s
 
 ## Teacher Account
 
-| Email | Password | Notes |
-|---|---|---|
+| Email                | Password      | Notes                                                             |
+| -------------------- | ------------- | ----------------------------------------------------------------- |
 | `teacher@school.com` | `password123` | Ms. Frizzle — demo class owner, K-2 class with join code `STARS1` |
 
 ## K-2 Student Accounts
 
-| Email | Password | Notes |
-|---|---|---|
-| `student@test.com` | `password` | Fresh K-2 student, Set 1 incomplete |
-| `explorer@test.com` | `explore123` | Set 1 complete, Set 2 unlocked |
+| Email               | Password     | Notes                               |
+| ------------------- | ------------ | ----------------------------------- |
+| `student@test.com`  | `password`   | Fresh K-2 student, Set 1 incomplete |
+| `explorer@test.com` | `explore123` | Set 1 complete, Set 2 unlocked      |
 
 **Class code (emoji-picker flow):** `STARS1` — enter under "I'm a Student" → "Join with a Code", then pick your emoji to log in without a password. Seeded class **"Ms. Frizzle's Star Class"** (band k2) with three emoji students, no PIN: **Nova ⭐ · Comet 🚀 · Luna 🌙**.
 
+**Track Builder test fixture:** Log in to `STARS1` as Comet or Luna, open the student gallery, and ride Nova's shared **Star Sprint** track. The creator studio remains gated until Set 3 is approved for student release; local reviewers can remove `k2-stem-track-maker` from `HIDDEN_MODULE_SLUGS` to test the full build-and-save flow.
+
 ## Grade 3-5 Student Account
 
-| Email | Password | Notes |
-|---|---|---|
+| Email             | Password    | Notes                                                           |
+| ----------------- | ----------- | --------------------------------------------------------------- |
 | `jordan@test.com` | `jordan123` | Enrolled in a g3_5 class — sees Data Dash and other 3-5 content |
 
 ## Pathways Accounts (Ages 14-17)
 
-| Email | Password | Notes |
-|---|---|---|
+| Email                  | Password     | Notes                                                                    |
+| ---------------------- | ------------ | ------------------------------------------------------------------------ |
 | `facilitator@test.com` | `pathway123` | Coach Davis — facilitator/program manager for the ETO Spring 2026 cohort |
-| `marcus@test.com` | `marcus123` | Launch band (16-17), partial Cyber Launch progress (3/7 modules done) |
-| `aisha@test.com` | `aisha123` | Explorer band (14-15), fresh account, 0 completions |
+| `marcus@test.com`      | `marcus123`  | Launch band (16-17), partial Cyber Launch progress (3/7 modules done)    |
+| `aisha@test.com`       | `aisha123`   | Explorer band (14-15), fresh account, 0 completions                      |
 
 **Cohort join code:** `ETO2026` — for the "ETO Spring 2026 — Cyber Cohort"
 

--- a/prisma/__tests__/seedStars1.test.ts
+++ b/prisma/__tests__/seedStars1.test.ts
@@ -44,8 +44,18 @@ describe("seed defines the STARS1 K-2 emoji-login class (#698)", () => {
   });
 
   it("keeps STARS1 students PIN-less (emoji-only login path)", () => {
-    const block = src.slice(src.indexOf("starStudents"), src.indexOf("starStudents") + 600);
+    const block = src.slice(
+      src.indexOf("starStudents"),
+      src.indexOf("starStudents") + 600,
+    );
     expect(block).not.toMatch(/loginPin/);
+  });
+
+  it("seeds a shared Track Builder creation for cross-student gallery testing", () => {
+    expect(src).toContain('id: "seed-race-track-star-sprint"');
+    expect(src).toContain('authorId: "star-nova"');
+    expect(src).toContain('type: "race_track"');
+    expect(src).toContain('status: "SHARED"');
   });
 
   it("root and backend seed files stay byte-identical (sync invariant)", () => {

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -163,7 +163,9 @@ async function main() {
 
   // Test Explorer — student with Set 1 fully completed (for Set 2 testing)
   const explorerHash = await bcrypt.hash("explore123", 10);
-  let explorer = await prisma.user.findUnique({ where: { email: "explorer@test.com" } });
+  let explorer = await prisma.user.findUnique({
+    where: { email: "explorer@test.com" },
+  });
   if (!explorer) {
     explorer = await prisma.user.create({
       data: {
@@ -186,10 +188,17 @@ async function main() {
   }
 
   // Enroll explorer in teacher's class
-  const teacherCourse = await prisma.course.findFirst({ where: { teacherId: teacher.id } });
+  const teacherCourse = await prisma.course.findFirst({
+    where: { teacherId: teacher.id },
+  });
   if (teacherCourse) {
     await prisma.enrollment.upsert({
-      where: { studentId_courseId: { studentId: explorer.id, courseId: teacherCourse.id } },
+      where: {
+        studentId_courseId: {
+          studentId: explorer.id,
+          courseId: teacherCourse.id,
+        },
+      },
       create: { studentId: explorer.id, courseId: teacherCourse.id },
       update: {},
     });
@@ -199,13 +208,24 @@ async function main() {
   // Create avatar for explorer
   await prisma.avatar.upsert({
     where: { studentId: explorer.id },
-    create: { studentId: explorer.id, level: 5, xp: 650, hp: 100, energy: 100, speed: 4, control: 3, focus: 3 },
+    create: {
+      studentId: explorer.id,
+      level: 5,
+      xp: 650,
+      hp: 100,
+      energy: 100,
+      speed: 4,
+      control: 3,
+      focus: 3,
+    },
     update: { level: 5, xp: 650, speed: 4, control: 3, focus: 3 },
   });
 
   // Jordan — 9-year-old student in a grade 3-5 class
   const jordanHash = await bcrypt.hash("jordan123", 10);
-  let jordan = await prisma.user.findUnique({ where: { email: "jordan@test.com" } });
+  let jordan = await prisma.user.findUnique({
+    where: { email: "jordan@test.com" },
+  });
   if (!jordan) {
     jordan = await prisma.user.create({
       data: {
@@ -232,11 +252,18 @@ async function main() {
   // Create a grade 3-5 class and enroll Jordan
   const g35Class = await prisma.course.upsert({
     where: { joinCode: "GRADE35" },
-    create: { name: "Grade 3-5 STEM", joinCode: "GRADE35", teacherId: teacher.id, gradeBand: "g3_5" },
+    create: {
+      name: "Grade 3-5 STEM",
+      joinCode: "GRADE35",
+      teacherId: teacher.id,
+      gradeBand: "g3_5",
+    },
     update: { gradeBand: "g3_5" },
   });
   await prisma.enrollment.upsert({
-    where: { studentId_courseId: { studentId: jordan.id, courseId: g35Class.id } },
+    where: {
+      studentId_courseId: { studentId: jordan.id, courseId: g35Class.id },
+    },
     create: { studentId: jordan.id, courseId: g35Class.id },
     update: {},
   });
@@ -262,7 +289,11 @@ async function main() {
   const starsClass = await prisma.course.upsert({
     where: { joinCode: "STARS1" },
     // gradeBand intentionally omitted on create — schema default is "k2".
-    create: { name: "Ms. Frizzle's Star Class", joinCode: "STARS1", teacherId: teacher.id },
+    create: {
+      name: "Ms. Frizzle's Star Class",
+      joinCode: "STARS1",
+      teacherId: teacher.id,
+    },
     update: { gradeBand: "k2", teacherId: teacher.id },
   });
 
@@ -287,7 +318,9 @@ async function main() {
       update: { name: s.name, loginIcon: s.loginIcon },
     });
     await prisma.enrollment.upsert({
-      where: { studentId_courseId: { studentId: kid.id, courseId: starsClass.id } },
+      where: {
+        studentId_courseId: { studentId: kid.id, courseId: starsClass.id },
+      },
       create: { studentId: kid.id, courseId: starsClass.id },
       update: {},
     });
@@ -298,6 +331,47 @@ async function main() {
     "star students.",
   );
 
+  // Shared Track Builder fixture for gallery + ride-path testing. The creator
+  // studio remains intentionally gated, but any STARS1 student can open the
+  // gallery and ride Nova's deterministic, server-valid track.
+  const seededRaceTrack = {
+    v: 1,
+    name: "Star Sprint",
+    grid: { w: 6, h: 6 },
+    pieces: [
+      { x: 0, y: 1, type: "start", rot: 0 },
+      { x: 1, y: 1, type: "straight", rot: 0 },
+      { x: 2, y: 1, type: "gentleCurve", rot: 180 },
+      { x: 2, y: 2, type: "straight", rot: 90 },
+      { x: 2, y: 3, type: "gentleCurve", rot: 0 },
+      { x: 3, y: 3, type: "boost", rot: 0 },
+      { x: 4, y: 3, type: "finish", rot: 0 },
+    ],
+  };
+  await prisma.creation.upsert({
+    where: { id: "seed-race-track-star-sprint" },
+    create: {
+      id: "seed-race-track-star-sprint",
+      authorId: "star-nova",
+      courseId: starsClass.id,
+      type: "race_track",
+      title: seededRaceTrack.name,
+      content: seededRaceTrack,
+      status: "SHARED",
+      encouragements: 2,
+    },
+    update: {
+      authorId: "star-nova",
+      courseId: starsClass.id,
+      type: "race_track",
+      title: seededRaceTrack.name,
+      content: seededRaceTrack,
+      status: "SHARED",
+      encouragements: 2,
+    },
+  });
+  console.log("Seeded shared STARS1 Track Builder creation: Star Sprint.");
+
   // 5. Seed Content
   console.log("Seeding modules...");
 
@@ -305,14 +379,16 @@ async function main() {
     where: { slug: "stem-1-intro" },
     update: {
       title: "Quantum Explorers",
-      description: "Discover the tiny particles that power the future! Unlocks with specialization.",
+      description:
+        "Discover the tiny particles that power the future! Unlocks with specialization.",
       level: "K-2",
       published: true,
     },
     create: {
       slug: "stem-1-intro",
       title: "Quantum Explorers",
-      description: "Discover the tiny particles that power the future! Unlocks with specialization.",
+      description:
+        "Discover the tiny particles that power the future! Unlocks with specialization.",
       level: "K-2",
       published: true,
     },
@@ -373,14 +449,89 @@ async function main() {
   const storyContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "bpp-s1", text: { en: "Boost is a little helper robot in the Bright Lab. Today, Boost has one job: carry a tiny battery to the charging station.", es: "Boost es un pequeño robot ayudante en el Laboratorio Brillante. Hoy, Boost tiene un trabajo: llevar una pequeña batería a la estación de carga." }, icon: "🤖" },
-      { id: "bpp-s2", text: { en: "Boost cannot just rush forward. Boost has to look, think, and put the steps in the right order.", es: "Boost no puede apresurarse. Boost tiene que mirar, pensar y poner los pasos en el orden correcto." }, icon: "🧠" },
-      { id: "bpp-s3", text: { en: "When we help Boost turn and move the right way, we are practicing sequencing. Sequencing means putting steps in order.", es: "Cuando ayudamos a Boost a girar y moverse correctamente, estamos practicando la secuenciación. Secuenciar significa poner los pasos en orden." }, icon: "📋" },
+      {
+        id: "bpp-s1",
+        text: {
+          en: "Boost is a little helper robot in the Bright Lab. Today, Boost has one job: carry a tiny battery to the charging station.",
+          es: "Boost es un pequeño robot ayudante en el Laboratorio Brillante. Hoy, Boost tiene un trabajo: llevar una pequeña batería a la estación de carga.",
+        },
+        icon: "🤖",
+      },
+      {
+        id: "bpp-s2",
+        text: {
+          en: "Boost cannot just rush forward. Boost has to look, think, and put the steps in the right order.",
+          es: "Boost no puede apresurarse. Boost tiene que mirar, pensar y poner los pasos en el orden correcto.",
+        },
+        icon: "🧠",
+      },
+      {
+        id: "bpp-s3",
+        text: {
+          en: "When we help Boost turn and move the right way, we are practicing sequencing. Sequencing means putting steps in order.",
+          es: "Cuando ayudamos a Boost a girar y moverse correctamente, estamos practicando la secuenciación. Secuenciar significa poner los pasos en orden.",
+        },
+        icon: "📋",
+      },
     ],
     questions: [
-      { id: "bpp-q1", prompt: { en: "What is Boost trying to do?", es: "¿Qué intenta hacer Boost?" }, choices: [{ en: "Reach the charging station", es: "Llegar a la estación de carga" }, { en: "Go to sleep", es: "Irse a dormir" }, { en: "Paint the wall", es: "Pintar la pared" }], answerIndex: 0, hint: { en: "Read the first slide again — what is Boost's job today?", es: "Lee la primera diapositiva de nuevo — ¿cuál es el trabajo de Boost hoy?" } },
-      { id: "bpp-q2", prompt: { en: "What should Boost do first?", es: "¿Qué debe hacer Boost primero?" }, choices: [{ en: "Make a plan", es: "Hacer un plan" }, { en: "Guess fast", es: "Adivinar rápido" }, { en: "Spin in circles", es: "Girar en círculos" }], answerIndex: 0, hint: { en: "Boost has to look and think before moving.", es: "Boost tiene que mirar y pensar antes de moverse." } },
-      { id: "bpp-q3", prompt: { en: "What does sequencing mean?", es: "¿Qué significa secuenciar?" }, choices: [{ en: "Putting steps in order", es: "Poner los pasos en orden" }, { en: "Jumping over walls", es: "Saltar sobre paredes" }, { en: "Moving as fast as possible", es: "Moverse lo más rápido posible" }], answerIndex: 0, hint: { en: "The last slide explains what sequencing means.", es: "La última diapositiva explica qué significa secuenciar." } },
+      {
+        id: "bpp-q1",
+        prompt: {
+          en: "What is Boost trying to do?",
+          es: "¿Qué intenta hacer Boost?",
+        },
+        choices: [
+          {
+            en: "Reach the charging station",
+            es: "Llegar a la estación de carga",
+          },
+          { en: "Go to sleep", es: "Irse a dormir" },
+          { en: "Paint the wall", es: "Pintar la pared" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Read the first slide again — what is Boost's job today?",
+          es: "Lee la primera diapositiva de nuevo — ¿cuál es el trabajo de Boost hoy?",
+        },
+      },
+      {
+        id: "bpp-q2",
+        prompt: {
+          en: "What should Boost do first?",
+          es: "¿Qué debe hacer Boost primero?",
+        },
+        choices: [
+          { en: "Make a plan", es: "Hacer un plan" },
+          { en: "Guess fast", es: "Adivinar rápido" },
+          { en: "Spin in circles", es: "Girar en círculos" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Boost has to look and think before moving.",
+          es: "Boost tiene que mirar y pensar antes de moverse.",
+        },
+      },
+      {
+        id: "bpp-q3",
+        prompt: {
+          en: "What does sequencing mean?",
+          es: "¿Qué significa secuenciar?",
+        },
+        choices: [
+          { en: "Putting steps in order", es: "Poner los pasos en orden" },
+          { en: "Jumping over walls", es: "Saltar sobre paredes" },
+          {
+            en: "Moving as fast as possible",
+            es: "Moverse lo más rápido posible",
+          },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "The last slide explains what sequencing means.",
+          es: "La última diapositiva explica qué significa secuenciar.",
+        },
+      },
     ],
   });
   const storyAct = await prisma.activity.findFirst({
@@ -389,7 +540,10 @@ async function main() {
   if (storyAct) {
     await prisma.activity.update({
       where: { id: storyAct.id },
-      data: { title: "Story: Meet Boost the Careful Planner", content: storyContent },
+      data: {
+        title: "Story: Meet Boost the Careful Planner",
+        content: storyContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -411,7 +565,11 @@ async function main() {
   if (gameAct) {
     await prisma.activity.update({
       where: { id: gameAct.id },
-      data: { id: "lost-steps", title: "Game: Boost's Lost Steps", content: gameContent },
+      data: {
+        id: "lost-steps",
+        title: "Game: Boost's Lost Steps",
+        content: gameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -478,17 +636,73 @@ async function main() {
   const rhymeStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.rhymo.s1" }, icon: "🚲", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.rhymo.s2" }, icon: "🎵", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.rhymo.s3" }, icon: "🐱", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.rhymo.s4" }, icon: "🏁", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.rhymo.s1" },
+        icon: "🚲",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.rhymo.s2" },
+        icon: "🎵",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.rhymo.s3" },
+        icon: "🐱",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.rhymo.s4" },
+        icon: "🏁",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.rhymo.q1.prompt" }, choices: [{ i18nKey: "content.rhymo.q1.c1" }, { i18nKey: "content.rhymo.q1.c2" }, { i18nKey: "content.rhymo.q1.c3" }, { i18nKey: "content.rhymo.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.rhymo.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.rhymo.q2.prompt" }, choices: [{ i18nKey: "content.rhymo.q2.c1" }, { i18nKey: "content.rhymo.q2.c2" }, { i18nKey: "content.rhymo.q2.c3" }, { i18nKey: "content.rhymo.q2.c4" }], answerIndex: 1, hint: { i18nKey: "content.rhymo.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.rhymo.q3.prompt" }, choices: [{ i18nKey: "content.rhymo.q3.c1" }, { i18nKey: "content.rhymo.q3.c2" }, { i18nKey: "content.rhymo.q3.c3" }, { i18nKey: "content.rhymo.q3.c4" }], answerIndex: 1, hint: { i18nKey: "content.rhymo.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.rhymo.q1.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q1.c1" },
+          { i18nKey: "content.rhymo.q1.c2" },
+          { i18nKey: "content.rhymo.q1.c3" },
+          { i18nKey: "content.rhymo.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.rhymo.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.rhymo.q2.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q2.c1" },
+          { i18nKey: "content.rhymo.q2.c2" },
+          { i18nKey: "content.rhymo.q2.c3" },
+          { i18nKey: "content.rhymo.q2.c4" },
+        ],
+        answerIndex: 1,
+        hint: { i18nKey: "content.rhymo.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.rhymo.q3.prompt" },
+        choices: [
+          { i18nKey: "content.rhymo.q3.c1" },
+          { i18nKey: "content.rhymo.q3.c2" },
+          { i18nKey: "content.rhymo.q3.c3" },
+          { i18nKey: "content.rhymo.q3.c4" },
+        ],
+        answerIndex: 1,
+        hint: { i18nKey: "content.rhymo.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.rhymo.reviewKeyIdea" }, vocab: ["rhyme", "sound", "end"] },
+    review: {
+      keyIdea: { i18nKey: "content.rhymo.reviewKeyIdea" },
+      vocab: ["rhyme", "sound", "end"],
+    },
   });
   const rhymeStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2RhymeLesson.id, kind: INFO, order: 1 },
@@ -518,7 +732,11 @@ async function main() {
   if (rhymeGameAct) {
     await prisma.activity.update({
       where: { id: rhymeGameAct.id },
-      data: { id: "rhyme-ride", title: "Game: Rhyme & Ride", content: rhymeGameContent },
+      data: {
+        id: "rhyme-ride",
+        title: "Game: Rhyme & Ride",
+        content: rhymeGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -539,14 +757,16 @@ async function main() {
     where: { slug: "k2-stem-bounce-buds" },
     update: {
       title: "Bounce & Buds",
-      description: "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
+      description:
+        "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
       level: "K-2",
       published: true,
     },
     create: {
       slug: "k2-stem-bounce-buds",
       title: "Bounce & Buds",
-      description: "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
+      description:
+        "Bounce Buddy through the right gate to learn about plants! 🌿🧫",
       level: "K-2",
       published: true,
     },
@@ -585,17 +805,73 @@ async function main() {
   const bounceStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.buddy.s1" }, icon: "🌿", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.buddy.s2" }, icon: "🧫", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.buddy.s3" }, icon: "🦠", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.buddy.s4" }, icon: "💻", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.buddy.s1" },
+        icon: "🌿",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.buddy.s2" },
+        icon: "🧫",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.buddy.s3" },
+        icon: "🦠",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.buddy.s4" },
+        icon: "💻",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.buddy.q1.prompt" }, choices: [{ i18nKey: "content.buddy.q1.c1" }, { i18nKey: "content.buddy.q1.c2" }, { i18nKey: "content.buddy.q1.c3" }, { i18nKey: "content.buddy.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.buddy.q2.prompt" }, choices: [{ i18nKey: "content.buddy.q2.c1" }, { i18nKey: "content.buddy.q2.c2" }, { i18nKey: "content.buddy.q2.c3" }, { i18nKey: "content.buddy.q2.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.buddy.q3.prompt" }, choices: [{ i18nKey: "content.buddy.q3.c1" }, { i18nKey: "content.buddy.q3.c2" }, { i18nKey: "content.buddy.q3.c3" }, { i18nKey: "content.buddy.q3.c4" }], answerIndex: 0, hint: { i18nKey: "content.buddy.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.buddy.q1.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q1.c1" },
+          { i18nKey: "content.buddy.q1.c2" },
+          { i18nKey: "content.buddy.q1.c3" },
+          { i18nKey: "content.buddy.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.buddy.q2.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q2.c1" },
+          { i18nKey: "content.buddy.q2.c2" },
+          { i18nKey: "content.buddy.q2.c3" },
+          { i18nKey: "content.buddy.q2.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.buddy.q3.prompt" },
+        choices: [
+          { i18nKey: "content.buddy.q3.c1" },
+          { i18nKey: "content.buddy.q3.c2" },
+          { i18nKey: "content.buddy.q3.c3" },
+          { i18nKey: "content.buddy.q3.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.buddy.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.buddy.reviewKeyIdea" }, vocab: ["cell", "microbe", "root"] },
+    review: {
+      keyIdea: { i18nKey: "content.buddy.reviewKeyIdea" },
+      vocab: ["cell", "microbe", "root"],
+    },
   });
   const bounceStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2BounceLesson.id, kind: INFO, order: 1 },
@@ -626,7 +902,11 @@ async function main() {
   if (bounceGameAct) {
     await prisma.activity.update({
       where: { id: bounceGameAct.id },
-      data: { id: "bounce-buds", title: "Game: Bounce & Buds", content: bounceGameContent },
+      data: {
+        id: "bounce-buds",
+        title: "Game: Bounce & Buds",
+        content: bounceGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -693,17 +973,73 @@ async function main() {
   const gotchaStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "s1", text: { i18nKey: "content.gearbot.s1" }, icon: "⚙️", imageKey: "type_story" },
-      { id: "s2", text: { i18nKey: "content.gearbot.s2" }, icon: "📝", imageKey: "type_story" },
-      { id: "s3", text: { i18nKey: "content.gearbot.s3" }, icon: "🛠️", imageKey: "type_quiz" },
-      { id: "s4", text: { i18nKey: "content.gearbot.s4" }, icon: "🌟", imageKey: "type_game" },
+      {
+        id: "s1",
+        text: { i18nKey: "content.gearbot.s1" },
+        icon: "⚙️",
+        imageKey: "type_story",
+      },
+      {
+        id: "s2",
+        text: { i18nKey: "content.gearbot.s2" },
+        icon: "📝",
+        imageKey: "type_story",
+      },
+      {
+        id: "s3",
+        text: { i18nKey: "content.gearbot.s3" },
+        icon: "🛠️",
+        imageKey: "type_quiz",
+      },
+      {
+        id: "s4",
+        text: { i18nKey: "content.gearbot.s4" },
+        icon: "🌟",
+        imageKey: "type_game",
+      },
     ],
     questions: [
-      { id: "q1", prompt: { i18nKey: "content.gearbot.q1.prompt" }, choices: [{ i18nKey: "content.gearbot.q1.c1" }, { i18nKey: "content.gearbot.q1.c2" }, { i18nKey: "content.gearbot.q1.c3" }, { i18nKey: "content.gearbot.q1.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q1.hint" } },
-      { id: "q2", prompt: { i18nKey: "content.gearbot.q2.prompt" }, choices: [{ i18nKey: "content.gearbot.q2.c1" }, { i18nKey: "content.gearbot.q2.c2" }, { i18nKey: "content.gearbot.q2.c3" }, { i18nKey: "content.gearbot.q2.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q2.hint" } },
-      { id: "q3", prompt: { i18nKey: "content.gearbot.q3.prompt" }, choices: [{ i18nKey: "content.gearbot.q3.c1" }, { i18nKey: "content.gearbot.q3.c2" }, { i18nKey: "content.gearbot.q3.c3" }, { i18nKey: "content.gearbot.q3.c4" }], answerIndex: 0, hint: { i18nKey: "content.gearbot.q3.hint" } },
+      {
+        id: "q1",
+        prompt: { i18nKey: "content.gearbot.q1.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q1.c1" },
+          { i18nKey: "content.gearbot.q1.c2" },
+          { i18nKey: "content.gearbot.q1.c3" },
+          { i18nKey: "content.gearbot.q1.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q1.hint" },
+      },
+      {
+        id: "q2",
+        prompt: { i18nKey: "content.gearbot.q2.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q2.c1" },
+          { i18nKey: "content.gearbot.q2.c2" },
+          { i18nKey: "content.gearbot.q2.c3" },
+          { i18nKey: "content.gearbot.q2.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q2.hint" },
+      },
+      {
+        id: "q3",
+        prompt: { i18nKey: "content.gearbot.q3.prompt" },
+        choices: [
+          { i18nKey: "content.gearbot.q3.c1" },
+          { i18nKey: "content.gearbot.q3.c2" },
+          { i18nKey: "content.gearbot.q3.c3" },
+          { i18nKey: "content.gearbot.q3.c4" },
+        ],
+        answerIndex: 0,
+        hint: { i18nKey: "content.gearbot.q3.hint" },
+      },
     ],
-    review: { keyIdea: { i18nKey: "content.gearbot.reviewKeyIdea" }, vocab: ["debug", "plan", "practice", "rule"] },
+    review: {
+      keyIdea: { i18nKey: "content.gearbot.reviewKeyIdea" },
+      vocab: ["debug", "plan", "practice", "rule"],
+    },
   });
   const gotchaStoryAct = await prisma.activity.findFirst({
     where: { lessonId: k2GotchaLesson.id, kind: INFO, order: 1 },
@@ -739,13 +1075,69 @@ async function main() {
       catchWindowX: 0.95,
     },
     rounds: [
-      { clueText: { i18nKey: "content.gotchaGame.r1.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r1.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r1.d1" }, { i18nKey: "content.gotchaGame.r1.d2" }], hint: { i18nKey: "content.gotchaGame.r1.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r2.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r2.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r2.d1" }, { i18nKey: "content.gotchaGame.r2.d2" }], hint: { i18nKey: "content.gotchaGame.r2.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r3.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r3.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r3.d1" }, { i18nKey: "content.gotchaGame.r3.d2" }], hint: { i18nKey: "content.gotchaGame.r3.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r4.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r4.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r4.d1" }, { i18nKey: "content.gotchaGame.r4.d2" }], hint: { i18nKey: "content.gotchaGame.r4.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r5.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r5.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r5.d1" }, { i18nKey: "content.gotchaGame.r5.d2" }], hint: { i18nKey: "content.gotchaGame.r5.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r6.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r6.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r6.d1" }, { i18nKey: "content.gotchaGame.r6.d2" }], hint: { i18nKey: "content.gotchaGame.r6.hint" } },
-      { clueText: { i18nKey: "content.gotchaGame.r7.clue" }, correctLabel: { i18nKey: "content.gotchaGame.r7.correct" }, distractors: [{ i18nKey: "content.gotchaGame.r7.d1" }, { i18nKey: "content.gotchaGame.r7.d2" }], hint: { i18nKey: "content.gotchaGame.r7.hint" } },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r1.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r1.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r1.d1" },
+          { i18nKey: "content.gotchaGame.r1.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r1.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r2.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r2.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r2.d1" },
+          { i18nKey: "content.gotchaGame.r2.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r2.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r3.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r3.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r3.d1" },
+          { i18nKey: "content.gotchaGame.r3.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r3.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r4.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r4.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r4.d1" },
+          { i18nKey: "content.gotchaGame.r4.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r4.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r5.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r5.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r5.d1" },
+          { i18nKey: "content.gotchaGame.r5.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r5.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r6.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r6.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r6.d1" },
+          { i18nKey: "content.gotchaGame.r6.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r6.hint" },
+      },
+      {
+        clueText: { i18nKey: "content.gotchaGame.r7.clue" },
+        correctLabel: { i18nKey: "content.gotchaGame.r7.correct" },
+        distractors: [
+          { i18nKey: "content.gotchaGame.r7.d1" },
+          { i18nKey: "content.gotchaGame.r7.d2" },
+        ],
+        hint: { i18nKey: "content.gotchaGame.r7.hint" },
+      },
     ],
   });
 
@@ -756,7 +1148,11 @@ async function main() {
   if (gotchaGameAct) {
     await prisma.activity.update({
       where: { id: gotchaGameAct.id },
-      data: { id: "gotcha-gears", title: "Game: Gotcha Gears (Catch the Gear!)", content: gotchaGameContent },
+      data: {
+        id: "gotcha-gears",
+        title: "Game: Gotcha Gears (Catch the Gear!)",
+        content: gotchaGameContent,
+      },
     });
   } else {
     await prisma.activity.create({
@@ -777,48 +1173,194 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   const k2TankModule = await prisma.module.upsert({
     where: { slug: "k2-stem-tank-trek" },
-    update: { title: "Tank Trek", description: "Guide a robot through mazes! 🤖🧩", level: "K-2", published: true },
-    create: { slug: "k2-stem-tank-trek", title: "Tank Trek", description: "Guide a robot through mazes! 🤖🧩", level: "K-2", published: true },
+    update: {
+      title: "Tank Trek",
+      description: "Guide a robot through mazes! 🤖🧩",
+      level: "K-2",
+      published: true,
+    },
+    create: {
+      slug: "k2-stem-tank-trek",
+      title: "Tank Trek",
+      description: "Guide a robot through mazes! 🤖🧩",
+      level: "K-2",
+      published: true,
+    },
   });
   console.log("Created module:", k2TankModule.slug);
 
-  let k2TankUnit = await prisma.unit.findFirst({ where: { moduleId: k2TankModule.id, title: "Unit 1: Robot Navigation" } });
+  let k2TankUnit = await prisma.unit.findFirst({
+    where: { moduleId: k2TankModule.id, title: "Unit 1: Robot Navigation" },
+  });
   if (!k2TankUnit) {
-    k2TankUnit = await prisma.unit.create({ data: { title: "Unit 1: Robot Navigation", order: 1, Module: { connect: { id: k2TankModule.id } }, teacher: { connect: { id: teacher.id } } } });
+    k2TankUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Robot Navigation",
+        order: 1,
+        Module: { connect: { id: k2TankModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
   }
 
-  let k2TankLesson = await prisma.lesson.findFirst({ where: { unitId: k2TankUnit.id, title: "Tank Trek" } });
+  let k2TankLesson = await prisma.lesson.findFirst({
+    where: { unitId: k2TankUnit.id, title: "Tank Trek" },
+  });
   if (!k2TankLesson) {
-    k2TankLesson = await prisma.lesson.create({ data: { title: "Tank Trek", order: 1, Unit: { connect: { id: k2TankUnit.id } } } });
+    k2TankLesson = await prisma.lesson.create({
+      data: {
+        title: "Tank Trek",
+        order: 1,
+        Unit: { connect: { id: k2TankUnit.id } },
+      },
+    });
   }
 
   const tankStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "tt-s1", text: { en: "Meet Bolt! Bolt listens to your code words to move safely through the maze.", es: "¡Conoce a Bolt! Bolt escucha tus palabras de código para moverse con seguridad por el laberinto." }, icon: "🤖" },
-      { id: "tt-s2", text: { en: "Use clear commands: Forward, Turn Left, Turn Right. Order matters!", es: "Usa comandos claros: Adelante, Girar Izquierda, Girar Derecha. ¡El orden importa!" }, icon: "🧭" },
-      { id: "tt-s3", text: { en: "Great robot coders test, fix, and try again. Short smart paths earn more stars!", es: "Los grandes programadores de robots prueban, corrigen e intentan otra vez. ¡Los caminos cortos e inteligentes ganan más estrellas!" }, icon: "⭐" },
+      {
+        id: "tt-s1",
+        text: {
+          en: "Meet Bolt! Bolt listens to your code words to move safely through the maze.",
+          es: "¡Conoce a Bolt! Bolt escucha tus palabras de código para moverse con seguridad por el laberinto.",
+        },
+        icon: "🤖",
+      },
+      {
+        id: "tt-s2",
+        text: {
+          en: "Use clear commands: Forward, Turn Left, Turn Right. Order matters!",
+          es: "Usa comandos claros: Adelante, Girar Izquierda, Girar Derecha. ¡El orden importa!",
+        },
+        icon: "🧭",
+      },
+      {
+        id: "tt-s3",
+        text: {
+          en: "Great robot coders test, fix, and try again. Short smart paths earn more stars!",
+          es: "Los grandes programadores de robots prueban, corrigen e intentan otra vez. ¡Los caminos cortos e inteligentes ganan más estrellas!",
+        },
+        icon: "⭐",
+      },
     ],
     questions: [
-      { id: "tt-q1", prompt: { en: "Which command makes Bolt move ahead one space?", es: "¿Qué comando hace que Bolt avance un espacio?" }, choices: [{ en: "Forward", es: "Adelante" }, { en: "Turn Left", es: "Girar Izquierda" }, { en: "Turn Right", es: "Girar Derecha" }, { en: "Stop and spin", es: "Parar y girar" }], answerIndex: 0, hint: { en: "Forward means move ahead.", es: "Adelante significa moverse al frente." } },
-      { id: "tt-q2", prompt: { en: "Two paths reach the goal. Which is more efficient?", es: "Dos caminos llegan a la meta. ¿Cuál es más eficiente?" }, choices: [{ en: "The path with fewer commands", es: "El camino con menos comandos" }, { en: "The path with more turns", es: "El camino con más giros" }, { en: "The longest path", es: "El camino más largo" }, { en: "Any path is always equal", es: "Cualquier camino siempre es igual" }], answerIndex: 0, hint: { en: "Efficient means doing the job in fewer steps.", es: "Eficiente significa hacer el trabajo con menos pasos." } },
-      { id: "tt-q3", prompt: { en: "Bolt bumped a wall. What should you do next?", es: "Bolt chocó con una pared. ¿Qué debes hacer después?" }, choices: [{ en: "Change one command and test again", es: "Cambiar un comando y probar otra vez" }, { en: "Keep the same plan forever", es: "Seguir el mismo plan para siempre" }, { en: "Press random buttons", es: "Presionar botones al azar" }, { en: "Quit the mission", es: "Salir de la misión" }], answerIndex: 0, hint: { en: "Debugging means fixing and retesting.", es: "Depurar significa corregir y volver a probar." } },
+      {
+        id: "tt-q1",
+        prompt: {
+          en: "Which command makes Bolt move ahead one space?",
+          es: "¿Qué comando hace que Bolt avance un espacio?",
+        },
+        choices: [
+          { en: "Forward", es: "Adelante" },
+          { en: "Turn Left", es: "Girar Izquierda" },
+          { en: "Turn Right", es: "Girar Derecha" },
+          { en: "Stop and spin", es: "Parar y girar" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Forward means move ahead.",
+          es: "Adelante significa moverse al frente.",
+        },
+      },
+      {
+        id: "tt-q2",
+        prompt: {
+          en: "Two paths reach the goal. Which is more efficient?",
+          es: "Dos caminos llegan a la meta. ¿Cuál es más eficiente?",
+        },
+        choices: [
+          {
+            en: "The path with fewer commands",
+            es: "El camino con menos comandos",
+          },
+          { en: "The path with more turns", es: "El camino con más giros" },
+          { en: "The longest path", es: "El camino más largo" },
+          {
+            en: "Any path is always equal",
+            es: "Cualquier camino siempre es igual",
+          },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Efficient means doing the job in fewer steps.",
+          es: "Eficiente significa hacer el trabajo con menos pasos.",
+        },
+      },
+      {
+        id: "tt-q3",
+        prompt: {
+          en: "Bolt bumped a wall. What should you do next?",
+          es: "Bolt chocó con una pared. ¿Qué debes hacer después?",
+        },
+        choices: [
+          {
+            en: "Change one command and test again",
+            es: "Cambiar un comando y probar otra vez",
+          },
+          {
+            en: "Keep the same plan forever",
+            es: "Seguir el mismo plan para siempre",
+          },
+          { en: "Press random buttons", es: "Presionar botones al azar" },
+          { en: "Quit the mission", es: "Salir de la misión" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "Debugging means fixing and retesting.",
+          es: "Depurar significa corregir y volver a probar.",
+        },
+      },
     ],
   });
 
-  let tankStoryAct = await prisma.activity.findFirst({ where: { lessonId: k2TankLesson.id, kind: INFO, order: 1 } });
+  let tankStoryAct = await prisma.activity.findFirst({
+    where: { lessonId: k2TankLesson.id, kind: INFO, order: 1 },
+  });
   if (tankStoryAct) {
-    await prisma.activity.update({ where: { id: tankStoryAct.id }, data: { title: "Story: Meet Bolt", content: tankStoryContent } });
+    await prisma.activity.update({
+      where: { id: tankStoryAct.id },
+      data: { title: "Story: Meet Bolt", content: tankStoryContent },
+    });
   } else {
-    await prisma.activity.create({ data: { title: "Story: Meet Bolt", kind: INFO, order: 1, content: tankStoryContent, Lesson: { connect: { id: k2TankLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        title: "Story: Meet Bolt",
+        kind: INFO,
+        order: 1,
+        content: tankStoryContent,
+        Lesson: { connect: { id: k2TankLesson.id } },
+      },
+    });
   }
 
-  const tankGameContent = JSON.stringify({ gameKey: "tank_trek", chapters: [] });
-  let tankGameAct = await prisma.activity.findFirst({ where: { lessonId: k2TankLesson.id, kind: INTERACT, order: 2 } });
+  const tankGameContent = JSON.stringify({
+    gameKey: "tank_trek",
+    chapters: [],
+  });
+  let tankGameAct = await prisma.activity.findFirst({
+    where: { lessonId: k2TankLesson.id, kind: INTERACT, order: 2 },
+  });
   if (tankGameAct) {
-    await prisma.activity.update({ where: { id: tankGameAct.id }, data: { id: "tank-trek", title: "Game: Tank Trek", content: tankGameContent } });
+    await prisma.activity.update({
+      where: { id: tankGameAct.id },
+      data: {
+        id: "tank-trek",
+        title: "Game: Tank Trek",
+        content: tankGameContent,
+      },
+    });
   } else {
-    await prisma.activity.create({ data: { id: "tank-trek", title: "Game: Tank Trek", kind: INTERACT, order: 2, content: tankGameContent, Lesson: { connect: { id: k2TankLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        id: "tank-trek",
+        title: "Game: Tank Trek",
+        kind: INTERACT,
+        order: 2,
+        content: tankGameContent,
+        Lesson: { connect: { id: k2TankLesson.id } },
+      },
+    });
   }
   console.log("Seeded Tank Trek module + activities.");
 
@@ -827,48 +1369,188 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   const k2QuantumModule = await prisma.module.upsert({
     where: { slug: "k2-stem-quantum-quest" },
-    update: { title: "Quantum Quest", description: "Explore quantum puzzles in a space math adventure! 🚀✨", level: "K-2", published: true },
-    create: { slug: "k2-stem-quantum-quest", title: "Quantum Quest", description: "Explore quantum puzzles in a space math adventure! 🚀✨", level: "K-2", published: true },
+    update: {
+      title: "Quantum Quest",
+      description: "Explore quantum puzzles in a space math adventure! 🚀✨",
+      level: "K-2",
+      published: true,
+    },
+    create: {
+      slug: "k2-stem-quantum-quest",
+      title: "Quantum Quest",
+      description: "Explore quantum puzzles in a space math adventure! 🚀✨",
+      level: "K-2",
+      published: true,
+    },
   });
   console.log("Created module:", k2QuantumModule.slug);
 
-  let k2QuantumUnit = await prisma.unit.findFirst({ where: { moduleId: k2QuantumModule.id, title: "Unit 1: Star Math" } });
+  let k2QuantumUnit = await prisma.unit.findFirst({
+    where: { moduleId: k2QuantumModule.id, title: "Unit 1: Star Math" },
+  });
   if (!k2QuantumUnit) {
-    k2QuantumUnit = await prisma.unit.create({ data: { title: "Unit 1: Star Math", order: 1, Module: { connect: { id: k2QuantumModule.id } }, teacher: { connect: { id: teacher.id } } } });
+    k2QuantumUnit = await prisma.unit.create({
+      data: {
+        title: "Unit 1: Star Math",
+        order: 1,
+        Module: { connect: { id: k2QuantumModule.id } },
+        teacher: { connect: { id: teacher.id } },
+      },
+    });
   }
 
-  let k2QuantumLesson = await prisma.lesson.findFirst({ where: { unitId: k2QuantumUnit.id, title: "Quantum Quest" } });
+  let k2QuantumLesson = await prisma.lesson.findFirst({
+    where: { unitId: k2QuantumUnit.id, title: "Quantum Quest" },
+  });
   if (!k2QuantumLesson) {
-    k2QuantumLesson = await prisma.lesson.create({ data: { title: "Quantum Quest", order: 1, Unit: { connect: { id: k2QuantumUnit.id } } } });
+    k2QuantumLesson = await prisma.lesson.create({
+      data: {
+        title: "Quantum Quest",
+        order: 1,
+        Unit: { connect: { id: k2QuantumUnit.id } },
+      },
+    });
   }
 
   const quantumStoryContent = JSON.stringify({
     type: "story_quiz",
     slides: [
-      { id: "qq-s1", text: { en: "Welcome, Space Explorer! Your mission is to spot number patterns and true clues in the stars.", es: "¡Bienvenido, Explorador Espacial! Tu misión es encontrar patrones de números y pistas verdaderas en las estrellas." }, icon: "🚀" },
-      { id: "qq-s2", text: { en: "Look carefully at every choice. Use evidence: count, compare, and notice what repeats.", es: "Mira con atención cada opción. Usa evidencia: cuenta, compara y nota lo que se repite." }, icon: "🔍" },
-      { id: "qq-s3", text: { en: "Each correct answer builds your streak power. Careful thinking keeps your mission safe!", es: "Cada respuesta correcta aumenta tu racha. ¡Pensar con cuidado mantiene tu misión segura!" }, icon: "🌟" },
+      {
+        id: "qq-s1",
+        text: {
+          en: "Welcome, Space Explorer! Your mission is to spot number patterns and true clues in the stars.",
+          es: "¡Bienvenido, Explorador Espacial! Tu misión es encontrar patrones de números y pistas verdaderas en las estrellas.",
+        },
+        icon: "🚀",
+      },
+      {
+        id: "qq-s2",
+        text: {
+          en: "Look carefully at every choice. Use evidence: count, compare, and notice what repeats.",
+          es: "Mira con atención cada opción. Usa evidencia: cuenta, compara y nota lo que se repite.",
+        },
+        icon: "🔍",
+      },
+      {
+        id: "qq-s3",
+        text: {
+          en: "Each correct answer builds your streak power. Careful thinking keeps your mission safe!",
+          es: "Cada respuesta correcta aumenta tu racha. ¡Pensar con cuidado mantiene tu misión segura!",
+        },
+        icon: "🌟",
+      },
     ],
     questions: [
-      { id: "qq-q1", prompt: { en: "Which pattern comes next: 2, 4, 6, __?", es: "¿Qué patrón sigue: 2, 4, 6, __?" }, choices: [{ en: "8", es: "8" }, { en: "7", es: "7" }, { en: "5", es: "5" }, { en: "10", es: "10" }], answerIndex: 0, hint: { en: "The pattern adds 2 each time.", es: "El patrón suma 2 cada vez." } },
-      { id: "qq-q2", prompt: { en: "You count 3 stars, then 2 more. How many stars now?", es: "Cuentas 3 estrellas y luego 2 más. ¿Cuántas estrellas hay ahora?" }, choices: [{ en: "4", es: "4" }, { en: "5", es: "5" }, { en: "6", es: "6" }, { en: "3", es: "3" }], answerIndex: 1, hint: { en: "Count on: 3, 4, 5.", es: "Cuenta hacia adelante: 3, 4, 5." } },
-      { id: "qq-q3", prompt: { en: "Which answer shows careful evidence?", es: "¿Qué respuesta muestra evidencia cuidadosa?" }, choices: [{ en: "Pick the biggest number quickly", es: "Elegir el número más grande rápido" }, { en: "Guess before you look", es: "Adivinar antes de mirar" }, { en: "Check the pattern, then choose", es: "Revisar el patrón y luego elegir" }, { en: "Tap any star", es: "Tocar cualquier estrella" }], answerIndex: 2, hint: { en: "Scientists observe first.", es: "Los científicos observan primero." } },
+      {
+        id: "qq-q1",
+        prompt: {
+          en: "Which pattern comes next: 2, 4, 6, __?",
+          es: "¿Qué patrón sigue: 2, 4, 6, __?",
+        },
+        choices: [
+          { en: "8", es: "8" },
+          { en: "7", es: "7" },
+          { en: "5", es: "5" },
+          { en: "10", es: "10" },
+        ],
+        answerIndex: 0,
+        hint: {
+          en: "The pattern adds 2 each time.",
+          es: "El patrón suma 2 cada vez.",
+        },
+      },
+      {
+        id: "qq-q2",
+        prompt: {
+          en: "You count 3 stars, then 2 more. How many stars now?",
+          es: "Cuentas 3 estrellas y luego 2 más. ¿Cuántas estrellas hay ahora?",
+        },
+        choices: [
+          { en: "4", es: "4" },
+          { en: "5", es: "5" },
+          { en: "6", es: "6" },
+          { en: "3", es: "3" },
+        ],
+        answerIndex: 1,
+        hint: {
+          en: "Count on: 3, 4, 5.",
+          es: "Cuenta hacia adelante: 3, 4, 5.",
+        },
+      },
+      {
+        id: "qq-q3",
+        prompt: {
+          en: "Which answer shows careful evidence?",
+          es: "¿Qué respuesta muestra evidencia cuidadosa?",
+        },
+        choices: [
+          {
+            en: "Pick the biggest number quickly",
+            es: "Elegir el número más grande rápido",
+          },
+          { en: "Guess before you look", es: "Adivinar antes de mirar" },
+          {
+            en: "Check the pattern, then choose",
+            es: "Revisar el patrón y luego elegir",
+          },
+          { en: "Tap any star", es: "Tocar cualquier estrella" },
+        ],
+        answerIndex: 2,
+        hint: {
+          en: "Scientists observe first.",
+          es: "Los científicos observan primero.",
+        },
+      },
     ],
   });
 
-  let quantumStoryAct = await prisma.activity.findFirst({ where: { lessonId: k2QuantumLesson.id, kind: INFO, order: 1 } });
+  let quantumStoryAct = await prisma.activity.findFirst({
+    where: { lessonId: k2QuantumLesson.id, kind: INFO, order: 1 },
+  });
   if (quantumStoryAct) {
-    await prisma.activity.update({ where: { id: quantumStoryAct.id }, data: { title: "Story: Space Explorer", content: quantumStoryContent } });
+    await prisma.activity.update({
+      where: { id: quantumStoryAct.id },
+      data: { title: "Story: Space Explorer", content: quantumStoryContent },
+    });
   } else {
-    await prisma.activity.create({ data: { title: "Story: Space Explorer", kind: INFO, order: 1, content: quantumStoryContent, Lesson: { connect: { id: k2QuantumLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        title: "Story: Space Explorer",
+        kind: INFO,
+        order: 1,
+        content: quantumStoryContent,
+        Lesson: { connect: { id: k2QuantumLesson.id } },
+      },
+    });
   }
 
-  const quantumGameContent = JSON.stringify({ gameKey: "quantum_quest", sectors: [] });
-  let quantumGameAct = await prisma.activity.findFirst({ where: { lessonId: k2QuantumLesson.id, kind: INTERACT, order: 2 } });
+  const quantumGameContent = JSON.stringify({
+    gameKey: "quantum_quest",
+    sectors: [],
+  });
+  let quantumGameAct = await prisma.activity.findFirst({
+    where: { lessonId: k2QuantumLesson.id, kind: INTERACT, order: 2 },
+  });
   if (quantumGameAct) {
-    await prisma.activity.update({ where: { id: quantumGameAct.id }, data: { id: "quantum-quest", title: "Game: Quantum Quest", content: quantumGameContent } });
+    await prisma.activity.update({
+      where: { id: quantumGameAct.id },
+      data: {
+        id: "quantum-quest",
+        title: "Game: Quantum Quest",
+        content: quantumGameContent,
+      },
+    });
   } else {
-    await prisma.activity.create({ data: { id: "quantum-quest", title: "Game: Quantum Quest", kind: INTERACT, order: 2, content: quantumGameContent, Lesson: { connect: { id: k2QuantumLesson.id } } } });
+    await prisma.activity.create({
+      data: {
+        id: "quantum-quest",
+        title: "Game: Quantum Quest",
+        kind: INTERACT,
+        order: 2,
+        content: quantumGameContent,
+        Lesson: { connect: { id: k2QuantumLesson.id } },
+      },
+    });
   }
   console.log("Seeded Quantum Quest module + activities.");
 
@@ -876,17 +1558,47 @@ async function main() {
   // Test Explorer — Set 1 completion records
   // ═══════════════════════════════════════════════════════════════════════════
   const set1Activities = [
-    { activityId: "bounce-buds", moduleSlug: "k2-stem-bounce-buds", timeSpentS: 180, daysAgo: 5 },
-    { activityId: "gotcha-gears", moduleSlug: "k2-stem-gotcha-gears", timeSpentS: 210, daysAgo: 4 },
-    { activityId: "rhyme-ride", moduleSlug: "k2-stem-rhyme-ride", timeSpentS: 240, daysAgo: 3 },
-    { activityId: "tank-trek", moduleSlug: "k2-stem-tank-trek", timeSpentS: 195, daysAgo: 2 },
-    { activityId: "quantum-quest", moduleSlug: "k2-stem-quantum-quest", timeSpentS: 220, daysAgo: 1 },
+    {
+      activityId: "bounce-buds",
+      moduleSlug: "k2-stem-bounce-buds",
+      timeSpentS: 180,
+      daysAgo: 5,
+    },
+    {
+      activityId: "gotcha-gears",
+      moduleSlug: "k2-stem-gotcha-gears",
+      timeSpentS: 210,
+      daysAgo: 4,
+    },
+    {
+      activityId: "rhyme-ride",
+      moduleSlug: "k2-stem-rhyme-ride",
+      timeSpentS: 240,
+      daysAgo: 3,
+    },
+    {
+      activityId: "tank-trek",
+      moduleSlug: "k2-stem-tank-trek",
+      timeSpentS: 195,
+      daysAgo: 2,
+    },
+    {
+      activityId: "quantum-quest",
+      moduleSlug: "k2-stem-quantum-quest",
+      timeSpentS: 220,
+      daysAgo: 1,
+    },
   ];
 
   for (const sa of set1Activities) {
     const completedAt = new Date(Date.now() - sa.daysAgo * 86400000);
     await prisma.progress.upsert({
-      where: { studentId_activityId: { studentId: explorer.id, activityId: sa.activityId } },
+      where: {
+        studentId_activityId: {
+          studentId: explorer.id,
+          activityId: sa.activityId,
+        },
+      },
       create: {
         studentId: explorer.id,
         activityId: sa.activityId,
@@ -900,16 +1612,48 @@ async function main() {
 
   // Game personal bests for explorer
   const explorerBests = [
-    { gameKey: "buddy_garden_sort", bestScore: 45, lastScore: 45, bestStreak: 4, bestRoundsCompleted: 8 },
-    { gameKey: "gotcha_gears_unity", bestScore: 80, lastScore: 60, bestStreak: 3, bestRoundsCompleted: 7 },
-    { gameKey: "boost_path_planner", bestScore: 35, lastScore: 35, bestStreak: 2, bestRoundsCompleted: 3 },
-    { gameKey: "rhymo_rhyme_rocket", bestScore: 120, lastScore: 90, bestStreak: 5, bestRoundsCompleted: 15 },
-    { gameKey: "tank_trek", bestScore: 16, lastScore: 14, bestStreak: 3, bestRoundsCompleted: 7 }, // star-sum units (7 levels x 3 max = 21); the old 55 was fabricated and unearnable
+    {
+      gameKey: "buddy_garden_sort",
+      bestScore: 45,
+      lastScore: 45,
+      bestStreak: 4,
+      bestRoundsCompleted: 8,
+    },
+    {
+      gameKey: "gotcha_gears_unity",
+      bestScore: 80,
+      lastScore: 60,
+      bestStreak: 3,
+      bestRoundsCompleted: 7,
+    },
+    {
+      gameKey: "boost_path_planner",
+      bestScore: 35,
+      lastScore: 35,
+      bestStreak: 2,
+      bestRoundsCompleted: 3,
+    },
+    {
+      gameKey: "rhymo_rhyme_rocket",
+      bestScore: 120,
+      lastScore: 90,
+      bestStreak: 5,
+      bestRoundsCompleted: 15,
+    },
+    {
+      gameKey: "tank_trek",
+      bestScore: 16,
+      lastScore: 14,
+      bestStreak: 3,
+      bestRoundsCompleted: 7,
+    }, // star-sum units (7 levels x 3 max = 21); the old 55 was fabricated and unearnable
   ];
 
   for (const gb of explorerBests) {
     await prisma.gamePersonalBest.upsert({
-      where: { studentId_gameKey: { studentId: explorer.id, gameKey: gb.gameKey } },
+      where: {
+        studentId_gameKey: { studentId: explorer.id, gameKey: gb.gameKey },
+      },
       create: { studentId: explorer.id, ...gb, playCount: 3 },
       update: gb,
     });
@@ -931,18 +1675,112 @@ async function main() {
       story: {
         title: "Story: Maze Explorer",
         slides: [
-          { id: "mm-s1", text: { en: "Spark the helper bot is lost in the idea maze! Glowing orbs are scattered everywhere, but sneaky sweepers are patrolling the paths. Spark needs YOUR help to collect every orb and find the exit.", es: "¡Spark el robot ayudante está perdido en el laberinto de ideas! Hay esferas brillantes por todas partes, pero los barredores patrullan los caminos. ¡Spark necesita TU ayuda para recoger cada esfera y encontrar la salida!" }, icon: "🗺️" },
-          { id: "mm-s2", text: { en: "But here's the trick — Spark can't just run in! The sweepers move in patterns. Watch them carefully before you move. The smartest path isn't always the shortest one.", es: "Pero hay un truco — ¡Spark no puede solo correr! Los barredores se mueven en patrones. Obsérvalos antes de moverte. El camino más inteligente no siempre es el más corto." }, icon: "🤔" },
-          { id: "mm-s3", text: { en: "Ready? Guide Spark through the maze. Collect all the orbs. Avoid the sweepers. Think before you move!", es: "¿Listo? Guía a Spark por el laberinto. Recoge todas las esferas. Evita los barredores. ¡Piensa antes de moverte!" }, icon: "⭐" },
+          {
+            id: "mm-s1",
+            text: {
+              en: "Spark the helper bot is lost in the idea maze! Glowing orbs are scattered everywhere, but sneaky sweepers are patrolling the paths. Spark needs YOUR help to collect every orb and find the exit.",
+              es: "¡Spark el robot ayudante está perdido en el laberinto de ideas! Hay esferas brillantes por todas partes, pero los barredores patrullan los caminos. ¡Spark necesita TU ayuda para recoger cada esfera y encontrar la salida!",
+            },
+            icon: "🗺️",
+          },
+          {
+            id: "mm-s2",
+            text: {
+              en: "But here's the trick — Spark can't just run in! The sweepers move in patterns. Watch them carefully before you move. The smartest path isn't always the shortest one.",
+              es: "Pero hay un truco — ¡Spark no puede solo correr! Los barredores se mueven en patrones. Obsérvalos antes de moverte. El camino más inteligente no siempre es el más corto.",
+            },
+            icon: "🤔",
+          },
+          {
+            id: "mm-s3",
+            text: {
+              en: "Ready? Guide Spark through the maze. Collect all the orbs. Avoid the sweepers. Think before you move!",
+              es: "¿Listo? Guía a Spark por el laberinto. Recoge todas las esferas. Evita los barredores. ¡Piensa antes de moverte!",
+            },
+            icon: "⭐",
+          },
         ],
         questions: [
-          { id: "mm-q1", prompt: { en: "What should you do before moving in a maze?", es: "¿Qué debes hacer antes de moverte en un laberinto?" }, choices: [{ en: "Plan a path", es: "Planificar un camino" }, { en: "Run fast", es: "Correr rápido" }, { en: "Close your eyes", es: "Cerrar los ojos" }, { en: "Ask for directions", es: "Pedir direcciones" }], answerIndex: 0 },
+          {
+            id: "mm-q1",
+            prompt: {
+              en: "What should you do before moving in a maze?",
+              es: "¿Qué debes hacer antes de moverte en un laberinto?",
+            },
+            choices: [
+              { en: "Plan a path", es: "Planificar un camino" },
+              { en: "Run fast", es: "Correr rápido" },
+              { en: "Close your eyes", es: "Cerrar los ojos" },
+              { en: "Ask for directions", es: "Pedir direcciones" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "mmz-q1", prompt: { en: "Before moving through the maze, what should you do first?", es: "Antes de moverte en el laberinto, ¿qué debes hacer primero?" }, choices: [{ en: "Run as fast as you can", es: "Correr lo más rápido posible" }, { en: "Watch the sweeper's pattern", es: "Observar el patrón del barredor" }, { en: "Close your eyes and guess", es: "Cerrar los ojos y adivinar" }, { en: "Pick the shortest path", es: "Elegir el camino más corto" }], answerIndex: 1 },
-        { id: "mmz-q2", prompt: { en: "A sweeper moves left, right, left, right. What does it do next?", es: "Un barredor se mueve izquierda, derecha, izquierda, derecha. ¿Qué hace después?" }, choices: [{ en: "Stop", es: "Parar" }, { en: "Move up", es: "Ir arriba" }, { en: "Move left", es: "Ir a la izquierda" }, { en: "Disappear", es: "Desaparecer" }], answerIndex: 2 },
-        { id: "mmz-q3", prompt: { en: "Which is the smartest path?", es: "¿Cuál es el camino más inteligente?" }, choices: [{ en: "The shortest path past a sweeper", es: "El camino más corto pasando un barredor" }, { en: "A longer path that avoids sweepers", es: "Un camino más largo que evita barredores" }, { en: "Standing still forever", es: "Quedarse quieto para siempre" }, { en: "The path with the most turns", es: "El camino con más giros" }], answerIndex: 1 },
+        {
+          id: "mmz-q1",
+          prompt: {
+            en: "Before moving through the maze, what should you do first?",
+            es: "Antes de moverte en el laberinto, ¿qué debes hacer primero?",
+          },
+          choices: [
+            {
+              en: "Run as fast as you can",
+              es: "Correr lo más rápido posible",
+            },
+            {
+              en: "Watch the sweeper's pattern",
+              es: "Observar el patrón del barredor",
+            },
+            {
+              en: "Close your eyes and guess",
+              es: "Cerrar los ojos y adivinar",
+            },
+            { en: "Pick the shortest path", es: "Elegir el camino más corto" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "mmz-q2",
+          prompt: {
+            en: "A sweeper moves left, right, left, right. What does it do next?",
+            es: "Un barredor se mueve izquierda, derecha, izquierda, derecha. ¿Qué hace después?",
+          },
+          choices: [
+            { en: "Stop", es: "Parar" },
+            { en: "Move up", es: "Ir arriba" },
+            { en: "Move left", es: "Ir a la izquierda" },
+            { en: "Disappear", es: "Desaparecer" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "mmz-q3",
+          prompt: {
+            en: "Which is the smartest path?",
+            es: "¿Cuál es el camino más inteligente?",
+          },
+          choices: [
+            {
+              en: "The shortest path past a sweeper",
+              es: "El camino más corto pasando un barredor",
+            },
+            {
+              en: "A longer path that avoids sweepers",
+              es: "Un camino más largo que evita barredores",
+            },
+            {
+              en: "Standing still forever",
+              es: "Quedarse quieto para siempre",
+            },
+            {
+              en: "The path with the most turns",
+              es: "El camino con más giros",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -955,18 +1793,106 @@ async function main() {
       story: {
         title: "Story: Body Lab",
         slides: [
-          { id: "mmi-s1", text: { en: "Welcome to the Motion Lab! Today you're the scientist AND the athlete. You'll run, jump, and throw — then measure how you did.", es: "¡Bienvenido al Laboratorio de Movimiento! Hoy eres el científico Y el atleta. Correrás, saltarás y lanzarás — luego medirás cómo te fue." }, icon: "🏃" },
-          { id: "mmi-s2", text: { en: "But here's what makes a real scientist — after you measure, you get to IMPROVE. Pick one coaching tip, try again, and see if your numbers go up.", es: "Pero esto es lo que hace a un verdadero científico — después de medir, puedes MEJORAR. Elige un consejo, inténtalo de nuevo y mira si tus números suben." }, icon: "📏" },
-          { id: "mmi-s3", text: { en: "Ready to test your body and your brain? Let's go!", es: "¿Listo para probar tu cuerpo y tu cerebro? ¡Vamos!" }, icon: "💪" },
+          {
+            id: "mmi-s1",
+            text: {
+              en: "Welcome to the Motion Lab! Today you're the scientist AND the athlete. You'll run, jump, and throw — then measure how you did.",
+              es: "¡Bienvenido al Laboratorio de Movimiento! Hoy eres el científico Y el atleta. Correrás, saltarás y lanzarás — luego medirás cómo te fue.",
+            },
+            icon: "🏃",
+          },
+          {
+            id: "mmi-s2",
+            text: {
+              en: "But here's what makes a real scientist — after you measure, you get to IMPROVE. Pick one coaching tip, try again, and see if your numbers go up.",
+              es: "Pero esto es lo que hace a un verdadero científico — después de medir, puedes MEJORAR. Elige un consejo, inténtalo de nuevo y mira si tus números suben.",
+            },
+            icon: "📏",
+          },
+          {
+            id: "mmi-s3",
+            text: {
+              en: "Ready to test your body and your brain? Let's go!",
+              es: "¿Listo para probar tu cuerpo y tu cerebro? ¡Vamos!",
+            },
+            icon: "💪",
+          },
         ],
         questions: [
-          { id: "mmi-q1", prompt: { en: "How do you know you got better at something?", es: "¿Cómo sabes que mejoraste en algo?" }, choices: [{ en: "Measure and compare", es: "Medir y comparar" }, { en: "Guess", es: "Adivinar" }, { en: "Ask a fish", es: "Preguntar a un pez" }, { en: "Just feel it", es: "Solo sentirlo" }], answerIndex: 0 },
+          {
+            id: "mmi-q1",
+            prompt: {
+              en: "How do you know you got better at something?",
+              es: "¿Cómo sabes que mejoraste en algo?",
+            },
+            choices: [
+              { en: "Measure and compare", es: "Medir y comparar" },
+              { en: "Guess", es: "Adivinar" },
+              { en: "Ask a fish", es: "Preguntar a un pez" },
+              { en: "Just feel it", es: "Solo sentirlo" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "mmv-q1", prompt: { en: "What should you do after your first try?", es: "¿Qué debes hacer después de tu primer intento?" }, choices: [{ en: "Give up", es: "Rendirse" }, { en: "Try the exact same thing again", es: "Intentar exactamente lo mismo" }, { en: "Look at your results and pick one thing to change", es: "Mirar tus resultados y elegir una cosa para cambiar" }, { en: "Change everything at once", es: "Cambiar todo a la vez" }], answerIndex: 2 },
-        { id: "mmv-q2", prompt: { en: "Which body part helps the most with jumping?", es: "¿Qué parte del cuerpo ayuda más a saltar?" }, choices: [{ en: "Your arms", es: "Tus brazos" }, { en: "Your legs", es: "Tus piernas" }, { en: "Your ears", es: "Tus orejas" }, { en: "Your neck", es: "Tu cuello" }], answerIndex: 1 },
-        { id: "mmv-q3", prompt: { en: "You threw the ball 10 feet. Then you used a tip and threw it 14 feet. What happened?", es: "Lanzaste la pelota 10 pies. Luego usaste un consejo y la lanzaste 14 pies. ¿Qué pasó?" }, choices: [{ en: "Nothing changed", es: "Nada cambió" }, { en: "The tip helped you throw farther", es: "El consejo te ayudó a lanzar más lejos" }, { en: "You should try a different tip", es: "Deberías probar otro consejo" }, { en: "Throwing doesn't use your arms", es: "Lanzar no usa tus brazos" }], answerIndex: 1 },
+        {
+          id: "mmv-q1",
+          prompt: {
+            en: "What should you do after your first try?",
+            es: "¿Qué debes hacer después de tu primer intento?",
+          },
+          choices: [
+            { en: "Give up", es: "Rendirse" },
+            {
+              en: "Try the exact same thing again",
+              es: "Intentar exactamente lo mismo",
+            },
+            {
+              en: "Look at your results and pick one thing to change",
+              es: "Mirar tus resultados y elegir una cosa para cambiar",
+            },
+            { en: "Change everything at once", es: "Cambiar todo a la vez" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "mmv-q2",
+          prompt: {
+            en: "Which body part helps the most with jumping?",
+            es: "¿Qué parte del cuerpo ayuda más a saltar?",
+          },
+          choices: [
+            { en: "Your arms", es: "Tus brazos" },
+            { en: "Your legs", es: "Tus piernas" },
+            { en: "Your ears", es: "Tus orejas" },
+            { en: "Your neck", es: "Tu cuello" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "mmv-q3",
+          prompt: {
+            en: "You threw the ball 10 feet. Then you used a tip and threw it 14 feet. What happened?",
+            es: "Lanzaste la pelota 10 pies. Luego usaste un consejo y la lanzaste 14 pies. ¿Qué pasó?",
+          },
+          choices: [
+            { en: "Nothing changed", es: "Nada cambió" },
+            {
+              en: "The tip helped you throw farther",
+              es: "El consejo te ayudó a lanzar más lejos",
+            },
+            {
+              en: "You should try a different tip",
+              es: "Deberías probar otro consejo",
+            },
+            {
+              en: "Throwing doesn't use your arms",
+              es: "Lanzar no usa tus brazos",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -979,18 +1905,110 @@ async function main() {
       story: {
         title: "Story: Pattern Patrol",
         slides: [
-          { id: "ss-s1", text: { en: "Light drops are falling. Catch them in the right lane.", es: "Caen gotas de luz. Atrápalas en el carril correcto." }, icon: "🌌" },
-          { id: "ss-s2", text: { en: "Watch the pattern: blue, gold, blue, gold...", es: "Mira el patrón: azul, dorado, azul, dorado..." }, icon: "🔍" },
-          { id: "ss-s3", text: { en: "If a light is mystery, tap Scan first.", es: "Si una luz es misterio, toca Escanear primero." }, icon: "🛡️" },
+          {
+            id: "ss-s1",
+            text: {
+              en: "Light drops are falling. Catch them in the right lane.",
+              es: "Caen gotas de luz. Atrápalas en el carril correcto.",
+            },
+            icon: "🌌",
+          },
+          {
+            id: "ss-s2",
+            text: {
+              en: "Watch the pattern: blue, gold, blue, gold...",
+              es: "Mira el patrón: azul, dorado, azul, dorado...",
+            },
+            icon: "🔍",
+          },
+          {
+            id: "ss-s3",
+            text: {
+              en: "If a light is mystery, tap Scan first.",
+              es: "Si una luz es misterio, toca Escanear primero.",
+            },
+            icon: "🛡️",
+          },
         ],
         questions: [
-          { id: "ss-q1", prompt: { en: "What is a pattern?", es: "¿Qué es un patrón?" }, choices: [{ en: "Something that repeats", es: "Algo que se repite" }, { en: "A random mess", es: "Un desorden" }, { en: "A color", es: "Un color" }, { en: "A loud sound", es: "Un sonido fuerte" }], answerIndex: 0, hint: { en: "Look for what repeats.", es: "Busca lo que se repite." } },
+          {
+            id: "ss-q1",
+            prompt: { en: "What is a pattern?", es: "¿Qué es un patrón?" },
+            choices: [
+              { en: "Something that repeats", es: "Algo que se repite" },
+              { en: "A random mess", es: "Un desorden" },
+              { en: "A color", es: "Un color" },
+              { en: "A loud sound", es: "Un sonido fuerte" },
+            ],
+            answerIndex: 0,
+            hint: {
+              en: "Look for what repeats.",
+              es: "Busca lo que se repite.",
+            },
+          },
         ],
       },
       quiz: [
-        { id: "ss-qz1", prompt: { en: "Blue, gold, blue, gold, blue. What comes next?", es: "Azul, dorado, azul, dorado, azul. ¿Qué sigue?" }, choices: [{ en: "Blue", es: "Azul" }, { en: "Gold", es: "Dorado" }, { en: "Red", es: "Rojo" }, { en: "Green", es: "Verde" }], answerIndex: 1, hint: { en: "Say the pattern out loud.", es: "Di el patrón en voz alta." } },
-        { id: "ss-qz2", prompt: { en: "You see a mystery light. What should you do?", es: "Ves una luz misteriosa. ¿Qué debes hacer?" }, choices: [{ en: "Guess fast", es: "Adivinar rápido" }, { en: "Tap Scan first", es: "Tocar Escanear primero" }, { en: "Run away", es: "Huir" }, { en: "Skip your turn", es: "Saltar tu turno" }], answerIndex: 1, hint: { en: "Scan helps you check before choosing.", es: "Escanear te ayuda a revisar antes de elegir." } },
-        { id: "ss-qz3", prompt: { en: "Why watch before you choose?", es: "¿Por qué mirar antes de elegir?" }, choices: [{ en: "To predict the next drop", es: "Para predecir la próxima gota" }, { en: "To make it harder", es: "Para hacerlo más difícil" }, { en: "Because patterns do not matter", es: "Porque los patrones no importan" }, { en: "To lose points", es: "Para perder puntos" }], answerIndex: 0, hint: { en: "Watching helps your brain plan.", es: "Mirar ayuda a tu cerebro a planear." } },
+        {
+          id: "ss-qz1",
+          prompt: {
+            en: "Blue, gold, blue, gold, blue. What comes next?",
+            es: "Azul, dorado, azul, dorado, azul. ¿Qué sigue?",
+          },
+          choices: [
+            { en: "Blue", es: "Azul" },
+            { en: "Gold", es: "Dorado" },
+            { en: "Red", es: "Rojo" },
+            { en: "Green", es: "Verde" },
+          ],
+          answerIndex: 1,
+          hint: {
+            en: "Say the pattern out loud.",
+            es: "Di el patrón en voz alta.",
+          },
+        },
+        {
+          id: "ss-qz2",
+          prompt: {
+            en: "You see a mystery light. What should you do?",
+            es: "Ves una luz misteriosa. ¿Qué debes hacer?",
+          },
+          choices: [
+            { en: "Guess fast", es: "Adivinar rápido" },
+            { en: "Tap Scan first", es: "Tocar Escanear primero" },
+            { en: "Run away", es: "Huir" },
+            { en: "Skip your turn", es: "Saltar tu turno" },
+          ],
+          answerIndex: 1,
+          hint: {
+            en: "Scan helps you check before choosing.",
+            es: "Escanear te ayuda a revisar antes de elegir.",
+          },
+        },
+        {
+          id: "ss-qz3",
+          prompt: {
+            en: "Why watch before you choose?",
+            es: "¿Por qué mirar antes de elegir?",
+          },
+          choices: [
+            {
+              en: "To predict the next drop",
+              es: "Para predecir la próxima gota",
+            },
+            { en: "To make it harder", es: "Para hacerlo más difícil" },
+            {
+              en: "Because patterns do not matter",
+              es: "Porque los patrones no importan",
+            },
+            { en: "To lose points", es: "Para perder puntos" },
+          ],
+          answerIndex: 0,
+          hint: {
+            en: "Watching helps your brain plan.",
+            es: "Mirar ayuda a tu cerebro a planear.",
+          },
+        },
       ],
     },
     {
@@ -1003,18 +2021,100 @@ async function main() {
       story: {
         title: "Story: Signal School",
         slides: [
-          { id: "fl-s1", text: { en: "You're driving the science delivery cart today! The lab needs these supplies FAST — but the road is full of obstacles. Cones, puddles, and blocked lanes are everywhere.", es: "¡Hoy conduces el carrito de entregas del laboratorio! El laboratorio necesita estos materiales RÁPIDO — pero el camino está lleno de obstáculos. Conos, charcos y carriles bloqueados por todas partes." }, icon: "🚦" },
-          { id: "fl-s2", text: { en: "Follow the road signals: green arrow means GO, yellow means GET READY, red X means AVOID. The safest driver wins — not the fastest!", es: "Sigue las señales del camino: flecha verde significa AVANZA, amarillo significa PREPÁRATE, X roja significa EVITA. ¡El conductor más seguro gana — no el más rápido!" }, icon: "🤔" },
-          { id: "fl-s3", text: { en: "Watch ahead, read the signs, and deliver those supplies safely. Let's roll!", es: "Mira adelante, lee las señales y entrega los materiales con seguridad. ¡Vamos!" }, icon: "⏱️" },
+          {
+            id: "fl-s1",
+            text: {
+              en: "You're driving the science delivery cart today! The lab needs these supplies FAST — but the road is full of obstacles. Cones, puddles, and blocked lanes are everywhere.",
+              es: "¡Hoy conduces el carrito de entregas del laboratorio! El laboratorio necesita estos materiales RÁPIDO — pero el camino está lleno de obstáculos. Conos, charcos y carriles bloqueados por todas partes.",
+            },
+            icon: "🚦",
+          },
+          {
+            id: "fl-s2",
+            text: {
+              en: "Follow the road signals: green arrow means GO, yellow means GET READY, red X means AVOID. The safest driver wins — not the fastest!",
+              es: "Sigue las señales del camino: flecha verde significa AVANZA, amarillo significa PREPÁRATE, X roja significa EVITA. ¡El conductor más seguro gana — no el más rápido!",
+            },
+            icon: "🤔",
+          },
+          {
+            id: "fl-s3",
+            text: {
+              en: "Watch ahead, read the signs, and deliver those supplies safely. Let's roll!",
+              es: "Mira adelante, lee las señales y entrega los materiales con seguridad. ¡Vamos!",
+            },
+            icon: "⏱️",
+          },
         ],
         questions: [
-          { id: "fl-q1", prompt: { en: "What does a green signal mean?", es: "¿Qué significa una señal verde?" }, choices: [{ en: "Go", es: "Avanzar" }, { en: "Stop", es: "Parar" }, { en: "Sleep", es: "Dormir" }, { en: "Wait", es: "Esperar" }], answerIndex: 0 },
+          {
+            id: "fl-q1",
+            prompt: {
+              en: "What does a green signal mean?",
+              es: "¿Qué significa una señal verde?",
+            },
+            choices: [
+              { en: "Go", es: "Avanzar" },
+              { en: "Stop", es: "Parar" },
+              { en: "Sleep", es: "Dormir" },
+              { en: "Wait", es: "Esperar" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "fl-qz1", prompt: { en: "You see a yellow road sign. What does it mean?", es: "Ves una señal amarilla. ¿Qué significa?" }, choices: [{ en: "Speed up", es: "Acelerar" }, { en: "Stop immediately", es: "Parar inmediatamente" }, { en: "Get ready — something is about to change", es: "Prepárate — algo está a punto de cambiar" }, { en: "Close your eyes", es: "Cerrar los ojos" }], answerIndex: 2 },
-        { id: "fl-qz2", prompt: { en: "What matters most when driving the delivery cart?", es: "¿Qué es lo más importante al conducir el carrito de entregas?" }, choices: [{ en: "Going as fast as possible", es: "Ir lo más rápido posible" }, { en: "Getting there safely", es: "Llegar con seguridad" }, { en: "Crashing into every cone", es: "Chocarse con cada cono" }, { en: "Ignoring the signs", es: "Ignorar las señales" }], answerIndex: 1 },
-        { id: "fl-qz3", prompt: { en: "There's a boost pad in a lane with a red X. What should you do?", es: "Hay un impulso en un carril con una X roja. ¿Qué debes hacer?" }, choices: [{ en: "Go for the boost", es: "Ir por el impulso" }, { en: "Avoid that lane — red X means danger", es: "Evitar ese carril — X roja significa peligro" }, { en: "Stop the cart", es: "Parar el carrito" }, { en: "Switch to a random lane", es: "Cambiar a un carril aleatorio" }], answerIndex: 1 },
+        {
+          id: "fl-qz1",
+          prompt: {
+            en: "You see a yellow road sign. What does it mean?",
+            es: "Ves una señal amarilla. ¿Qué significa?",
+          },
+          choices: [
+            { en: "Speed up", es: "Acelerar" },
+            { en: "Stop immediately", es: "Parar inmediatamente" },
+            {
+              en: "Get ready — something is about to change",
+              es: "Prepárate — algo está a punto de cambiar",
+            },
+            { en: "Close your eyes", es: "Cerrar los ojos" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "fl-qz2",
+          prompt: {
+            en: "What matters most when driving the delivery cart?",
+            es: "¿Qué es lo más importante al conducir el carrito de entregas?",
+          },
+          choices: [
+            { en: "Going as fast as possible", es: "Ir lo más rápido posible" },
+            { en: "Getting there safely", es: "Llegar con seguridad" },
+            { en: "Crashing into every cone", es: "Chocarse con cada cono" },
+            { en: "Ignoring the signs", es: "Ignorar las señales" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "fl-qz3",
+          prompt: {
+            en: "There's a boost pad in a lane with a red X. What should you do?",
+            es: "Hay un impulso en un carril con una X roja. ¿Qué debes hacer?",
+          },
+          choices: [
+            { en: "Go for the boost", es: "Ir por el impulso" },
+            {
+              en: "Avoid that lane — red X means danger",
+              es: "Evitar ese carril — X roja significa peligro",
+            },
+            { en: "Stop the cart", es: "Parar el carrito" },
+            {
+              en: "Switch to a random lane",
+              es: "Cambiar a un carril aleatorio",
+            },
+          ],
+          answerIndex: 1,
+        },
       ],
     },
     {
@@ -1027,19 +2127,126 @@ async function main() {
       story: {
         title: "Story: Race Lab",
         slides: [
-          { id: "qtr-s1", text: { en: "Welcome to the engineering garage! Today you'll build, test, and improve your racer. But here's the rule: you can only change ONE thing at a time.", es: "¡Bienvenido al garaje de ingeniería! Hoy construirás, probarás y mejorarás tu corredor. Pero hay una regla: solo puedes cambiar UNA cosa a la vez." }, icon: "🏎️" },
-          { id: "qtr-s2", text: { en: "First, do a practice lap. Then look at your results — time, bumps, smoothness. Pick ONE upgrade: better tires, a speed boost, or steadier steering. Then race again!", es: "Primero, haz una vuelta de práctica. Luego mira tus resultados — tiempo, golpes, suavidad. Elige UNA mejora: mejores neumáticos, turbo de velocidad o dirección más estable. ¡Luego corre de nuevo!" }, icon: "🔧" },
-          { id: "qtr-s3", text: { en: "Real scientists test one change at a time. That's how you know what actually worked. Ready to qualify, tune, and race?", es: "Los científicos reales prueban un cambio a la vez. Así sabes qué realmente funcionó. ¿Listo para probar, ajustar y competir?" }, icon: "🧪" },
+          {
+            id: "qtr-s1",
+            text: {
+              en: "Welcome to the engineering garage! Today you'll build, test, and improve your racer. But here's the rule: you can only change ONE thing at a time.",
+              es: "¡Bienvenido al garaje de ingeniería! Hoy construirás, probarás y mejorarás tu corredor. Pero hay una regla: solo puedes cambiar UNA cosa a la vez.",
+            },
+            icon: "🏎️",
+          },
+          {
+            id: "qtr-s2",
+            text: {
+              en: "First, do a practice lap. Then look at your results — time, bumps, smoothness. Pick ONE upgrade: better tires, a speed boost, or steadier steering. Then race again!",
+              es: "Primero, haz una vuelta de práctica. Luego mira tus resultados — tiempo, golpes, suavidad. Elige UNA mejora: mejores neumáticos, turbo de velocidad o dirección más estable. ¡Luego corre de nuevo!",
+            },
+            icon: "🔧",
+          },
+          {
+            id: "qtr-s3",
+            text: {
+              en: "Real scientists test one change at a time. That's how you know what actually worked. Ready to qualify, tune, and race?",
+              es: "Los científicos reales prueban un cambio a la vez. Así sabes qué realmente funcionó. ¿Listo para probar, ajustar y competir?",
+            },
+            icon: "🧪",
+          },
         ],
         questions: [
-          { id: "qtr-q1", prompt: { en: "To make a fair test, how many things should you change at a time?", es: "Para hacer una prueba justa, ¿cuántas cosas debes cambiar a la vez?" }, choices: [{ en: "One", es: "Una" }, { en: "All of them", es: "Todas" }, { en: "None", es: "Ninguna" }, { en: "Three", es: "Tres" }], answerIndex: 0 },
+          {
+            id: "qtr-q1",
+            prompt: {
+              en: "To make a fair test, how many things should you change at a time?",
+              es: "Para hacer una prueba justa, ¿cuántas cosas debes cambiar a la vez?",
+            },
+            choices: [
+              { en: "One", es: "Una" },
+              { en: "All of them", es: "Todas" },
+              { en: "None", es: "Ninguna" },
+              { en: "Three", es: "Tres" },
+            ],
+            answerIndex: 0,
+          },
         ],
       },
       quiz: [
-        { id: "qtr-qz1", prompt: { en: "How many things should you change at a time when tuning?", es: "¿Cuántas cosas debes cambiar a la vez al ajustar?" }, choices: [{ en: "As many as possible", es: "Todas las posibles" }, { en: "Two", es: "Dos" }, { en: "One", es: "Una" }, { en: "None", es: "Ninguna" }], answerIndex: 2 },
-        { id: "qtr-qz2", prompt: { en: "Your first lap had 5 bumps. You added Grip Tires and your second lap had 2 bumps. What happened?", es: "Tu primera vuelta tuvo 5 golpes. Agregaste Neumáticos de Agarre y tu segunda vuelta tuvo 2 golpes. ¿Qué pasó?" }, choices: [{ en: "Nothing changed", es: "Nada cambió" }, { en: "Grip Tires helped you bump less", es: "Los neumáticos de agarre te ayudaron a golpear menos" }, { en: "The track got easier", es: "La pista se hizo más fácil" }, { en: "Bumps don't matter", es: "Los golpes no importan" }], answerIndex: 1 },
-        { id: "qtr-qz3", prompt: { en: "Why do engineers change only one thing at a time?", es: "¿Por qué los ingenieros cambian solo una cosa a la vez?" }, choices: [{ en: "Because they're slow", es: "Porque son lentos" }, { en: "So they know which change made the difference", es: "Para saber qué cambio hizo la diferencia" }, { en: "Because two changes would break everything", es: "Porque dos cambios romperían todo" }, { en: "They don't — they change everything", es: "No lo hacen — cambian todo" }], answerIndex: 1 },
-        { id: "qtr-qz4", prompt: { en: "You picked Speed Boost but bumped into more walls. What does that tell you?", es: "Elegiste Turbo de Velocidad pero chocaste con más paredes. ¿Qué te dice eso?" }, choices: [{ en: "Speed Boost made it harder to control", es: "El Turbo hizo más difícil de controlar" }, { en: "Speed Boost doesn't work", es: "El Turbo no funciona" }, { en: "You should always pick Speed Boost", es: "Siempre debes elegir Turbo" }, { en: "Bumps help you go faster", es: "Los golpes te ayudan a ir más rápido" }], answerIndex: 0 },
+        {
+          id: "qtr-qz1",
+          prompt: {
+            en: "How many things should you change at a time when tuning?",
+            es: "¿Cuántas cosas debes cambiar a la vez al ajustar?",
+          },
+          choices: [
+            { en: "As many as possible", es: "Todas las posibles" },
+            { en: "Two", es: "Dos" },
+            { en: "One", es: "Una" },
+            { en: "None", es: "Ninguna" },
+          ],
+          answerIndex: 2,
+        },
+        {
+          id: "qtr-qz2",
+          prompt: {
+            en: "Your first lap had 5 bumps. You added Grip Tires and your second lap had 2 bumps. What happened?",
+            es: "Tu primera vuelta tuvo 5 golpes. Agregaste Neumáticos de Agarre y tu segunda vuelta tuvo 2 golpes. ¿Qué pasó?",
+          },
+          choices: [
+            { en: "Nothing changed", es: "Nada cambió" },
+            {
+              en: "Grip Tires helped you bump less",
+              es: "Los neumáticos de agarre te ayudaron a golpear menos",
+            },
+            { en: "The track got easier", es: "La pista se hizo más fácil" },
+            { en: "Bumps don't matter", es: "Los golpes no importan" },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "qtr-qz3",
+          prompt: {
+            en: "Why do engineers change only one thing at a time?",
+            es: "¿Por qué los ingenieros cambian solo una cosa a la vez?",
+          },
+          choices: [
+            { en: "Because they're slow", es: "Porque son lentos" },
+            {
+              en: "So they know which change made the difference",
+              es: "Para saber qué cambio hizo la diferencia",
+            },
+            {
+              en: "Because two changes would break everything",
+              es: "Porque dos cambios romperían todo",
+            },
+            {
+              en: "They don't — they change everything",
+              es: "No lo hacen — cambian todo",
+            },
+          ],
+          answerIndex: 1,
+        },
+        {
+          id: "qtr-qz4",
+          prompt: {
+            en: "You picked Speed Boost but bumped into more walls. What does that tell you?",
+            es: "Elegiste Turbo de Velocidad pero chocaste con más paredes. ¿Qué te dice eso?",
+          },
+          choices: [
+            {
+              en: "Speed Boost made it harder to control",
+              es: "El Turbo hizo más difícil de controlar",
+            },
+            { en: "Speed Boost doesn't work", es: "El Turbo no funciona" },
+            {
+              en: "You should always pick Speed Boost",
+              es: "Siempre debes elegir Turbo",
+            },
+            {
+              en: "Bumps help you go faster",
+              es: "Los golpes te ayudan a ir más rápido",
+            },
+          ],
+          answerIndex: 0,
+        },
       ],
     },
   ];
@@ -1047,24 +2254,56 @@ async function main() {
   for (const s2 of set2Modules) {
     const mod = await prisma.module.upsert({
       where: { slug: s2.slug },
-      update: { title: s2.title, description: s2.description, level: "K-2", published: true },
-      create: { slug: s2.slug, title: s2.title, description: s2.description, level: "K-2", published: true },
+      update: {
+        title: s2.title,
+        description: s2.description,
+        level: "K-2",
+        published: true,
+      },
+      create: {
+        slug: s2.slug,
+        title: s2.title,
+        description: s2.description,
+        level: "K-2",
+        published: true,
+      },
     });
 
     // Get or create unit — use first unit of this module (not by title, which may have changed)
-    let s2Unit = await prisma.unit.findFirst({ where: { moduleId: mod.id }, orderBy: { order: "asc" } });
+    let s2Unit = await prisma.unit.findFirst({
+      where: { moduleId: mod.id },
+      orderBy: { order: "asc" },
+    });
     if (!s2Unit) {
-      s2Unit = await prisma.unit.create({ data: { title: "Unit 1", order: 1, Module: { connect: { id: mod.id } }, teacher: { connect: { id: teacher.id } } } });
+      s2Unit = await prisma.unit.create({
+        data: {
+          title: "Unit 1",
+          order: 1,
+          Module: { connect: { id: mod.id } },
+          teacher: { connect: { id: teacher.id } },
+        },
+      });
     }
 
     // Get or create lesson — use first lesson of this unit
-    let s2Lesson = await prisma.lesson.findFirst({ where: { unitId: s2Unit.id }, orderBy: { order: "asc" } });
+    let s2Lesson = await prisma.lesson.findFirst({
+      where: { unitId: s2Unit.id },
+      orderBy: { order: "asc" },
+    });
     if (!s2Lesson) {
-      s2Lesson = await prisma.lesson.create({ data: { title: s2.title, order: 1, Unit: { connect: { id: s2Unit.id } } } });
+      s2Lesson = await prisma.lesson.create({
+        data: {
+          title: s2.title,
+          order: 1,
+          Unit: { connect: { id: s2Unit.id } },
+        },
+      });
     }
 
     // Clean up duplicate lessons (from previous seed runs with different titles)
-    const allLessons = await prisma.lesson.findMany({ where: { unitId: s2Unit.id } });
+    const allLessons = await prisma.lesson.findMany({
+      where: { unitId: s2Unit.id },
+    });
     for (const dup of allLessons) {
       if (dup.id !== s2Lesson.id) {
         await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
@@ -1073,7 +2312,10 @@ async function main() {
     }
 
     // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
-    const existingActs = await prisma.activity.findMany({ where: { lessonId: s2Lesson.id }, orderBy: { order: "asc" } });
+    const existingActs = await prisma.activity.findMany({
+      where: { lessonId: s2Lesson.id },
+      orderBy: { order: "asc" },
+    });
     for (const act of existingActs) {
       if (act.order > 3) {
         await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
@@ -1085,23 +2327,57 @@ async function main() {
       type: "story_quiz",
       slides: s2.story.slides,
       questions: s2.story.questions,
-      review: { keyIdea: { en: s2.description }, vocab: [s2.strand.toLowerCase()] },
+      review: {
+        keyIdea: { en: s2.description },
+        vocab: [s2.strand.toLowerCase()],
+      },
     });
 
-    let storyAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, kind: INFO, order: 1 } });
+    let storyAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, kind: INFO, order: 1 },
+    });
     if (storyAct) {
-      await prisma.activity.update({ where: { id: storyAct.id }, data: { title: s2.story.title, content: storyContent } });
+      await prisma.activity.update({
+        where: { id: storyAct.id },
+        data: { title: s2.story.title, content: storyContent },
+      });
     } else {
-      await prisma.activity.create({ data: { title: s2.story.title, kind: INFO, order: 1, content: storyContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          title: s2.story.title,
+          kind: INFO,
+          order: 1,
+          content: storyContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     // Activity 2: Game (INTERACT)
     const gameContent = JSON.stringify({ gameKey: s2.gameKey });
-    let gameAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, kind: INTERACT, order: 2 } });
+    let gameAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, kind: INTERACT, order: 2 },
+    });
     if (gameAct) {
-      await prisma.activity.update({ where: { id: gameAct.id }, data: { id: s2.activityId, title: `Game: ${s2.title}`, content: gameContent } });
+      await prisma.activity.update({
+        where: { id: gameAct.id },
+        data: {
+          id: s2.activityId,
+          title: `Game: ${s2.title}`,
+          content: gameContent,
+        },
+      });
     } else {
-      await prisma.activity.create({ data: { id: s2.activityId, title: `Game: ${s2.title}`, kind: INTERACT, order: 2, content: gameContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          id: s2.activityId,
+          title: `Game: ${s2.title}`,
+          kind: INTERACT,
+          order: 2,
+          content: gameContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     // Activity 3: Quiz (INFO with quiz questions)
@@ -1110,14 +2386,313 @@ async function main() {
       slides: [],
       questions: s2.quiz ?? [],
     });
-    let quizAct = await prisma.activity.findFirst({ where: { lessonId: s2Lesson.id, order: 3 } });
+    let quizAct = await prisma.activity.findFirst({
+      where: { lessonId: s2Lesson.id, order: 3 },
+    });
     if (quizAct) {
-      await prisma.activity.update({ where: { id: quizAct.id }, data: { title: `Quiz: ${s2.title}`, kind: INFO, content: quizContent } });
+      await prisma.activity.update({
+        where: { id: quizAct.id },
+        data: { title: `Quiz: ${s2.title}`, kind: INFO, content: quizContent },
+      });
     } else {
-      await prisma.activity.create({ data: { title: `Quiz: ${s2.title}`, kind: INFO, order: 3, content: quizContent, Lesson: { connect: { id: s2Lesson.id } } } });
+      await prisma.activity.create({
+        data: {
+          title: `Quiz: ${s2.title}`,
+          kind: INFO,
+          order: 3,
+          content: quizContent,
+          Lesson: { connect: { id: s2Lesson.id } },
+        },
+      });
     }
 
     console.log("Seeded Set 2 module:", s2.slug, "(story + game + quiz)");
+  }
+
+  // ---------------------------------------------------------------------
+  // SET 3 — Mastery ("mastery through making"; game 1 only, GATED from
+  // students via HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts — the
+  // module is seeded + published so ungating is a one-line frontend change).
+  // ---------------------------------------------------------------------
+  const set3Modules = [
+    {
+      slug: "k2-stem-track-maker",
+      title: "Boost Track Builder",
+      description: "Build your own motorcycle track, then ride it! 🏍️🛠️",
+      activityId: "track-maker",
+      gameKey: "track_maker",
+      strand: "Quantum",
+      story: {
+        title: "Story: Boost's New Wheels",
+        slides: [
+          {
+            id: "tm-s1",
+            text: {
+              en: "Boost just got a shiny motorcycle — vroom! But there's a problem: there's no track to ride it on. Guess who gets to build one? YOU!",
+              es: "¡Boost tiene una moto nueva y brillante — brum! Pero hay un problema: no hay pista para montarla. ¿Adivina quién va a construir una? ¡TÚ!",
+            },
+            icon: "🏍️",
+          },
+          {
+            id: "tm-s2",
+            text: {
+              en: "Here's Boost's builder tip: bikes love straights, but curves are tricky. Go too fast into a sharp curve and — whoaaa — spin-out! Good builders think about speed.",
+              es: "El consejo de Boost: a las motos les encantan las rectas, pero las curvas son difíciles. Si entras muy rápido a una curva cerrada — ¡uuuy — trompo! Los buenos constructores piensan en la velocidad.",
+            },
+            icon: "🛠️",
+          },
+          {
+            id: "tm-s3",
+            text: {
+              en: "Build your track, ride it, and make it better each time. Every wobble teaches you something. Ready, builder?",
+              es: "Construye tu pista, móntala y mejórala cada vez. Cada tambaleo te enseña algo. ¿Listo, constructor?",
+            },
+            icon: "⭐",
+          },
+        ],
+        questions: [
+          {
+            id: "tm-q1",
+            prompt: {
+              en: "What happens if the bike goes too fast into a sharp curve?",
+              es: "¿Qué pasa si la moto entra muy rápido a una curva cerrada?",
+            },
+            choices: [
+              { en: "It spins out", es: "Da un trompo" },
+              { en: "It flies away", es: "Sale volando" },
+              { en: "Nothing happens", es: "No pasa nada" },
+              { en: "It gets bigger", es: "Se hace más grande" },
+            ],
+            answerIndex: 0,
+          },
+        ],
+      },
+      quiz: [
+        {
+          id: "tmz-q1",
+          prompt: {
+            en: "The bike keeps spinning out on your sharp curve. What could help?",
+            es: "La moto sigue dando trompos en tu curva cerrada. ¿Qué podría ayudar?",
+          },
+          choices: [
+            {
+              en: "Slow down before the curve",
+              es: "Frenar antes de la curva",
+            },
+            {
+              en: "Put a boost pad right before it",
+              es: "Poner un acelerador justo antes",
+            },
+            { en: "Ride faster", es: "Ir más rápido" },
+            { en: "Close your eyes", es: "Cerrar los ojos" },
+          ],
+          answerIndex: 0,
+        },
+        {
+          id: "tmz-q2",
+          prompt: {
+            en: "Your ride didn't go how you wanted. What does a good builder do?",
+            es: "Tu paseo no salió como querías. ¿Qué hace un buen constructor?",
+          },
+          choices: [
+            {
+              en: "Change the track and try again",
+              es: "Cambiar la pista y probar otra vez",
+            },
+            {
+              en: "Stop building forever",
+              es: "Dejar de construir para siempre",
+            },
+            { en: "Blame the bike", es: "Culpar a la moto" },
+            { en: "Delete everything", es: "Borrar todo" },
+          ],
+          answerIndex: 0,
+        },
+        {
+          id: "tmz-q3",
+          prompt: {
+            en: "What does a boost pad do?",
+            es: "¿Qué hace un acelerador?",
+          },
+          choices: [
+            {
+              en: "Makes the bike zoom fast",
+              es: "Hace que la moto vaya súper rápido",
+            },
+            { en: "Stops the bike", es: "Detiene la moto" },
+            { en: "Paints the bike", es: "Pinta la moto" },
+            { en: "Makes the track longer", es: "Alarga la pista" },
+          ],
+          answerIndex: 0,
+        },
+      ],
+    },
+  ];
+
+  for (const s3 of set3Modules) {
+    const mod = await prisma.module.upsert({
+      where: { slug: s3.slug },
+      update: {
+        title: s3.title,
+        description: s3.description,
+        level: "K-2",
+        published: true,
+      },
+      create: {
+        slug: s3.slug,
+        title: s3.title,
+        description: s3.description,
+        level: "K-2",
+        published: true,
+      },
+    });
+
+    // Get or create unit — use first unit of this module (not by title, which may have changed)
+    let s3Unit = await prisma.unit.findFirst({
+      where: { moduleId: mod.id },
+      orderBy: { order: "asc" },
+    });
+    if (!s3Unit) {
+      s3Unit = await prisma.unit.create({
+        data: {
+          title: "Unit 1",
+          order: 1,
+          Module: { connect: { id: mod.id } },
+          teacher: { connect: { id: teacher.id } },
+        },
+      });
+    }
+
+    // Get or create lesson — use first lesson of this unit
+    let s3Lesson = await prisma.lesson.findFirst({
+      where: { unitId: s3Unit.id },
+      orderBy: { order: "asc" },
+    });
+    if (!s3Lesson) {
+      s3Lesson = await prisma.lesson.create({
+        data: {
+          title: s3.title,
+          order: 1,
+          Unit: { connect: { id: s3Unit.id } },
+        },
+      });
+    }
+
+    // Clean up duplicate lessons (from previous seed runs with different titles)
+    const allS3Lessons = await prisma.lesson.findMany({
+      where: { unitId: s3Unit.id },
+    });
+    for (const dup of allS3Lessons) {
+      if (dup.id !== s3Lesson.id) {
+        await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
+        await prisma.lesson.delete({ where: { id: dup.id } }).catch(() => {});
+      }
+    }
+
+    // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
+    const existingS3Acts = await prisma.activity.findMany({
+      where: { lessonId: s3Lesson.id },
+      orderBy: { order: "asc" },
+    });
+    for (const act of existingS3Acts) {
+      if (act.order > 3) {
+        await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
+      }
+    }
+
+    // Activity 1: Story (INFO)
+    const s3StoryContent = JSON.stringify({
+      type: "story_quiz",
+      slides: s3.story.slides,
+      questions: s3.story.questions,
+      review: {
+        keyIdea: { en: s3.description },
+        vocab: [s3.strand.toLowerCase()],
+      },
+    });
+
+    let s3StoryAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, kind: INFO, order: 1 },
+    });
+    if (s3StoryAct) {
+      await prisma.activity.update({
+        where: { id: s3StoryAct.id },
+        data: { title: s3.story.title, content: s3StoryContent },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          title: s3.story.title,
+          kind: INFO,
+          order: 1,
+          content: s3StoryContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    // Activity 2: Game (INTERACT)
+    const s3GameContent = JSON.stringify({ gameKey: s3.gameKey });
+    let s3GameAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, kind: INTERACT, order: 2 },
+    });
+    if (s3GameAct) {
+      await prisma.activity.update({
+        where: { id: s3GameAct.id },
+        data: {
+          id: s3.activityId,
+          title: `Game: ${s3.title}`,
+          content: s3GameContent,
+        },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          id: s3.activityId,
+          title: `Game: ${s3.title}`,
+          kind: INTERACT,
+          order: 2,
+          content: s3GameContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    // Activity 3: Quiz (INFO with quiz questions)
+    const s3QuizContent = JSON.stringify({
+      type: "story_quiz",
+      slides: [],
+      questions: s3.quiz ?? [],
+    });
+    let s3QuizAct = await prisma.activity.findFirst({
+      where: { lessonId: s3Lesson.id, order: 3 },
+    });
+    if (s3QuizAct) {
+      await prisma.activity.update({
+        where: { id: s3QuizAct.id },
+        data: {
+          title: `Quiz: ${s3.title}`,
+          kind: INFO,
+          content: s3QuizContent,
+        },
+      });
+    } else {
+      await prisma.activity.create({
+        data: {
+          title: `Quiz: ${s3.title}`,
+          kind: INFO,
+          order: 3,
+          content: s3QuizContent,
+          Lesson: { connect: { id: s3Lesson.id } },
+        },
+      });
+    }
+
+    console.log(
+      "Seeded Set 3 module:",
+      s3.slug,
+      "(story + game + quiz — gated)",
+    );
   }
 
   console.log("Seeding units...");
@@ -1173,25 +2748,28 @@ async function main() {
     where: { lessonId: lesson.id, title: "Build a Bot" },
   });
   if (buildBot) {
-    await prisma.activity.delete({ where: { id: buildBot.id } }).catch(() => {});
+    await prisma.activity
+      .delete({ where: { id: buildBot.id } })
+      .catch(() => {});
     console.log("Cleaned up removed Build-a-Bot activity.");
   }
   console.log("Seeded activities.");
-
 
   // ── Grade 3-5 first playable module: Data Dash: Sort & Discover ──
   const g35DataDashModule = await prisma.module.upsert({
     where: { slug: "g35-data-dash-sort-discover" },
     update: {
       title: "Data Dash: Sort & Discover",
-      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      description:
+        "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
       level: "G3-5",
       published: true,
     },
     create: {
       slug: "g35-data-dash-sort-discover",
       title: "Data Dash: Sort & Discover",
-      description: "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
+      description:
+        "Classify plant data with multiple attributes, infer rules, and support claims with chart evidence.",
       level: "G3-5",
       published: true,
     },
@@ -1199,7 +2777,10 @@ async function main() {
   console.log("Created module:", g35DataDashModule.slug);
 
   let g35DataDashUnit = await prisma.unit.findFirst({
-    where: { moduleId: g35DataDashModule.id, title: "Unit 1: Greenhouse Data Lab" },
+    where: {
+      moduleId: g35DataDashModule.id,
+      title: "Unit 1: Greenhouse Data Lab",
+    },
   });
   if (!g35DataDashUnit) {
     g35DataDashUnit = await prisma.unit.create({
@@ -1213,7 +2794,10 @@ async function main() {
   }
 
   let g35DataDashLesson = await prisma.lesson.findFirst({
-    where: { unitId: g35DataDashUnit.id, title: "Lesson 1: Sort, Infer, Explain" },
+    where: {
+      unitId: g35DataDashUnit.id,
+      title: "Lesson 1: Sort, Infer, Explain",
+    },
   });
   if (!g35DataDashLesson) {
     g35DataDashLesson = await prisma.lesson.create({
@@ -1264,64 +2848,148 @@ async function main() {
     questions: [
       {
         id: "dd-q1",
-        prompt: { en: "Which choice is a classification rule (not just one observation)?", es: "¿Qué opción es una regla de clasificación (no solo una observación)?" },
+        prompt: {
+          en: "Which choice is a classification rule (not just one observation)?",
+          es: "¿Qué opción es una regla de clasificación (no solo una observación)?",
+        },
         choices: [
-          { en: "Group plants by seed type", es: "Agrupar plantas por tipo de semilla" },
-          { en: "This fern needs high water", es: "Este helecho necesita mucha agua" },
-          { en: "Plant bed A has three plants", es: "La cama de plantas A tiene tres plantas" },
-          { en: "Card 4 has the prettiest flowers", es: "La tarjeta 4 tiene las flores más bonitas" }
+          {
+            en: "Group plants by seed type",
+            es: "Agrupar plantas por tipo de semilla",
+          },
+          {
+            en: "This fern needs high water",
+            es: "Este helecho necesita mucha agua",
+          },
+          {
+            en: "Plant bed A has three plants",
+            es: "La cama de plantas A tiene tres plantas",
+          },
+          {
+            en: "Card 4 has the prettiest flowers",
+            es: "La tarjeta 4 tiene las flores más bonitas",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "A rule can be used on every card.", es: "Una regla puede usarse en cada tarjeta." }
+        hint: {
+          en: "A rule can be used on every card.",
+          es: "Una regla puede usarse en cada tarjeta.",
+        },
       },
       {
         id: "dd-q2",
-        prompt: { en: "If two cards both have cone seeds, what is true?", es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?" },
+        prompt: {
+          en: "If two cards both have cone seeds, what is true?",
+          es: "Si dos tarjetas tienen semillas en cono, ¿qué es verdadero?",
+        },
         choices: [
           { en: "They match on seed type", es: "Coinciden en tipo de semilla" },
-          { en: "They must be in the same plant bed", es: "Deben estar en la misma cama de plantas" },
-          { en: "They must need the same water", es: "Deben necesitar la misma agua" },
-          { en: "They must be the same color", es: "Deben ser del mismo color" }
+          {
+            en: "They must be in the same plant bed",
+            es: "Deben estar en la misma cama de plantas",
+          },
+          {
+            en: "They must need the same water",
+            es: "Deben necesitar la misma agua",
+          },
+          {
+            en: "They must be the same color",
+            es: "Deben ser del mismo color",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Look only at the named attribute.", es: "Mira solo el atributo nombrado." }
+        hint: {
+          en: "Look only at the named attribute.",
+          es: "Mira solo el atributo nombrado.",
+        },
       },
       {
         id: "dd-q3",
-        prompt: { en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?", es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?" },
+        prompt: {
+          en: "A chart shows full sunlight = 5, shade = 2, partial = 1. Which claim is best supported?",
+          es: "Un gráfico muestra luz solar completa = 5, sombra = 2, parcial = 1. ¿Qué afirmación está mejor respaldada?",
+        },
         choices: [
-          { en: "Most plants need full sunlight", es: "La mayoría de las plantas necesitan luz solar completa" },
-          { en: "All plants need shade", es: "Todas las plantas necesitan sombra" },
-          { en: "No plants need partial sunlight", es: "Ninguna planta necesita luz solar parcial" },
-          { en: "Plants prefer shade over sunlight", es: "Las plantas prefieren la sombra al sol" }
+          {
+            en: "Most plants need full sunlight",
+            es: "La mayoría de las plantas necesitan luz solar completa",
+          },
+          {
+            en: "All plants need shade",
+            es: "Todas las plantas necesitan sombra",
+          },
+          {
+            en: "No plants need partial sunlight",
+            es: "Ninguna planta necesita luz solar parcial",
+          },
+          {
+            en: "Plants prefer shade over sunlight",
+            es: "Las plantas prefieren la sombra al sol",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Choose the claim that matches the largest count.", es: "Elige la afirmación que coincide con el mayor conteo." }
+        hint: {
+          en: "Choose the claim that matches the largest count.",
+          es: "Elige la afirmación que coincide con el mayor conteo.",
+        },
       },
       {
         id: "dd-q4",
-        prompt: { en: "What is the strongest evidence for your claim?", es: "¿Cuál es la evidencia más fuerte para tu afirmación?" },
+        prompt: {
+          en: "What is the strongest evidence for your claim?",
+          es: "¿Cuál es la evidencia más fuerte para tu afirmación?",
+        },
         choices: [
-          { en: "The full-sun bar is tallest", es: "La barra de sol completo es la más alta" },
-          { en: "I like full-sun plants", es: "Me gustan las plantas de sol completo" },
-          { en: "My friend chose that answer", es: "Mi amigo eligió esa respuesta" },
-          { en: "It just felt like the right answer", es: "Sentí que era la respuesta correcta" }
+          {
+            en: "The full-sun bar is tallest",
+            es: "La barra de sol completo es la más alta",
+          },
+          {
+            en: "I like full-sun plants",
+            es: "Me gustan las plantas de sol completo",
+          },
+          {
+            en: "My friend chose that answer",
+            es: "Mi amigo eligió esa respuesta",
+          },
+          {
+            en: "It just felt like the right answer",
+            es: "Sentí que era la respuesta correcta",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "Evidence comes from measured data.", es: "La evidencia proviene de datos medidos." }
+        hint: {
+          en: "Evidence comes from measured data.",
+          es: "La evidencia proviene de datos medidos.",
+        },
       },
       {
         id: "dd-q5",
-        prompt: { en: "Why is multi-attribute sorting useful?", es: "¿Por qué es útil clasificar por múltiples atributos?" },
+        prompt: {
+          en: "Why is multi-attribute sorting useful?",
+          es: "¿Por qué es útil clasificar por múltiples atributos?",
+        },
         choices: [
-          { en: "It helps find deeper patterns and better explanations", es: "Ayuda a encontrar patrones más profundos y mejores explicaciones" },
+          {
+            en: "It helps find deeper patterns and better explanations",
+            es: "Ayuda a encontrar patrones más profundos y mejores explicaciones",
+          },
           { en: "It makes data random", es: "Hace los datos aleatorios" },
-          { en: "It removes the need for evidence", es: "Elimina la necesidad de evidencia" },
-          { en: "It makes sorting faster than using one attribute", es: "Hace que clasificar sea más rápido que usar un atributo" }
+          {
+            en: "It removes the need for evidence",
+            es: "Elimina la necesidad de evidencia",
+          },
+          {
+            en: "It makes sorting faster than using one attribute",
+            es: "Hace que clasificar sea más rápido que usar un atributo",
+          },
         ],
         answerIndex: 0,
-        hint: { en: "More than one attribute can reveal hidden structure.", es: "Más de un atributo puede revelar estructura oculta." }
-      }
+        hint: {
+          en: "More than one attribute can reveal hidden structure.",
+          es: "Más de un atributo puede revelar estructura oculta.",
+        },
+      },
     ],
   });
 
@@ -1384,167 +3052,355 @@ async function main() {
   // ═══════════════════════════════════════════════════════════════════════════
   console.log("Seeding module families and variants...");
   try {
+    const familyDefs = [
+      {
+        key: "quantum_quest",
+        title: "Quantum Foundations",
+        iconEmoji: "⚛️",
+        k2: {
+          title: "Quantum Quest",
+          subtitle: "Explore quantum puzzles in a space math adventure!",
+          moduleSlug: "k2-stem-quantum-quest",
+        },
+        g3_5: {
+          title: "Quantum Mission: Pattern Lab",
+          subtitle: "Model quantum patterns and test outcomes!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 270,
+              topic: "probability, patterns, observation, and evidence",
+              vocabulary: [
+                "quantum",
+                "pattern",
+                "probability",
+                "outcome",
+                "evidence",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "pattern-identification",
+                "prediction",
+                "evidence-choice",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: ["observe", "predict", "test"],
+              mechanics: [
+                "state-toggle",
+                "outcome-tracker",
+                "pattern-matcher",
+                "hint-ladder",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "mission-control", progressType: "ring" },
+          },
+        },
+      },
+      {
+        key: "motion",
+        title: "Forces & Motion",
+        iconEmoji: "🚀",
+        k2: {
+          title: "Rhyme & Ride",
+          subtitle: "Ride through worlds and catch rhymes!",
+          moduleSlug: "k2-stem-rhyme-ride",
+        },
+        g3_5: {
+          title: "Motion Mission: Force Lab",
+          subtitle: "Predict, test, and master forces!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 260,
+              topic: "force, friction, mass, prediction",
+              vocabulary: [
+                "force",
+                "friction",
+                "mass",
+                "acceleration",
+                "prediction",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: ["prediction", "comparison", "variable-identification"],
+            },
+            game: {
+              rounds: 3,
+              phases: ["predict", "test", "adjust-variables"],
+              mechanics: [
+                "force-slider",
+                "surface-selector",
+                "target-practice",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "lab", progressType: "bar" },
+          },
+        },
+      },
+      {
+        key: "sorting",
+        title: "Sorting & Classification",
+        iconEmoji: "📊",
+        k2: {
+          title: "Bounce & Buds",
+          subtitle: "Bounce through the right gate!",
+          moduleSlug: "k2-stem-bounce-buds",
+        },
+        g3_5: {
+          title: "Data Dash: Sort & Discover",
+          subtitle: "Classify data and find hidden patterns!",
+          contentConfig: {
+            theme: "dashboard",
+            reading: {
+              wordCount: 240,
+              topic: "classification, organizing data, finding patterns",
+              vocabulary: ["classify", "attribute", "pattern", "data", "graph"],
+            },
+            questions: {
+              count: 6,
+              types: ["multi-attribute-sort", "hidden-rule", "chart-reading"],
+            },
+            game: {
+              rounds: 3,
+              phases: ["sort-by-attribute", "infer-rule", "read-chart"],
+              mechanics: ["drag-sort", "rule-builder", "bar-chart"],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "mission", progressType: "ring" },
+          },
+        },
+      },
+      {
+        key: "plant_variables",
+        title: "Plants & Fair Tests",
+        iconEmoji: "🌱",
+        k2: {
+          title: "Gotcha Gears",
+          subtitle: "Catch the right gear!",
+          moduleSlug: "k2-stem-gotcha-gears",
+        },
+        g3_5: {
+          title: "Variable Quest: Fair Test Lab",
+          subtitle: "Design experiments and test your ideas!",
+          contentConfig: {
+            theme: "lab",
+            reading: {
+              wordCount: 270,
+              topic:
+                "fair tests, changing one variable, evidence-based conclusions",
+              vocabulary: [
+                "variable",
+                "control",
+                "hypothesis",
+                "evidence",
+                "conclusion",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "fair-test-check",
+                "variable-identification",
+                "conclusion-choice",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: [
+                "setup-experiment",
+                "observe-results",
+                "evaluate-fairness",
+              ],
+              mechanics: ["variable-lock", "lab-notebook", "sentence-stems"],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "lab", progressType: "bar" },
+          },
+        },
+      },
+      {
+        key: "bridge",
+        title: "Engineering & Design",
+        iconEmoji: "🏗️",
+        k2: {
+          title: "Tank Trek",
+          subtitle: "Guide a robot through mazes!",
+          moduleSlug: "k2-stem-tank-trek",
+        },
+        g3_5: {
+          title: "Design Under Pressure: Bridge Lab",
+          subtitle: "Build, test, and redesign structures!",
+          contentConfig: {
+            theme: "blueprint",
+            reading: {
+              wordCount: 260,
+              topic: "stability, triangles, constraints, redesign",
+              vocabulary: [
+                "stability",
+                "triangle",
+                "constraint",
+                "load",
+                "redesign",
+              ],
+            },
+            questions: {
+              count: 5,
+              types: [
+                "weak-point-identification",
+                "material-choice",
+                "design-comparison",
+              ],
+            },
+            game: {
+              rounds: 3,
+              phases: ["build", "load-test", "redesign"],
+              mechanics: [
+                "weak-point-highlight",
+                "starter-blueprint",
+                "budget-constraint",
+                "before-after-compare",
+              ],
+            },
+            supports: {
+              hintLadder: true,
+              glossary: true,
+              readAloud: true,
+              recap: true,
+            },
+            ui: { tone: "blueprint", progressType: "ring" },
+          },
+        },
+      },
+    ];
 
-  const familyDefs = [
-    {
-      key: "quantum_quest",
-      title: "Quantum Foundations",
-      iconEmoji: "⚛️",
-      k2: { title: "Quantum Quest", subtitle: "Explore quantum puzzles in a space math adventure!", moduleSlug: "k2-stem-quantum-quest" },
-      g3_5: {
-        title: "Quantum Mission: Pattern Lab",
-        subtitle: "Model quantum patterns and test outcomes!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 270, topic: "probability, patterns, observation, and evidence", vocabulary: ["quantum", "pattern", "probability", "outcome", "evidence"] },
-          questions: { count: 5, types: ["pattern-identification", "prediction", "evidence-choice"] },
-          game: { rounds: 3, phases: ["observe", "predict", "test"], mechanics: ["state-toggle", "outcome-tracker", "pattern-matcher", "hint-ladder"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "mission-control", progressType: "ring" },
-        },
-      },
-    },
-    {
-      key: "motion",
-      title: "Forces & Motion",
-      iconEmoji: "🚀",
-      k2: { title: "Rhyme & Ride", subtitle: "Ride through worlds and catch rhymes!", moduleSlug: "k2-stem-rhyme-ride" },
-      g3_5: {
-        title: "Motion Mission: Force Lab",
-        subtitle: "Predict, test, and master forces!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 260, topic: "force, friction, mass, prediction", vocabulary: ["force", "friction", "mass", "acceleration", "prediction"] },
-          questions: { count: 5, types: ["prediction", "comparison", "variable-identification"] },
-          game: { rounds: 3, phases: ["predict", "test", "adjust-variables"], mechanics: ["force-slider", "surface-selector", "target-practice"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "lab", progressType: "bar" },
-        },
-      },
-    },
-    {
-      key: "sorting",
-      title: "Sorting & Classification",
-      iconEmoji: "📊",
-      k2: { title: "Bounce & Buds", subtitle: "Bounce through the right gate!", moduleSlug: "k2-stem-bounce-buds" },
-      g3_5: {
-        title: "Data Dash: Sort & Discover",
-        subtitle: "Classify data and find hidden patterns!",
-        contentConfig: {
-          theme: "dashboard",
-          reading: { wordCount: 240, topic: "classification, organizing data, finding patterns", vocabulary: ["classify", "attribute", "pattern", "data", "graph"] },
-          questions: { count: 6, types: ["multi-attribute-sort", "hidden-rule", "chart-reading"] },
-          game: { rounds: 3, phases: ["sort-by-attribute", "infer-rule", "read-chart"], mechanics: ["drag-sort", "rule-builder", "bar-chart"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "mission", progressType: "ring" },
-        },
-      },
-    },
-    {
-      key: "plant_variables",
-      title: "Plants & Fair Tests",
-      iconEmoji: "🌱",
-      k2: { title: "Gotcha Gears", subtitle: "Catch the right gear!", moduleSlug: "k2-stem-gotcha-gears" },
-      g3_5: {
-        title: "Variable Quest: Fair Test Lab",
-        subtitle: "Design experiments and test your ideas!",
-        contentConfig: {
-          theme: "lab",
-          reading: { wordCount: 270, topic: "fair tests, changing one variable, evidence-based conclusions", vocabulary: ["variable", "control", "hypothesis", "evidence", "conclusion"] },
-          questions: { count: 5, types: ["fair-test-check", "variable-identification", "conclusion-choice"] },
-          game: { rounds: 3, phases: ["setup-experiment", "observe-results", "evaluate-fairness"], mechanics: ["variable-lock", "lab-notebook", "sentence-stems"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "lab", progressType: "bar" },
-        },
-      },
-    },
-    {
-      key: "bridge",
-      title: "Engineering & Design",
-      iconEmoji: "🏗️",
-      k2: { title: "Tank Trek", subtitle: "Guide a robot through mazes!", moduleSlug: "k2-stem-tank-trek" },
-      g3_5: {
-        title: "Design Under Pressure: Bridge Lab",
-        subtitle: "Build, test, and redesign structures!",
-        contentConfig: {
-          theme: "blueprint",
-          reading: { wordCount: 260, topic: "stability, triangles, constraints, redesign", vocabulary: ["stability", "triangle", "constraint", "load", "redesign"] },
-          questions: { count: 5, types: ["weak-point-identification", "material-choice", "design-comparison"] },
-          game: { rounds: 3, phases: ["build", "load-test", "redesign"], mechanics: ["weak-point-highlight", "starter-blueprint", "budget-constraint", "before-after-compare"] },
-          supports: { hintLadder: true, glossary: true, readAloud: true, recap: true },
-          ui: { tone: "blueprint", progressType: "ring" },
-        },
-      },
-    },
-  ];
+    for (const fd of familyDefs) {
+      const family = await prisma.moduleFamily.upsert({
+        where: { key: fd.key },
+        create: { key: fd.key, title: fd.title, iconEmoji: fd.iconEmoji },
+        update: { title: fd.title, iconEmoji: fd.iconEmoji },
+      });
 
-  for (const fd of familyDefs) {
-    const family = await prisma.moduleFamily.upsert({
-      where: { key: fd.key },
-      create: { key: fd.key, title: fd.title, iconEmoji: fd.iconEmoji },
-      update: { title: fd.title, iconEmoji: fd.iconEmoji },
-    });
+      // K-2 variant (links to existing module)
+      await prisma.moduleVariant.upsert({
+        where: {
+          familyId_band_version: {
+            familyId: family.id,
+            band: "k2",
+            version: "1.0",
+          },
+        },
+        create: {
+          familyId: family.id,
+          band: "k2",
+          version: "1.0",
+          title: fd.k2.title,
+          subtitle: fd.k2.subtitle,
+          status: "active",
+          moduleSlug: fd.k2.moduleSlug,
+        },
+        update: {
+          title: fd.k2.title,
+          subtitle: fd.k2.subtitle,
+          moduleSlug: fd.k2.moduleSlug,
+        },
+      });
 
-    // K-2 variant (links to existing module)
-    await prisma.moduleVariant.upsert({
-      where: { familyId_band_version: { familyId: family.id, band: "k2", version: "1.0" } },
+      // G3-5 variant (new upper-elementary content)
+      await prisma.moduleVariant.upsert({
+        where: {
+          familyId_band_version: {
+            familyId: family.id,
+            band: "g3_5",
+            version: "1.0",
+          },
+        },
+        create: {
+          familyId: family.id,
+          band: "g3_5",
+          version: "1.0",
+          title: fd.g3_5.title,
+          subtitle: fd.g3_5.subtitle,
+          status: "active",
+          contentConfig: fd.g3_5.contentConfig,
+        },
+        update: {
+          title: fd.g3_5.title,
+          subtitle: fd.g3_5.subtitle,
+          contentConfig: fd.g3_5.contentConfig,
+        },
+      });
+
+      console.log(`  Seeded family "${fd.key}" with k2 + g3_5 variants`);
+    }
+
+    // Seed a demo g3_5 class if teacher exists
+    const demoClass = await prisma.course.upsert({
+      where: { joinCode: "UPPER35" },
       create: {
-        familyId: family.id,
-        band: "k2",
-        version: "1.0",
-        title: fd.k2.title,
-        subtitle: fd.k2.subtitle,
-        status: "active",
-        moduleSlug: fd.k2.moduleSlug,
+        name: "Grade 3-5 STEM Demo",
+        joinCode: "UPPER35",
+        teacherId: teacher.id,
+        gradeBand: "g3_5",
       },
-      update: { title: fd.k2.title, subtitle: fd.k2.subtitle, moduleSlug: fd.k2.moduleSlug },
+      update: { gradeBand: "g3_5" },
     });
+    console.log("Seeded demo g3_5 class:", demoClass.name);
 
-    // G3-5 variant (new upper-elementary content)
-    await prisma.moduleVariant.upsert({
-      where: { familyId_band_version: { familyId: family.id, band: "g3_5", version: "1.0" } },
-      create: {
-        familyId: family.id,
-        band: "g3_5",
-        version: "1.0",
-        title: fd.g3_5.title,
-        subtitle: fd.g3_5.subtitle,
-        status: "active",
-        contentConfig: fd.g3_5.contentConfig,
-      },
-      update: { title: fd.g3_5.title, subtitle: fd.g3_5.subtitle, contentConfig: fd.g3_5.contentConfig },
+    // Auto-assign all g3_5 variants to the demo class
+    const g35Variants = await prisma.moduleVariant.findMany({
+      where: { band: "g3_5", status: "active" },
     });
+    for (let i = 0; i < g35Variants.length; i++) {
+      await prisma.classModuleAssignment.upsert({
+        where: {
+          courseId_moduleVariantId: {
+            courseId: demoClass.id,
+            moduleVariantId: g35Variants[i].id,
+          },
+        },
+        create: {
+          courseId: demoClass.id,
+          moduleVariantId: g35Variants[i].id,
+          orderIndex: i,
+        },
+        update: { orderIndex: i },
+      });
+    }
+    console.log(`  Assigned ${g35Variants.length} g3_5 variants to demo class`);
 
-    console.log(`  Seeded family "${fd.key}" with k2 + g3_5 variants`);
-  }
-
-  // Seed a demo g3_5 class if teacher exists
-  const demoClass = await prisma.course.upsert({
-    where: { joinCode: "UPPER35" },
-    create: {
-      name: "Grade 3-5 STEM Demo",
-      joinCode: "UPPER35",
-      teacherId: teacher.id,
-      gradeBand: "g3_5",
-    },
-    update: { gradeBand: "g3_5" },
-  });
-  console.log("Seeded demo g3_5 class:", demoClass.name);
-
-  // Auto-assign all g3_5 variants to the demo class
-  const g35Variants = await prisma.moduleVariant.findMany({ where: { band: "g3_5", status: "active" } });
-  for (let i = 0; i < g35Variants.length; i++) {
-    await prisma.classModuleAssignment.upsert({
-      where: { courseId_moduleVariantId: { courseId: demoClass.id, moduleVariantId: g35Variants[i].id } },
-      create: { courseId: demoClass.id, moduleVariantId: g35Variants[i].id, orderIndex: i },
-      update: { orderIndex: i },
-    });
-  }
-  console.log(`  Assigned ${g35Variants.length} g3_5 variants to demo class`);
-
-  console.log("Module families and variants seeded.");
+    console.log("Module families and variants seeded.");
   } catch (e) {
-    console.warn("Module families seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Module families seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1553,413 +3409,537 @@ async function main() {
   console.log("Seeding Pathways data...");
 
   try {
-  // Facilitator
-  const facilitatorHash = await bcrypt.hash("pathway123", 10);
-  let facilitator = await prisma.user.findUnique({ where: { email: "facilitator@test.com" } });
-  if (!facilitator) {
-    facilitator = await prisma.user.create({
-      data: {
-        name: "Coach Davis",
-        email: "facilitator@test.com",
-        password: facilitatorHash,
-        role: "teacher",
-        userType: "pathways",
-      },
+    // Facilitator
+    const facilitatorHash = await bcrypt.hash("pathway123", 10);
+    let facilitator = await prisma.user.findUnique({
+      where: { email: "facilitator@test.com" },
     });
-  } else {
-    facilitator = await prisma.user.update({
-      where: { id: facilitator.id },
-      data: { password: facilitatorHash, userType: "pathways" },
-    });
-  }
-  console.log("Seeded facilitator:", facilitator.email);
-
-  // Marcus — Launch band, partial progress
-  const marcusHash = await bcrypt.hash("marcus123", 10);
-  let marcus = await prisma.user.findUnique({ where: { email: "marcus@test.com" } });
-  if (!marcus) {
-    marcus = await prisma.user.create({
-      data: {
-        name: "Marcus",
-        email: "marcus@test.com",
-        password: marcusHash,
-        role: "student",
-        userType: "pathways",
-        ageBand: "launch",
-        birthYear: 2009,
-      },
-    });
-  } else {
-    marcus = await prisma.user.update({
-      where: { id: marcus.id },
-      data: { password: marcusHash, userType: "pathways", ageBand: "launch", birthYear: 2009 },
-    });
-  }
-  console.log("Seeded Marcus:", marcus.email);
-
-  // Aisha — Explorer band, fresh
-  const aishaHash = await bcrypt.hash("aisha123", 10);
-  let aisha = await prisma.user.findUnique({ where: { email: "aisha@test.com" } });
-  if (!aisha) {
-    aisha = await prisma.user.create({
-      data: {
-        name: "Aisha",
-        email: "aisha@test.com",
-        password: aishaHash,
-        role: "student",
-        userType: "pathways",
-        ageBand: "explorer",
-        birthYear: 2011,
-      },
-    });
-  } else {
-    aisha = await prisma.user.update({
-      where: { id: aisha.id },
-      data: { password: aishaHash, userType: "pathways", ageBand: "explorer", birthYear: 2011 },
-    });
-  }
-  console.log("Seeded Aisha:", aisha.email);
-
-  // ── Active cohort: ETO Spring 2026 ──
-  const cohort = await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2026" },
-    create: {
-      name: "ETO Spring 2026 — Cyber Cohort",
-      band: "launch",
-      sitePartner: "Escape The Odds — South Side",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2026",
-      status: "active",
-      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
-      maxEnrollment: 12,
-      startDate: new Date("2026-03-02"),
-      endDate: new Date("2026-04-13"),
-      notes: [
-        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
-        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
-        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
-      ],
-    },
-    update: {
-      facilitatorId: facilitator.id,
-      status: "active",
-      description: "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
-      maxEnrollment: 12,
-      startDate: new Date("2026-03-02"),
-      endDate: new Date("2026-04-13"),
-      sitePartner: "Escape The Odds — South Side",
-      notes: [
-        { text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.", author: "Coach Davis", ts: new Date("2026-05-08").toISOString() },
-        { text: "Aisha needs more individual time on Network Basics.", author: "Coach Davis", ts: new Date("2026-05-10").toISOString() },
-        { text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.", author: "Coach Davis", ts: new Date("2026-05-12").toISOString() },
-      ],
-    },
-  });
-
-  // Enroll Marcus and Aisha
-  for (const u of [marcus, aisha]) {
-    await prisma.pathwayEnrollment.upsert({
-      where: { userId_cohortId: { userId: u.id, cohortId: cohort.id } },
-      create: { userId: u.id, cohortId: cohort.id },
-      update: {},
-    });
-  }
-
-  // Marcus's Cyber Launch milestones (partial progress).
-  // Section-level fields, homework responses, and time spent are filled in so
-  // Coach Davis's facilitator view shows real-looking work, not empty rows.
-  // upsert update block re-applies these every seed run — important when the
-  // section-progress migration lands on top of existing rows.
-  const MARCUS_HOMEWORK = {
-    "cyber-foundations":
-      "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
-    "digital-safety-sim":
-      "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
-    "network-basics":
-      "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
-  };
-  const marcusMilestones = [
-    { moduleSlug: "cyber-foundations", status: "completed", score: 85, daysAgo: 7, timeSpent: 62 },
-    { moduleSlug: "digital-safety-sim", status: "completed", score: 90, daysAgo: 5, timeSpent: 58 },
-    { moduleSlug: "network-basics", status: "completed", score: 78, daysAgo: 3, timeSpent: 65 },
-    { moduleSlug: "threat-detective", status: "in_progress", score: null, daysAgo: 1, timeSpent: 28 },
-  ];
-
-  // Clear any drifted Cyber Launch milestone state before re-seeding the
-  // canonical 4 rows. Without this, live demo usage that touches modules
-  // outside the seed array accumulates rows that the upsert-only loop
-  // never cleans up — Marcus drifted from "3 done + 1 in flight" to
-  // "1 done + 5 in flight" over the past two weeks. (See diagnostic
-  // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
-  await prisma.pathwayMilestone.deleteMany({
-    where: { userId: marcus.id, trackSlug: "cyber-launch" },
-  });
-
-  for (const m of marcusMilestones) {
-    const isDone = m.status === "completed";
-    const isInProgress = m.status === "in_progress";
-    const fullFields = {
-      status: m.status,
-      score: m.score,
-      completedAt: isDone ? new Date(Date.now() - m.daysAgo * 86400000) : null,
-      hookCompleted: isDone || isInProgress,
-      readingCompleted: isDone || isInProgress,
-      lessonCompleted: isDone || isInProgress,
-      practiceCompleted: isDone,
-      homeworkSubmitted: isDone,
-      homeworkResponse: isDone ? MARCUS_HOMEWORK[m.moduleSlug] ?? null : null,
-      quizCompleted: isDone,
-      quizScore: isDone ? m.score : null,
-      timeSpentMinutes: m.timeSpent,
-    };
-    await prisma.pathwayMilestone.create({
-      data: {
-        userId: marcus.id,
-        trackSlug: "cyber-launch",
-        moduleSlug: m.moduleSlug,
-        ...fullFields,
-      },
-    });
-  }
-  console.log("Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)");
-
-  // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
-  const endedCohort = await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2025F" },
-    create: {
-      name: "ETO Fall 2025 — Pilot Cohort",
-      band: "launch",
-      sitePartner: "Escape The Odds — West Side",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2025F",
-      status: "ended",
-      description: "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
-      maxEnrollment: 8,
-      startDate: new Date("2025-10-06"),
-      endDate: new Date("2025-11-17"),
-      notes: [
-        { text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.", author: "Coach Davis", ts: new Date("2025-11-20").toISOString() },
-      ],
-    },
-    update: { facilitatorId: facilitator.id, status: "ended" },
-  });
-
-  // Fictional graduates of the Fall 2025 pilot
-  const graduates = [
-    { name: "Jasmine", email: "grad-jasmine@brightboost.local", scores: [88, 92, 81, 79, 85, 100, 90] },
-    { name: "DeShawn", email: "grad-deshawn@brightboost.local", scores: [82, 95, 87, 84, 91, 100, 95] },
-    { name: "Reina", email: "grad-reina@brightboost.local", scores: [76, 88, 92, 89, 78, 100, 87] },
-  ];
-  const moduleSlugs = ["cyber-foundations", "digital-safety-sim", "network-basics", "threat-detective", "career-map", "cisco-netacad-link", "capstone-security-plan"];
-  const gradHash = await bcrypt.hash("graduate", 10);
-  for (const g of graduates) {
-    let gu = await prisma.user.findUnique({ where: { email: g.email } });
-    if (!gu) {
-      gu = await prisma.user.create({
+    if (!facilitator) {
+      facilitator = await prisma.user.create({
         data: {
-          name: g.name,
-          email: g.email,
-          password: gradHash,
+          name: "Coach Davis",
+          email: "facilitator@test.com",
+          password: facilitatorHash,
+          role: "teacher",
+          userType: "pathways",
+        },
+      });
+    } else {
+      facilitator = await prisma.user.update({
+        where: { id: facilitator.id },
+        data: { password: facilitatorHash, userType: "pathways" },
+      });
+    }
+    console.log("Seeded facilitator:", facilitator.email);
+
+    // Marcus — Launch band, partial progress
+    const marcusHash = await bcrypt.hash("marcus123", 10);
+    let marcus = await prisma.user.findUnique({
+      where: { email: "marcus@test.com" },
+    });
+    if (!marcus) {
+      marcus = await prisma.user.create({
+        data: {
+          name: "Marcus",
+          email: "marcus@test.com",
+          password: marcusHash,
           role: "student",
           userType: "pathways",
           ageBand: "launch",
-          birthYear: 2008,
+          birthYear: 2009,
+        },
+      });
+    } else {
+      marcus = await prisma.user.update({
+        where: { id: marcus.id },
+        data: {
+          password: marcusHash,
+          userType: "pathways",
+          ageBand: "launch",
+          birthYear: 2009,
         },
       });
     }
-    await prisma.pathwayEnrollment.upsert({
-      where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
-      create: { userId: gu.id, cohortId: endedCohort.id, status: "completed" },
-      update: { status: "completed" },
+    console.log("Seeded Marcus:", marcus.email);
+
+    // Aisha — Explorer band, fresh
+    const aishaHash = await bcrypt.hash("aisha123", 10);
+    let aisha = await prisma.user.findUnique({
+      where: { email: "aisha@test.com" },
     });
-    // Realistic completion milestones (each module completed during the Fall pilot).
-    // Section-level fields filled in so the facilitator outcomes report shows
-    // 6-of-6 sections done per module, not "completed but 0 sections".
-    for (let i = 0; i < moduleSlugs.length; i++) {
-      const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
-      const fullFields = {
+    if (!aisha) {
+      aisha = await prisma.user.create({
+        data: {
+          name: "Aisha",
+          email: "aisha@test.com",
+          password: aishaHash,
+          role: "student",
+          userType: "pathways",
+          ageBand: "explorer",
+          birthYear: 2011,
+        },
+      });
+    } else {
+      aisha = await prisma.user.update({
+        where: { id: aisha.id },
+        data: {
+          password: aishaHash,
+          userType: "pathways",
+          ageBand: "explorer",
+          birthYear: 2011,
+        },
+      });
+    }
+    console.log("Seeded Aisha:", aisha.email);
+
+    // ── Active cohort: ETO Spring 2026 ──
+    const cohort = await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2026" },
+      create: {
+        name: "ETO Spring 2026 — Cyber Cohort",
+        band: "launch",
+        sitePartner: "Escape The Odds — South Side",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2026",
+        status: "active",
+        description:
+          "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+        maxEnrollment: 12,
+        startDate: new Date("2026-03-02"),
+        endDate: new Date("2026-04-13"),
+        notes: [
+          {
+            text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-08").toISOString(),
+          },
+          {
+            text: "Aisha needs more individual time on Network Basics.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-10").toISOString(),
+          },
+          {
+            text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-12").toISOString(),
+          },
+        ],
+      },
+      update: {
+        facilitatorId: facilitator.id,
+        status: "active",
+        description:
+          "Spring 2026 pilot cohort with Escape The Odds. Six-week Cyber Launch curriculum, in-person sessions twice weekly.",
+        maxEnrollment: 12,
+        startDate: new Date("2026-03-02"),
+        endDate: new Date("2026-04-13"),
+        sitePartner: "Escape The Odds — South Side",
+        notes: [
+          {
+            text: "Marcus showing strong interest in DFIR — recommend extending Career Map discussion next session.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-08").toISOString(),
+          },
+          {
+            text: "Aisha needs more individual time on Network Basics.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-10").toISOString(),
+          },
+          {
+            text: "Cohort responding well to Phishing Sim scenarios. Plan to extend to social engineering deep-dive in week 4.",
+            author: "Coach Davis",
+            ts: new Date("2026-05-12").toISOString(),
+          },
+        ],
+      },
+    });
+
+    // Enroll Marcus and Aisha
+    for (const u of [marcus, aisha]) {
+      await prisma.pathwayEnrollment.upsert({
+        where: { userId_cohortId: { userId: u.id, cohortId: cohort.id } },
+        create: { userId: u.id, cohortId: cohort.id },
+        update: {},
+      });
+    }
+
+    // Marcus's Cyber Launch milestones (partial progress).
+    // Section-level fields, homework responses, and time spent are filled in so
+    // Coach Davis's facilitator view shows real-looking work, not empty rows.
+    // upsert update block re-applies these every seed run — important when the
+    // section-progress migration lands on top of existing rows.
+    const MARCUS_HOMEWORK = {
+      "cyber-foundations":
+        "This week I counted 47 times cybersecurity affected my daily life. Most surprising: my game console asked for MFA when I tried to add a new payment method. I always thought MFA was just for banks. Three examples that stood out: (1) school portal asking for 2FA at every login, (2) a 'this site is not secure' warning on a free movie site I tried, (3) my mom getting a phishing text pretending to be Chase.",
+      "digital-safety-sim":
+        "My 5 most important accounts: school email, personal email, bank, Instagram, Discord. Audit results — only 2 had unique passwords (school, bank), only 1 had MFA (bank). Recovery emails were stale on 3 of them. Action plan this week: install Bitwarden, generate unique passwords for the other 3 accounts, turn on MFA on email first (because it's the recovery channel for everything else).",
+      "network-basics":
+        "Drew my home network on paper. Router: Netgear Nighthawk (don't know model #). 11 devices connected — 4 phones, 2 laptops, smart TV, gaming console, Ring doorbell, smart bulb x2. Riskiest device: the smart TV — bought it in 2019 and I can't remember it ever updating. One change: move the smart-home stuff to the guest WiFi so if any of them gets popped it can't see the main network.",
+    };
+    const marcusMilestones = [
+      {
+        moduleSlug: "cyber-foundations",
         status: "completed",
-        score: g.scores[i],
-        completedAt: completedDate,
-        hookCompleted: true,
-        readingCompleted: true,
-        lessonCompleted: true,
-        practiceCompleted: true,
-        homeworkSubmitted: true,
-        homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
-        quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
-        quizScore: moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
-        timeSpentMinutes: 55 + ((i * 7) % 20),
+        score: 85,
+        daysAgo: 7,
+        timeSpent: 62,
+      },
+      {
+        moduleSlug: "digital-safety-sim",
+        status: "completed",
+        score: 90,
+        daysAgo: 5,
+        timeSpent: 58,
+      },
+      {
+        moduleSlug: "network-basics",
+        status: "completed",
+        score: 78,
+        daysAgo: 3,
+        timeSpent: 65,
+      },
+      {
+        moduleSlug: "threat-detective",
+        status: "in_progress",
+        score: null,
+        daysAgo: 1,
+        timeSpent: 28,
+      },
+    ];
+
+    // Clear any drifted Cyber Launch milestone state before re-seeding the
+    // canonical 4 rows. Without this, live demo usage that touches modules
+    // outside the seed array accumulates rows that the upsert-only loop
+    // never cleans up — Marcus drifted from "3 done + 1 in flight" to
+    // "1 done + 5 in flight" over the past two weeks. (See diagnostic
+    // finding M4.) Scope is bounded to Marcus's Cyber Launch track only.
+    await prisma.pathwayMilestone.deleteMany({
+      where: { userId: marcus.id, trackSlug: "cyber-launch" },
+    });
+
+    for (const m of marcusMilestones) {
+      const isDone = m.status === "completed";
+      const isInProgress = m.status === "in_progress";
+      const fullFields = {
+        status: m.status,
+        score: m.score,
+        completedAt: isDone
+          ? new Date(Date.now() - m.daysAgo * 86400000)
+          : null,
+        hookCompleted: isDone || isInProgress,
+        readingCompleted: isDone || isInProgress,
+        lessonCompleted: isDone || isInProgress,
+        practiceCompleted: isDone,
+        homeworkSubmitted: isDone,
+        homeworkResponse: isDone
+          ? (MARCUS_HOMEWORK[m.moduleSlug] ?? null)
+          : null,
+        quizCompleted: isDone,
+        quizScore: isDone ? m.score : null,
+        timeSpentMinutes: m.timeSpent,
       };
-      await prisma.pathwayMilestone.upsert({
-        where: { userId_trackSlug_moduleSlug: { userId: gu.id, trackSlug: "cyber-launch", moduleSlug: moduleSlugs[i] } },
-        create: {
-          userId: gu.id,
+      await prisma.pathwayMilestone.create({
+        data: {
+          userId: marcus.id,
           trackSlug: "cyber-launch",
-          moduleSlug: moduleSlugs[i],
+          moduleSlug: m.moduleSlug,
           ...fullFields,
         },
-        update: fullFields,
       });
     }
-  }
+    console.log(
+      "Seeded Marcus partial Cyber Launch progress (3 completed with homework, 1 in progress)",
+    );
 
-  // ── Draft cohort: ETO Summer 2026 — Planning ──
-  await prisma.pathwayCohort.upsert({
-    where: { joinCode: "ETO2026S" },
-    create: {
-      name: "ETO Summer 2026 — Planning",
-      band: "mixed",
-      sitePartner: "Escape The Odds — TBD",
-      facilitatorId: facilitator.id,
-      trackIds: ["cyber-launch"],
-      joinCode: "ETO2026S",
-      status: "draft",
-      description: "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
-      maxEnrollment: 16,
-      startDate: new Date("2026-06-15"),
-      endDate: new Date("2026-07-27"),
-      notes: [],
-    },
-    update: { facilitatorId: facilitator.id, status: "draft" },
-  });
-
-  console.log("Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.");
-
-  // ─── Onboarding seed for demo accounts ───────────────────────────────────
-  // Marcus and Coach Davis show up to demos as already-onboarded so the
-  // welcome flow doesn't re-trigger every time the DB is re-seeded. Aisha
-  // is intentionally LEFT OUT — she's the "fresh-user" demo and should
-  // walk through the welcome flow when someone hits her account.
-  console.log("Seeding Pathways onboarding for demo accounts...");
-  const onboardingDemoData = [
-    {
-      email: "marcus@test.com",
-      avatarSlug: "analyst",
-      missionStatement:
-        "I want to build a real career in cybersecurity and help my community stay safe online.",
-      dailyGoalLevel: "medium",
-      // Demo intent: every fresh demo should see the toolbox intro fire on
-      // first CTF visit. Live sessions used to leave this `true`, breaking
-      // the demo story on the next showing. (Diagnostic finding L3.)
-      toolboxIntroSeen: false,
-    },
-    {
-      email: "facilitator@test.com",
-      avatarSlug: "guardian",
-      missionStatement:
-        "I want to help my students see themselves in this work and build real pathways forward.",
-      dailyGoalLevel: "heavy",
-      toolboxIntroSeen: false,
-    },
-  ];
-
-  for (const data of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email: data.email } });
-    if (!user) {
-      console.log(`  Skipping ${data.email} — user not found`);
-      continue;
-    }
-    const payload = {
-      avatarChosen: true,
-      avatarSlug: data.avatarSlug,
-      skillsTourViewed: true,
-      skillsTourSkipped: false,
-      missionStatement: data.missionStatement,
-      dailyGoalLevel: data.dailyGoalLevel,
-      toolboxIntroSeen: data.toolboxIntroSeen,
-      completedAt: new Date(),
-    };
-    await prisma.pathwayOnboarding.upsert({
-      where: { userId: user.id },
-      update: payload,
-      create: { userId: user.id, ...payload },
-    });
-    console.log(`  Seeded onboarding for ${data.email}: ${data.avatarSlug}`);
-  }
-
-  // Award the Getting Started badge so those accounts reflect the
-  // completed-onboarding state in their badge collection. XP for the
-  // badge will be picked up by the gamification backfill (which runs
-  // after this seed in predeploy.sh).
-  for (const { email } of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) continue;
-    await prisma.pathwayBadge.upsert({
-      where: { userId_slug: { userId: user.id, slug: "getting_started" } },
-      update: {},
+    // ── Ended cohort: ETO Fall 2025 Pilot — 3 fictional graduates ──
+    const endedCohort = await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2025F" },
       create: {
-        userId: user.id,
-        slug: "getting_started",
-        metadata: { backfilled: true, source: "seed" },
+        name: "ETO Fall 2025 — Pilot Cohort",
+        band: "launch",
+        sitePartner: "Escape The Odds — West Side",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2025F",
+        status: "ended",
+        description:
+          "First Bright Boost Pathways pilot. Six-week intensive Cyber Launch program. 3 of 4 enrolled graduated with completed capstones.",
+        maxEnrollment: 8,
+        startDate: new Date("2025-10-06"),
+        endDate: new Date("2025-11-17"),
+        notes: [
+          {
+            text: "Strong inaugural cohort. All 3 graduates produced presentation-ready capstones. Two pursuing ISC2 CC now.",
+            author: "Coach Davis",
+            ts: new Date("2025-11-20").toISOString(),
+          },
+        ],
       },
+      update: { facilitatorId: facilitator.id, status: "ended" },
     });
-  }
-  console.log("  Awarded Getting Started badge to demo accounts");
 
-  // ─── Daily goals for today (demo accounts) ──────────────────────────────
-  // Without a row for "today", the home page goal card briefly renders an
-  // empty/skeleton state until the lazy server-side creation fires. Pre-
-  // seeding here means demos always open to a fully-rendered goal card.
-  // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
-  // should hit the lazy creation path so we can show that flow.
-  //
-  // NOTE: this mirrors getDailyGoalTargets() in
-  // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
-  // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
-  // off them at runtime to credit progress.
-  function getDailyGoalTargets(level) {
-    const effective = level || "medium";
-    if (effective === "light") {
+    // Fictional graduates of the Fall 2025 pilot
+    const graduates = [
+      {
+        name: "Jasmine",
+        email: "grad-jasmine@brightboost.local",
+        scores: [88, 92, 81, 79, 85, 100, 90],
+      },
+      {
+        name: "DeShawn",
+        email: "grad-deshawn@brightboost.local",
+        scores: [82, 95, 87, 84, 91, 100, 95],
+      },
+      {
+        name: "Reina",
+        email: "grad-reina@brightboost.local",
+        scores: [76, 88, 92, 89, 78, 100, 87],
+      },
+    ];
+    const moduleSlugs = [
+      "cyber-foundations",
+      "digital-safety-sim",
+      "network-basics",
+      "threat-detective",
+      "career-map",
+      "cisco-netacad-link",
+      "capstone-security-plan",
+    ];
+    const gradHash = await bcrypt.hash("graduate", 10);
+    for (const g of graduates) {
+      let gu = await prisma.user.findUnique({ where: { email: g.email } });
+      if (!gu) {
+        gu = await prisma.user.create({
+          data: {
+            name: g.name,
+            email: g.email,
+            password: gradHash,
+            role: "student",
+            userType: "pathways",
+            ageBand: "launch",
+            birthYear: 2008,
+          },
+        });
+      }
+      await prisma.pathwayEnrollment.upsert({
+        where: { userId_cohortId: { userId: gu.id, cohortId: endedCohort.id } },
+        create: {
+          userId: gu.id,
+          cohortId: endedCohort.id,
+          status: "completed",
+        },
+        update: { status: "completed" },
+      });
+      // Realistic completion milestones (each module completed during the Fall pilot).
+      // Section-level fields filled in so the facilitator outcomes report shows
+      // 6-of-6 sections done per module, not "completed but 0 sections".
+      for (let i = 0; i < moduleSlugs.length; i++) {
+        const completedDate = new Date(2025, 9, 13 + i * 5); // Oct 13 + 5 days per module
+        const fullFields = {
+          status: "completed",
+          score: g.scores[i],
+          completedAt: completedDate,
+          hookCompleted: true,
+          readingCompleted: true,
+          lessonCompleted: true,
+          practiceCompleted: true,
+          homeworkSubmitted: true,
+          homeworkResponse: `(${g.name}'s ${moduleSlugs[i]} submission — pilot cohort archive)`,
+          quizCompleted: moduleSlugs[i] !== "capstone-security-plan",
+          quizScore:
+            moduleSlugs[i] !== "capstone-security-plan" ? g.scores[i] : null,
+          timeSpentMinutes: 55 + ((i * 7) % 20),
+        };
+        await prisma.pathwayMilestone.upsert({
+          where: {
+            userId_trackSlug_moduleSlug: {
+              userId: gu.id,
+              trackSlug: "cyber-launch",
+              moduleSlug: moduleSlugs[i],
+            },
+          },
+          create: {
+            userId: gu.id,
+            trackSlug: "cyber-launch",
+            moduleSlug: moduleSlugs[i],
+            ...fullFields,
+          },
+          update: fullFields,
+        });
+      }
+    }
+
+    // ── Draft cohort: ETO Summer 2026 — Planning ──
+    await prisma.pathwayCohort.upsert({
+      where: { joinCode: "ETO2026S" },
+      create: {
+        name: "ETO Summer 2026 — Planning",
+        band: "mixed",
+        sitePartner: "Escape The Odds — TBD",
+        facilitatorId: facilitator.id,
+        trackIds: ["cyber-launch"],
+        joinCode: "ETO2026S",
+        status: "draft",
+        description:
+          "Planning cohort for the summer intensive — site partner and exact dates TBD. Recruiting begins June.",
+        maxEnrollment: 16,
+        startDate: new Date("2026-06-15"),
+        endDate: new Date("2026-07-27"),
+        notes: [],
+      },
+      update: { facilitatorId: facilitator.id, status: "draft" },
+    });
+
+    console.log(
+      "Seeded Pathways cohorts (3: active/ended/draft), enrollments, and milestones.",
+    );
+
+    // ─── Onboarding seed for demo accounts ───────────────────────────────────
+    // Marcus and Coach Davis show up to demos as already-onboarded so the
+    // welcome flow doesn't re-trigger every time the DB is re-seeded. Aisha
+    // is intentionally LEFT OUT — she's the "fresh-user" demo and should
+    // walk through the welcome flow when someone hits her account.
+    console.log("Seeding Pathways onboarding for demo accounts...");
+    const onboardingDemoData = [
+      {
+        email: "marcus@test.com",
+        avatarSlug: "analyst",
+        missionStatement:
+          "I want to build a real career in cybersecurity and help my community stay safe online.",
+        dailyGoalLevel: "medium",
+        // Demo intent: every fresh demo should see the toolbox intro fire on
+        // first CTF visit. Live sessions used to leave this `true`, breaking
+        // the demo story on the next showing. (Diagnostic finding L3.)
+        toolboxIntroSeen: false,
+      },
+      {
+        email: "facilitator@test.com",
+        avatarSlug: "guardian",
+        missionStatement:
+          "I want to help my students see themselves in this work and build real pathways forward.",
+        dailyGoalLevel: "heavy",
+        toolboxIntroSeen: false,
+      },
+    ];
+
+    for (const data of onboardingDemoData) {
+      const user = await prisma.user.findUnique({
+        where: { email: data.email },
+      });
+      if (!user) {
+        console.log(`  Skipping ${data.email} — user not found`);
+        continue;
+      }
+      const payload = {
+        avatarChosen: true,
+        avatarSlug: data.avatarSlug,
+        skillsTourViewed: true,
+        skillsTourSkipped: false,
+        missionStatement: data.missionStatement,
+        dailyGoalLevel: data.dailyGoalLevel,
+        toolboxIntroSeen: data.toolboxIntroSeen,
+        completedAt: new Date(),
+      };
+      await prisma.pathwayOnboarding.upsert({
+        where: { userId: user.id },
+        update: payload,
+        create: { userId: user.id, ...payload },
+      });
+      console.log(`  Seeded onboarding for ${data.email}: ${data.avatarSlug}`);
+    }
+
+    // Award the Getting Started badge so those accounts reflect the
+    // completed-onboarding state in their badge collection. XP for the
+    // badge will be picked up by the gamification backfill (which runs
+    // after this seed in predeploy.sh).
+    for (const { email } of onboardingDemoData) {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) continue;
+      await prisma.pathwayBadge.upsert({
+        where: { userId_slug: { userId: user.id, slug: "getting_started" } },
+        update: {},
+        create: {
+          userId: user.id,
+          slug: "getting_started",
+          metadata: { backfilled: true, source: "seed" },
+        },
+      });
+    }
+    console.log("  Awarded Getting Started badge to demo accounts");
+
+    // ─── Daily goals for today (demo accounts) ──────────────────────────────
+    // Without a row for "today", the home page goal card briefly renders an
+    // empty/skeleton state until the lazy server-side creation fires. Pre-
+    // seeding here means demos always open to a fully-rendered goal card.
+    // Aisha is intentionally LEFT OUT — she's the fresh-user demo and
+    // should hit the lazy creation path so we can show that flow.
+    //
+    // NOTE: this mirrors getDailyGoalTargets() in
+    // backend/src/services/gamification.ts. Keep slugs (`complete_section`,
+    // `earn_xp`, `try_lab_or_quiz`) stable — updateDailyGoalProgress() keys
+    // off them at runtime to credit progress.
+    function getDailyGoalTargets(level) {
+      const effective = level || "medium";
+      if (effective === "light") {
+        return [
+          { slug: "complete_section", label: "Complete 1 section", target: 1 },
+          { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+        ];
+      }
+      if (effective === "heavy") {
+        return [
+          { slug: "complete_section", label: "Complete 2 sections", target: 2 },
+          { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
+          {
+            slug: "try_lab_or_quiz",
+            label: "Try 1 lab or challenge",
+            target: 1,
+          },
+        ];
+      }
       return [
         { slug: "complete_section", label: "Complete 1 section", target: 1 },
-        { slug: "earn_xp", label: "Earn 30 XP", target: 30 },
+        { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
+        { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
       ];
     }
-    if (effective === "heavy") {
-      return [
-        { slug: "complete_section", label: "Complete 2 sections", target: 2 },
-        { slug: "earn_xp", label: "Earn 100 XP", target: 100 },
-        { slug: "try_lab_or_quiz", label: "Try 1 lab or challenge", target: 1 },
-      ];
+
+    const todayUtc = new Date();
+    todayUtc.setUTCHours(0, 0, 0, 0);
+
+    for (const data of onboardingDemoData) {
+      const user = await prisma.user.findUnique({
+        where: { email: data.email },
+      });
+      if (!user) continue;
+      const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
+        ...t,
+        current: 0,
+        completed: false,
+      }));
+      await prisma.pathwayDailyGoal.upsert({
+        where: { userId_date: { userId: user.id, date: todayUtc } },
+        // Don't clobber progress someone already accrued today; just ensure
+        // a row exists with the right shape.
+        update: {},
+        create: {
+          userId: user.id,
+          date: todayUtc,
+          goals,
+          allComplete: false,
+          bonusAwarded: false,
+        },
+      });
     }
-    return [
-      { slug: "complete_section", label: "Complete 1 section", target: 1 },
-      { slug: "earn_xp", label: "Earn 50 XP", target: 50 },
-      { slug: "try_lab_or_quiz", label: "Try 1 lab or quiz", target: 1 },
-    ];
-  }
-
-  const todayUtc = new Date();
-  todayUtc.setUTCHours(0, 0, 0, 0);
-
-  for (const data of onboardingDemoData) {
-    const user = await prisma.user.findUnique({ where: { email: data.email } });
-    if (!user) continue;
-    const goals = getDailyGoalTargets(data.dailyGoalLevel).map((t) => ({
-      ...t,
-      current: 0,
-      completed: false,
-    }));
-    await prisma.pathwayDailyGoal.upsert({
-      where: { userId_date: { userId: user.id, date: todayUtc } },
-      // Don't clobber progress someone already accrued today; just ensure
-      // a row exists with the right shape.
-      update: {},
-      create: {
-        userId: user.id,
-        date: todayUtc,
-        goals,
-        allComplete: false,
-        bonusAwarded: false,
-      },
-    });
-  }
-  console.log("  Seeded daily goals for demo accounts (today, by goal level)");
+    console.log(
+      "  Seeded daily goals for demo accounts (today, by goal level)",
+    );
   } catch (e) {
-    console.warn("Pathways seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Pathways seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1968,8 +3948,9 @@ async function main() {
   console.log("Seeding A/B experiments...");
   try {
     const creator =
-      (await prisma.user.findUnique({ where: { email: "facilitator@test.com" } })) ||
-      (await prisma.user.findFirst({ where: { role: "teacher" } }));
+      (await prisma.user.findUnique({
+        where: { email: "facilitator@test.com" },
+      })) || (await prisma.user.findFirst({ where: { role: "teacher" } }));
 
     if (creator) {
       await prisma.experiment.upsert({
@@ -1991,7 +3972,10 @@ async function main() {
       console.warn("No teacher user found — skipping experiment seed.");
     }
   } catch (e) {
-    console.warn("Experiment seed skipped (tables may not exist yet):", e.message);
+    console.warn(
+      "Experiment seed skipped (tables may not exist yet):",
+      e.message,
+    );
   }
 }
 

--- a/src/components/creations/GroupGallery.tsx
+++ b/src/components/creations/GroupGallery.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useApi } from "../../services/api";
 import CreationStatusChip, { type CreationStatus } from "./CreationStatusChip";
+import { trackToPolylinePoints } from "../games/trackMakerModel";
 
 // Phase 0 — group-scoped gallery of kid creations. Read path is GET
 // /creations?courseId= (server enforces group membership + visibility: shared/
@@ -17,7 +18,60 @@ type GalleryCreation = {
   encouragements: number;
   authorId: string;
   authorName: string;
+  /** Present for race_track only (the list endpoint ships the small track
+   *  layout so the card can draw its thumbnail). */
+  content?: unknown;
 };
+
+/** Playable creation types share the /student/challenge/:id player route. */
+const PLAYABLE_TYPES = new Set(["data_dash_challenge", "race_track"]);
+
+/**
+ * Mini track thumbnail for race_track cards. Any malformed/missing content
+ * yields no points, so we fall back to 🏍️ — the card must NEVER crash on a
+ * race_track creation, whatever its content looks like.
+ */
+function RaceTrackThumb({ content }: { content: unknown }) {
+  let points = "";
+  try {
+    const c = content as {
+      grid?: { w?: number; h?: number };
+      pieces?: unknown[];
+    } | null;
+    if (
+      c &&
+      typeof c.grid?.w === "number" &&
+      typeof c.grid?.h === "number" &&
+      Array.isArray(c.pieces)
+    ) {
+      points = trackToPolylinePoints(
+        c as Parameters<typeof trackToPolylinePoints>[0],
+        48,
+      );
+    }
+  } catch {
+    points = "";
+  }
+  if (!points) {
+    return (
+      <span className="text-2xl" aria-hidden>
+        🏍️
+      </span>
+    );
+  }
+  return (
+    <svg viewBox="0 0 48 48" className="w-12 h-12" aria-hidden>
+      <polyline
+        points={points}
+        fill="none"
+        stroke="#475569"
+        strokeWidth={5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
 export default function GroupGallery({
   courseId,
@@ -58,11 +112,19 @@ export default function GroupGallery({
   };
 
   if (state === "loading")
-    return <div className="p-6 text-center text-gray-500">{t("gallery.loading")}</div>;
+    return (
+      <div className="p-6 text-center text-gray-500">
+        {t("gallery.loading")}
+      </div>
+    );
   if (state === "error")
-    return <div className="p-6 text-center text-gray-600">{t("gallery.error")}</div>;
+    return (
+      <div className="p-6 text-center text-gray-600">{t("gallery.error")}</div>
+    );
   if (items.length === 0)
-    return <div className="p-6 text-center text-gray-600">{t("gallery.empty")}</div>;
+    return (
+      <div className="p-6 text-center text-gray-600">{t("gallery.empty")}</div>
+    );
 
   return (
     <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -72,16 +134,24 @@ export default function GroupGallery({
           className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm flex flex-col gap-2"
         >
           <div className="flex items-start justify-between gap-2">
-            <h3 className="font-semibold text-brightboost-navy">
-              {c.title || t("gallery.untitled")}
-            </h3>
+            <div className="flex items-center gap-2 min-w-0">
+              {c.type === "race_track" && (
+                <RaceTrackThumb content={c.content} />
+              )}
+              <h3 className="font-semibold text-brightboost-navy">
+                {c.title || t("gallery.untitled")}
+              </h3>
+            </div>
             <CreationStatusChip status={c.status} />
           </div>
           <p className="text-xs text-gray-500">
             {t("gallery.by", { name: c.authorName })}
           </p>
           <div className="mt-auto flex items-center justify-between pt-2">
-            <span className="text-sm text-amber-700" aria-label={t("gallery.boosts")}>
+            <span
+              className="text-sm text-amber-700"
+              aria-label={t("gallery.boosts")}
+            >
               ⭐ {c.encouragements}
             </span>
             {canEncourage ? (
@@ -92,12 +162,14 @@ export default function GroupGallery({
               >
                 {t("gallery.giveBoost")}
               </button>
-            ) : c.type === "data_dash_challenge" ? (
+            ) : PLAYABLE_TYPES.has(c.type) ? (
               <Link
                 to={`/student/challenge/${c.id}`}
                 className="px-3 py-1.5 text-sm rounded-md bg-brightboost-blue text-white font-semibold hover:bg-brightboost-navy"
               >
-                {t("gallery.play")}
+                {c.type === "race_track"
+                  ? t("gallery.ride", { defaultValue: "Ride" })
+                  : t("gallery.play")}
               </Link>
             ) : null}
           </div>

--- a/src/components/creations/__tests__/GroupGallery.test.tsx
+++ b/src/components/creations/__tests__/GroupGallery.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import GroupGallery from "../GroupGallery";
+
+// Mock i18n
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty" as const, init: () => {} },
+  I18nextProvider: ({ children }: { children: React.ReactNode }) => children,
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue || key,
+  }),
+}));
+
+// Mock useApi (GroupGallery imports ../../services/api)
+const mockGet = vi.fn();
+vi.mock("../../../services/api", () => ({
+  useApi: () => ({
+    get: mockGet,
+    post: vi.fn(),
+  }),
+}));
+
+const rideable = {
+  v: 1,
+  name: "Super Loop",
+  grid: { w: 8, h: 8 },
+  pieces: [
+    { x: 1, y: 3, type: "start", rot: 0 },
+    { x: 2, y: 3, type: "straight", rot: 0 },
+    { x: 3, y: 3, type: "finish", rot: 0 },
+  ],
+};
+
+function galleryItem(overrides: Record<string, unknown>) {
+  return {
+    id: "c1",
+    type: "data_dash_challenge",
+    title: "A Creation",
+    status: "COMPLETE",
+    encouragements: 0,
+    authorId: "u1",
+    authorName: "Ada",
+    ...overrides,
+  };
+}
+
+function renderGallery() {
+  return render(
+    <MemoryRouter>
+      <GroupGallery courseId="course-1" canEncourage={false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("GroupGallery — race_track cards (HARD REQUIREMENT: never crash)", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it("renders a race_track card with a polyline thumbnail and a Ride link", async () => {
+    mockGet.mockResolvedValue([
+      galleryItem({
+        type: "race_track",
+        title: "Super Loop",
+        content: rideable,
+      }),
+    ]);
+    const { container } = renderGallery();
+    await waitFor(() => expect(screen.getByText("Super Loop")).toBeTruthy());
+    expect(container.querySelector("svg polyline")).toBeTruthy();
+    const ride = screen.getByText("Ride");
+    expect(ride.closest("a")?.getAttribute("href")).toBe(
+      "/student/challenge/c1",
+    );
+  });
+
+  it("does NOT crash on a race_track card with malformed content — falls back to 🏍️", async () => {
+    mockGet.mockResolvedValue([
+      galleryItem({
+        type: "race_track",
+        title: "Broken Track",
+        content: { totally: "wrong", pieces: "not-an-array" },
+      }),
+    ]);
+    const { container } = renderGallery();
+    await waitFor(() => expect(screen.getByText("Broken Track")).toBeTruthy());
+    expect(container.querySelector("svg polyline")).toBeFalsy();
+    expect(screen.getByText("🏍️")).toBeTruthy();
+  });
+
+  it("does NOT crash on a race_track card with missing content — falls back to 🏍️", async () => {
+    mockGet.mockResolvedValue([
+      galleryItem({ type: "race_track", title: "No Layout" }),
+    ]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("No Layout")).toBeTruthy());
+    expect(screen.getByText("🏍️")).toBeTruthy();
+  });
+
+  it("does NOT crash on a race_track track that isn't rideable (dangling road)", async () => {
+    mockGet.mockResolvedValue([
+      galleryItem({
+        type: "race_track",
+        title: "Dangling",
+        content: {
+          ...rideable,
+          pieces: [
+            { x: 1, y: 3, type: "start", rot: 0 },
+            { x: 6, y: 6, type: "finish", rot: 0 },
+          ],
+        },
+      }),
+    ]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("Dangling")).toBeTruthy());
+    expect(screen.getByText("🏍️")).toBeTruthy();
+  });
+
+  it("keeps the Play link for data_dash_challenge cards (no regression)", async () => {
+    mockGet.mockResolvedValue([galleryItem({ title: "Sort It" })]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("Sort It")).toBeTruthy());
+    expect(screen.getByText("gallery.play")).toBeTruthy();
+  });
+});

--- a/src/components/games/TrackMakerGame.tsx
+++ b/src/components/games/TrackMakerGame.tsx
@@ -1,0 +1,1408 @@
+/**
+ * Boost Track Builder — Set 3 · game 1 ("mastery through making").
+ *
+ * The kid designs a motorcycle track (tap-to-place pieces), then rides it —
+ * the ride's whole challenge comes from their own design. Spin-outs are
+ * information about the track, never a game-over. The track persists as a
+ * Creation (`type: "race_track"`); rules live in ./trackMakerModel.ts and
+ * are unit-tested there. Design doc: docs/games/set3-track-maker-design.md.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import GameShell, { type GameResult } from "./shared/GameShell";
+import { getGradeBand } from "./gradeBandContent";
+import { pickLocale } from "@/utils/localizedContent";
+import { useApi } from "@/services/api";
+import {
+  CURVE_TOLERANCE,
+  DEFAULT_GRID,
+  NAME_KIT_ADJECTIVES,
+  NAME_KIT_NOUNS,
+  PATTERN_BOOK,
+  SOFT_TARGETS,
+  buildTrackMakerResult,
+  initialRideState,
+  newlyUnlocked,
+  pickReflectPrompt,
+  starterTrack,
+  stepRide,
+  suggestUniqueName,
+  trackToPolylinePoints,
+  unlockedPieceTypes,
+  validateRaceTrackContent,
+  walkTrack,
+  type PieceType,
+  type RaceTrackContent,
+  type ReflectPrompt,
+  type RideState,
+  type Rot,
+  type TrackPiece,
+} from "./trackMakerModel";
+
+// ── Local draft (autosave-on-navigate: nothing is ever lost) ────────────────
+// The server only ever stores RIDEABLE tracks (the validator is the security
+// boundary, so peers can never open a broken one). Mid-edit states that
+// aren't rideable yet are kept here so navigating away loses nothing.
+const DRAFT_KEY = "bb_track_maker_draft_v1";
+
+interface TrackDraft {
+  name: string;
+  pieces: TrackPiece[];
+  creationId: string | null;
+  ridesCompleted: number;
+}
+
+function loadDraft(): TrackDraft | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return null;
+    const d = JSON.parse(raw) as TrackDraft;
+    if (!Array.isArray(d.pieces) || typeof d.name !== "string") return null;
+    return d;
+  } catch {
+    return null;
+  }
+}
+
+function persistDraft(draft: TrackDraft) {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // Storage full/blocked — the in-memory state still stands.
+  }
+}
+
+// ── Piece rendering (simple per-cell SVG roads) ─────────────────────────────
+
+const ROAD = "#475569";
+const ROAD_EDGE = "#f59e0b";
+
+function PieceSvg({ type }: { type: PieceType }) {
+  switch (type) {
+    case "straight":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <path d="M 0 50 H 100" stroke={ROAD} strokeWidth={36} fill="none" />
+          <path
+            d="M 8 50 H 92"
+            stroke="#fff"
+            strokeWidth={3}
+            strokeDasharray="10 10"
+            fill="none"
+          />
+        </svg>
+      );
+    case "gentleCurve":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <path
+            d="M 50 0 Q 50 50 100 50"
+            stroke={ROAD}
+            strokeWidth={36}
+            fill="none"
+          />
+        </svg>
+      );
+    case "sharpCurve":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <path
+            d="M 50 0 L 50 50 L 100 50"
+            stroke={ROAD}
+            strokeWidth={36}
+            fill="none"
+            strokeLinejoin="miter"
+          />
+          <path
+            d="M 50 6 L 50 50 L 94 50"
+            stroke={ROAD_EDGE}
+            strokeWidth={4}
+            fill="none"
+            strokeDasharray="8 6"
+          />
+        </svg>
+      );
+    case "boost":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <path d="M 0 50 H 100" stroke={ROAD} strokeWidth={36} fill="none" />
+          <text x="50" y="62" textAnchor="middle" fontSize="34">
+            ⚡
+          </text>
+        </svg>
+      );
+    case "start":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <path d="M 50 50 H 100" stroke={ROAD} strokeWidth={36} fill="none" />
+          <circle cx="42" cy="50" r="24" fill="#16a34a" />
+          <text x="42" y="60" textAnchor="middle" fontSize="28">
+            🏍️
+          </text>
+        </svg>
+      );
+    case "finish":
+      return (
+        <svg viewBox="0 0 100 100" className="w-full h-full" aria-hidden>
+          <circle cx="50" cy="50" r="30" fill={ROAD} />
+          <text x="50" y="62" textAnchor="middle" fontSize="34">
+            🏁
+          </text>
+        </svg>
+      );
+  }
+}
+
+function PieceTile({ piece }: { piece: TrackPiece }) {
+  // The finish accepts entry from any side, so rotating its glyph would only
+  // flip the 🏁 upside down — keep it upright.
+  const rot = piece.type === "finish" ? 0 : piece.rot;
+  return (
+    <div className="w-full h-full" style={{ transform: `rotate(${rot}deg)` }}>
+      <PieceSvg type={piece.type} />
+    </div>
+  );
+}
+
+const PALETTE_LABEL_KEYS: Record<PieceType, { key: string; en: string }> = {
+  start: { key: "games.trackMaker.piece.start", en: "Start" },
+  straight: { key: "games.trackMaker.piece.straight", en: "Straight" },
+  gentleCurve: {
+    key: "games.trackMaker.piece.gentleCurve",
+    en: "Gentle curve",
+  },
+  sharpCurve: { key: "games.trackMaker.piece.sharpCurve", en: "Sharp curve" },
+  boost: { key: "games.trackMaker.piece.boost", en: "Boost pad" },
+  finish: { key: "games.trackMaker.piece.finish", en: "Finish flag" },
+};
+
+// ── Bike geometry: position along the walked path ───────────────────────────
+
+type Dir = "N" | "E" | "S" | "W";
+const SIDE_MID: Record<Dir, [number, number]> = {
+  N: [0.5, 0],
+  E: [1, 0.5],
+  S: [0.5, 1],
+  W: [0, 0.5],
+};
+
+function dirBetween(a: TrackPiece, b: TrackPiece): Dir {
+  if (b.x > a.x) return "E";
+  if (b.x < a.x) return "W";
+  if (b.y > a.y) return "S";
+  return "N";
+}
+
+/** Bike position in cell units: entry-mid → center → exit-mid polyline. */
+function bikePosition(
+  path: TrackPiece[],
+  pieceIndex: number,
+  progress: number,
+): { x: number; y: number } {
+  const piece = path[Math.min(pieceIndex, path.length - 1)];
+  const prev = path[pieceIndex - 1];
+  const next = path[pieceIndex + 1];
+  const entry: [number, number] = prev
+    ? SIDE_MID[
+        dirBetween(prev, piece) === "E"
+          ? "W"
+          : dirBetween(prev, piece) === "W"
+            ? "E"
+            : dirBetween(prev, piece) === "S"
+              ? "N"
+              : "S"
+      ]
+    : [0.5, 0.5];
+  const exit: [number, number] = next
+    ? SIDE_MID[dirBetween(piece, next)]
+    : [0.5, 0.5];
+  const center: [number, number] = [0.5, 0.5];
+  const [fx, fy] =
+    progress < 0.5
+      ? [
+          entry[0] + (center[0] - entry[0]) * (progress * 2),
+          entry[1] + (center[1] - entry[1]) * (progress * 2),
+        ]
+      : [
+          center[0] + (exit[0] - center[0]) * ((progress - 0.5) * 2),
+          center[1] + (exit[1] - center[1]) * ((progress - 0.5) * 2),
+        ];
+  return { x: piece.x + fx, y: piece.y + fy };
+}
+
+// ── The game core ───────────────────────────────────────────────────────────
+
+type Screen = "imagine" | "build" | "ride";
+
+interface CoreProps {
+  onFinish: (result: GameResult) => void;
+  reducedEffects: boolean;
+  band: "k2" | "g3_5";
+  /** Peer-ride mode: ride a classmate's saved track — no editing, no saving,
+   *  and never touching the local builder draft. */
+  fixedTrack?: RaceTrackContent | null;
+}
+
+function TrackMakerCore({
+  onFinish,
+  reducedEffects,
+  band,
+  fixedTrack,
+}: CoreProps) {
+  const { t } = useTranslation();
+  const api = useApi();
+  const rideOnly = !!fixedTrack;
+
+  // Build state
+  const draft = useMemo(() => (rideOnly ? null : loadDraft()), [rideOnly]);
+  const [screen, setScreen] = useState<Screen>(
+    rideOnly || draft ? "build" : "imagine",
+  );
+  const [pieces, setPieces] = useState<TrackPiece[]>(
+    fixedTrack?.pieces ?? draft?.pieces ?? starterTrack(),
+  );
+  const [name, setName] = useState<string>(
+    fixedTrack?.name ?? draft?.name ?? "",
+  );
+  const [tool, setTool] = useState<PieceType | "erase">("straight");
+  const [ridesCompleted, setRidesCompleted] = useState(
+    draft?.ridesCompleted ?? 0,
+  );
+  const [hintCell, setHintCell] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
+  // Maker telemetry (iteration signals, never rankings)
+  const [tweaks, setTweaks] = useState(0);
+  const tweaksSinceRideRef = useRef(0);
+  const [iterated, setIterated] = useState(false);
+  const [spinOutsTotal, setSpinOutsTotal] = useState(0);
+  const [targetsMet, setTargetsMet] = useState<Set<string>>(new Set());
+  const cleanStreakRef = useRef(0);
+  const bestCleanStreakRef = useRef(0);
+
+  // Overlays
+  const [announce, setAnnounce] = useState<PieceType[]>([]);
+  const [showIdeas, setShowIdeas] = useState(false);
+  const [pendingPattern, setPendingPattern] = useState<string | null>(null);
+  const [showNamePicker, setShowNamePicker] = useState(!draft && !rideOnly);
+  const [reflect, setReflect] = useState<ReflectPrompt | null>(null);
+  const [targetJustMet, setTargetJustMet] = useState<string | null>(null);
+
+  // Save state
+  const [creationId, setCreationId] = useState<string | null>(
+    draft?.creationId ?? null,
+  );
+  const [courseId, setCourseId] = useState<string | null>(null);
+  const [existingTitles, setExistingTitles] = useState<string[]>([]);
+  const [saveNote, setSaveNote] = useState<"saved" | "savedLocal" | null>(null);
+  const [shared, setShared] = useState(false);
+
+  const grid = DEFAULT_GRID;
+  const unlocked = unlockedPieceTypes(ridesCompleted);
+  const newPieceCandidatesRef = useRef<Set<PieceType>>(new Set());
+
+  const content: RaceTrackContent = useMemo(
+    () => ({
+      v: 1,
+      name:
+        name ||
+        `${pickLocale<string>(NAME_KIT_ADJECTIVES[0].label, "Super")} ${pickLocale<string>(NAME_KIT_NOUNS[0].label, "Track")}`,
+      grid,
+      pieces,
+    }),
+    [name, grid, pieces],
+  );
+  const validation = useMemo(
+    () => validateRaceTrackContent(content),
+    [content],
+  );
+  const rideable = validation.ok;
+
+  // ── Group context (for saving to the gallery) ──
+  useEffect(() => {
+    if (rideOnly) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        // GET /student/courses returns enrollment rows shaped
+        // { courseId, courseName, gradeBand, ... } — the id field is courseId.
+        const courses = (await api.get("/student/courses")) as {
+          courseId: string;
+        }[];
+        const list = Array.isArray(courses) ? courses : [];
+        if (!cancelled && list.length > 0) {
+          setCourseId(list[0].courseId);
+          try {
+            const creations = (await api.get(
+              `/creations?courseId=${list[0].courseId}`,
+            )) as { type: string; title: string | null }[];
+            if (!cancelled) {
+              setExistingTitles(
+                creations
+                  .filter((c) => c.type === "race_track")
+                  .map((c) => c.title ?? ""),
+              );
+            }
+          } catch {
+            /* gallery list is a nice-to-have for the dup-name guard */
+          }
+        }
+      } catch {
+        /* no course → local-only mode; building still works */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Persistence ──
+  const latestRef = useRef({ name, pieces, creationId, ridesCompleted });
+  latestRef.current = { name, pieces, creationId, ridesCompleted };
+
+  const persistLocal = useCallback(() => {
+    if (rideOnly) return; // a peer's track must never clobber my own draft
+    const s = latestRef.current;
+    persistDraft({
+      name: s.name,
+      pieces: s.pieces,
+      creationId: s.creationId,
+      ridesCompleted: s.ridesCompleted,
+    });
+  }, [rideOnly]);
+
+  useEffect(() => {
+    persistLocal();
+  }, [pieces, name, creationId, ridesCompleted, persistLocal]);
+  // Autosave on navigate-away (unmount): local always; server if rideable.
+  useEffect(() => {
+    if (rideOnly) return;
+    return () => {
+      persistLocal();
+      void saveToServerRef.current?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /** Saves the CURRENT track in place (never forks): first save POSTs a new
+   *  Creation, every later save PATCHes the same row. Returns the creation
+   *  id on server success, null when the save stayed local-only. */
+  const saveToServer = useCallback(async (): Promise<string | null> => {
+    const s = latestRef.current;
+    const c: RaceTrackContent = {
+      v: 1,
+      name: content.name,
+      grid,
+      pieces: s.pieces,
+    };
+    if (!validateRaceTrackContent(c).ok || !courseId) {
+      setSaveNote("savedLocal");
+      return null;
+    }
+    try {
+      if (s.creationId) {
+        await api.patch(`/creations/${s.creationId}`, { content: c });
+        setSaveNote("saved");
+        return s.creationId;
+      }
+      const created = (await api.post("/creations", {
+        courseId,
+        type: "race_track",
+        content: c,
+      })) as { id: string };
+      setCreationId(created.id);
+      setSaveNote("saved");
+      return created.id;
+    } catch {
+      // Server said no (e.g. offline) — the local draft still has everything.
+      setSaveNote("savedLocal");
+      return null;
+    }
+  }, [api, content.name, courseId, grid]);
+  const saveToServerRef = useRef(saveToServer);
+  saveToServerRef.current = saveToServer;
+
+  useEffect(() => {
+    if (!saveNote) return;
+    const id = setTimeout(() => setSaveNote(null), 2000);
+    return () => clearTimeout(id);
+  }, [saveNote]);
+
+  // ── Build actions ──
+  const editPiece = useCallback(
+    (x: number, y: number) => {
+      setHintCell(null);
+      const at = pieces.find((p) => p.x === x && p.y === y);
+      if (at) {
+        if (at.type === "start") return; // the start is anchored
+        if (tool === "erase") {
+          setPieces((prev) => prev.filter((p) => !(p.x === x && p.y === y)));
+        } else {
+          // Tapping any placed piece rotates it — one predictable rule.
+          setPieces((prev) =>
+            prev.map((p) =>
+              p.x === x && p.y === y
+                ? { ...p, rot: ((p.rot + 90) % 360) as Rot }
+                : p,
+            ),
+          );
+        }
+      } else {
+        if (tool === "erase" || !unlocked.includes(tool)) return;
+        setPieces((prev) => [...prev, { x, y, type: tool, rot: 0 as Rot }]);
+      }
+      setTweaks((n) => n + 1);
+      tweaksSinceRideRef.current += 1;
+    },
+    [pieces, tool, unlocked],
+  );
+
+  const applyPattern = useCallback((patternId: string) => {
+    const pattern = PATTERN_BOOK.find((p) => p.id === patternId);
+    if (!pattern) return;
+    setPieces(pattern.pieces.map((p) => ({ ...p })));
+    setTweaks((n) => n + 1);
+    tweaksSinceRideRef.current += 1;
+    setPendingPattern(null);
+    setShowIdeas(false);
+  }, []);
+
+  // ── Ride ──
+  const [ridePath, setRidePath] = useState<TrackPiece[] | null>(null);
+  const [rideSnap, setRideSnap] = useState<RideState>(initialRideState());
+  const [rideMsg, setRideMsg] = useState<"spinOut" | "wobble" | null>(null);
+  const rideRef = useRef<RideState>(initialRideState());
+  const leaningRef = useRef(false);
+  const pausedUntilRef = useRef(0);
+  const rafRef = useRef(0);
+  const lastTsRef = useRef(0);
+  const rideDoneRef = useRef(false);
+
+  const startRide = useCallback(() => {
+    const walk = walkTrack({ grid, pieces });
+    if (!walk.ok) {
+      if (walk.at) setHintCell(walk.at);
+      return;
+    }
+    if (!rideOnly) void saveToServer();
+    setRidePath(walk.path);
+    rideRef.current = initialRideState();
+    setRideSnap(rideRef.current);
+    setRideMsg(null);
+    rideDoneRef.current = false;
+    leaningRef.current = false;
+    pausedUntilRef.current = 0;
+    lastTsRef.current = 0;
+    setScreen("ride");
+  }, [grid, pieces, rideOnly, saveToServer]);
+
+  // Peer-ride mode goes straight to riding — the whole visit is the ride.
+  useEffect(() => {
+    if (rideOnly) startRide();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rideOnly]);
+
+  const finishRide = useCallback(() => {
+    const state = rideRef.current;
+    const path = ridePath ?? [];
+    const before = ridesCompleted;
+    const after = before + 1;
+    setRidesCompleted(after);
+
+    // Unlock announcements (one completed ride per unlock; spin-outs never
+    // gate). Peer rides don't earn builder unlocks — those are for making.
+    if (!rideOnly) {
+      const fresh = newlyUnlocked(before, after);
+      if (fresh.length > 0) {
+        setAnnounce((q) => [...q, ...fresh]);
+        fresh.forEach((p) => newPieceCandidatesRef.current.add(p));
+      }
+    }
+
+    // Clean streak (client-only feel-good stat, never a ranking)
+    if (state.spinOuts === 0) {
+      cleanStreakRef.current += 1;
+      bestCleanStreakRef.current = Math.max(
+        bestCleanStreakRef.current,
+        cleanStreakRef.current,
+      );
+    } else {
+      cleanStreakRef.current = 0;
+    }
+    setSpinOutsTotal((n) => n + state.spinOuts);
+
+    // Iteration = tweaked after a previous ride, then completed another
+    if (before > 0 && tweaksSinceRideRef.current > 0) setIterated(true);
+    tweaksSinceRideRef.current = 0;
+
+    // Soft targets (suggestions, never requirements)
+    const ctx = {
+      path,
+      boostsHit: state.boostsHit,
+      piecesOnTrack: pieces.length,
+    };
+    const newlyMet = SOFT_TARGETS.filter(
+      (target) => !targetsMet.has(target.id) && target.met(ctx),
+    ).map((target) => target.id);
+    if (newlyMet.length > 0) {
+      setTargetsMet((prev) => new Set([...prev, ...newlyMet]));
+    }
+    setTargetJustMet(newlyMet[0] ?? null);
+
+    // Context-aware Reflect prompt
+    let newPieceRidden: PieceType | undefined;
+    for (const p of path) {
+      if (newPieceCandidatesRef.current.has(p.type)) {
+        newPieceRidden = p.type;
+        newPieceCandidatesRef.current.delete(p.type);
+        break;
+      }
+    }
+    setReflect(
+      pickReflectPrompt({
+        spinOuts: state.spinOuts,
+        boostsHit: state.boostsHit,
+        newPieceRidden,
+      }),
+    );
+  }, [pieces.length, ridePath, ridesCompleted, rideOnly, targetsMet]);
+
+  useEffect(() => {
+    if (screen !== "ride" || !ridePath) return;
+    const tol = CURVE_TOLERANCE[band];
+    const loop = (ts: number) => {
+      if (rideDoneRef.current) return;
+      if (!lastTsRef.current) lastTsRef.current = ts;
+      const dt = Math.min(0.05, (ts - lastTsRef.current) / 1000);
+      lastTsRef.current = ts;
+
+      if (ts >= pausedUntilRef.current) {
+        const { state, events } = stepRide(
+          rideRef.current,
+          ridePath,
+          dt,
+          leaningRef.current,
+          tol,
+        );
+        rideRef.current = state;
+        setRideSnap(state);
+        if (events.spunOut) {
+          setRideMsg("spinOut");
+          pausedUntilRef.current = ts + (reducedEffects ? 800 : 1400);
+        } else if (events.wobbled) {
+          setRideMsg("wobble");
+        } else if (events.entered) {
+          setRideMsg(null);
+        }
+        if (events.finished) {
+          rideDoneRef.current = true;
+          finishRide();
+          return;
+        }
+      }
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [screen, ridePath, band, reducedEffects, finishRide]);
+
+  // Keyboard: hold Space/ArrowDown to lean (mouse users get the button)
+  useEffect(() => {
+    if (screen !== "ride") return;
+    const down = (e: KeyboardEvent) => {
+      if (e.code === "Space" || e.code === "ArrowDown") {
+        e.preventDefault();
+        leaningRef.current = true;
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === "Space" || e.code === "ArrowDown")
+        leaningRef.current = false;
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [screen]);
+
+  // ── Finish the whole session ──
+  const done = useCallback(() => {
+    onFinish(
+      buildTrackMakerResult({
+        rideable,
+        ridesCompleted,
+        iterated,
+        targetsMet: targetsMet.size,
+        bestCleanStreak: bestCleanStreakRef.current,
+        spinOuts: spinOutsTotal,
+        tweaks,
+        sharedToGallery: shared,
+      }),
+    );
+  }, [
+    onFinish,
+    rideable,
+    ridesCompleted,
+    iterated,
+    targetsMet,
+    spinOutsTotal,
+    tweaks,
+    shared,
+  ]);
+
+  const shareToGallery = useCallback(async () => {
+    const id = latestRef.current.creationId ?? (await saveToServer());
+    if (!id) return;
+    try {
+      await api.patch(`/creations/${id}`, { status: "COMPLETE" });
+      setShared(true);
+    } catch {
+      /* stays unshared; button remains available */
+    }
+  }, [api, saveToServer]);
+
+  const applyName = useCallback(
+    (adjLabel: string, nounLabel: string) => {
+      const base = `${adjLabel} ${nounLabel}`;
+      setName(suggestUniqueName(base, existingTitles));
+      setShowNamePicker(false);
+      if (latestRef.current.creationId) void saveToServer();
+    },
+    [existingTitles, saveToServer],
+  );
+
+  // ── Screens ──
+
+  if (screen === "imagine") {
+    return (
+      <div className="flex flex-col items-center gap-6 text-center py-10 px-4">
+        <div className="text-6xl" aria-hidden>
+          🏍️
+        </div>
+        <h2 className="text-2xl font-bold text-slate-800">
+          {t("games.trackMaker.imagine.prompt", {
+            defaultValue:
+              "What kind of track will you build — loopy, zoomy, twisty?",
+          })}
+        </h2>
+        <p className="text-slate-600 max-w-md">
+          {t("games.trackMaker.imagine.hint", {
+            defaultValue: "Build a track for Boost's motorcycle, then ride it!",
+          })}
+        </p>
+        <button
+          type="button"
+          onClick={() => setScreen("build")}
+          className="min-h-14 px-10 rounded-full bg-green-600 text-white text-xl font-bold shadow-lg active:scale-95 touch-manipulation"
+        >
+          {t("games.trackMaker.imagine.start", {
+            defaultValue: "Start building!",
+          })}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setScreen("build");
+            setShowIdeas(true);
+          }}
+          className="min-h-11 px-6 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+        >
+          {t("games.trackMaker.ideas.open", {
+            defaultValue: "Show me ideas 📖",
+          })}
+        </button>
+      </div>
+    );
+  }
+
+  if (screen === "ride" && ridePath) {
+    const pos = bikePosition(ridePath, rideSnap.pieceIndex, rideSnap.progress);
+    const nextPiece = ridePath[rideSnap.pieceIndex + 1];
+    const cellPct = 100 / grid.w;
+    const tol = CURVE_TOLERANCE[band];
+    return (
+      <div className="flex flex-col items-center gap-3 w-full">
+        {/* Speed bar with the curve-safe zone marked */}
+        <div className="w-full max-w-[520px] px-1">
+          <div
+            className="relative h-4 rounded-full bg-slate-200 overflow-hidden"
+            aria-hidden
+          >
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-green-400 via-yellow-400 to-red-500 transition-[width] duration-75"
+              style={{ width: `${Math.round(rideSnap.speed * 100)}%` }}
+            />
+            <div
+              className="absolute inset-y-0 w-0.5 bg-slate-700"
+              style={{ left: `${tol.sharpCurve * 100}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-xs text-slate-500 mt-0.5">
+            <span>
+              {t("games.trackMaker.ride.lean", { defaultValue: "leaning" })}
+            </span>
+            {nextPiece?.type === "sharpCurve" && (
+              <span className="font-bold text-amber-600" role="status">
+                {t("games.trackMaker.ride.sharpAhead", {
+                  defaultValue: "Sharp curve ahead!",
+                })}
+              </span>
+            )}
+            {nextPiece?.type === "gentleCurve" && (
+              <span className="font-semibold text-sky-600" role="status">
+                {t("games.trackMaker.ride.curveAhead", {
+                  defaultValue: "Curve ahead",
+                })}
+              </span>
+            )}
+            <span>
+              {t("games.trackMaker.ride.zoom", { defaultValue: "zooming" })}
+            </span>
+          </div>
+        </div>
+
+        {/* The track with the bike */}
+        <div
+          className="relative w-full max-w-[520px] rounded-2xl bg-emerald-100 p-1"
+          style={{ aspectRatio: `${grid.w} / ${grid.h}` }}
+        >
+          {pieces.map((p) => (
+            <div
+              key={`${p.x},${p.y}`}
+              className="absolute"
+              style={{
+                left: `${p.x * cellPct}%`,
+                top: `${p.y * (100 / grid.h)}%`,
+                width: `${cellPct}%`,
+                height: `${100 / grid.h}%`,
+              }}
+            >
+              <PieceTile piece={p} />
+            </div>
+          ))}
+          <div
+            className={`absolute text-2xl -translate-x-1/2 -translate-y-1/2 ${
+              rideSnap.wobbling && !reducedEffects ? "shake" : ""
+            }`}
+            style={{
+              left: `${(pos.x / grid.w) * 100}%`,
+              top: `${(pos.y / grid.h) * 100}%`,
+            }}
+            aria-hidden
+          >
+            🏍️
+          </div>
+          {rideMsg === "spinOut" && (
+            <div
+              className="absolute inset-x-4 top-1/3 rounded-2xl bg-white/95 border-2 border-amber-300 p-3 text-center text-slate-800 font-semibold shadow-lg"
+              role="status"
+            >
+              {t("games.trackMaker.ride.spinOut", {
+                defaultValue:
+                  "Whoa — too fast for that curve! Boost is okay. Try holding LEAN before the turn.",
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* THE one input */}
+        <button
+          type="button"
+          onPointerDown={() => {
+            leaningRef.current = true;
+          }}
+          onPointerUp={() => {
+            leaningRef.current = false;
+          }}
+          onPointerLeave={() => {
+            leaningRef.current = false;
+          }}
+          onPointerCancel={() => {
+            leaningRef.current = false;
+          }}
+          className="w-full max-w-xs min-h-16 rounded-full bg-sky-600 text-white text-2xl font-extrabold shadow-lg active:scale-95 select-none touch-manipulation"
+          aria-label={t("games.trackMaker.ride.holdToLean", {
+            defaultValue: "Hold to lean into curves",
+          })}
+        >
+          {t("games.trackMaker.ride.holdButton", {
+            defaultValue: "HOLD to lean 🏍️",
+          })}
+        </button>
+        {rideMsg === "wobble" && (
+          <p className="text-amber-600 font-semibold" role="status">
+            {t("games.trackMaker.ride.wobble", {
+              defaultValue: "Wobbly! Just made it!",
+            })}
+          </p>
+        )}
+
+        {/* Reflect beat — a wondering question, separate from save/name */}
+        {reflect && (
+          <div className="fixed inset-0 z-40 bg-slate-900/50 flex items-center justify-center p-4">
+            <div className="bg-white rounded-3xl p-6 max-w-md w-full text-center flex flex-col gap-4 shadow-2xl">
+              <div className="text-4xl" aria-hidden>
+                🏁
+              </div>
+              <h3 className="text-xl font-bold text-slate-800">
+                {t("games.trackMaker.ride.finished", {
+                  defaultValue: "You finished your track!",
+                })}
+              </h3>
+              <p className="text-slate-700 text-lg">
+                {t(reflect.key, reflect.params)}
+              </p>
+              {targetJustMet && (
+                <p className="text-green-700 font-semibold" role="status">
+                  {t(`games.trackMaker.target.${targetJustMet}Met`, {
+                    defaultValue:
+                      "You did it — that was one of the try-this ideas! ⭐",
+                  })}
+                </p>
+              )}
+              <div className="flex flex-col gap-2">
+                {!rideOnly && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setReflect(null);
+                      setScreen("build");
+                    }}
+                    className="min-h-12 rounded-full bg-green-600 text-white font-bold text-lg active:scale-95 touch-manipulation"
+                  >
+                    {t("games.trackMaker.ride.tweak", {
+                      defaultValue: "Tweak my track 🔧",
+                    })}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setReflect(null);
+                    startRide();
+                  }}
+                  className="min-h-12 rounded-full bg-sky-600 text-white font-bold text-lg active:scale-95 touch-manipulation"
+                >
+                  {t("games.trackMaker.ride.again", {
+                    defaultValue: "Ride again 🏍️",
+                  })}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setReflect(null);
+                    done();
+                  }}
+                  className="min-h-11 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+                >
+                  {t("games.trackMaker.ride.done", {
+                    defaultValue: "Done for now",
+                  })}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── Build screen ──
+  const currentTarget = SOFT_TARGETS.find((s) => !targetsMet.has(s.id));
+  const displayName =
+    name || t("games.trackMaker.build.unnamed", { defaultValue: "My Track" });
+
+  return (
+    <div className="flex flex-col items-center gap-3 w-full">
+      {/* Top bar: the current track's name is always visible */}
+      <div className="w-full max-w-[520px] flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => setShowNamePicker(true)}
+          className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-800 active:scale-95 touch-manipulation"
+          aria-label={t("games.trackMaker.build.renameAria", {
+            defaultValue: "Track name — tap to change",
+          })}
+        >
+          🏷️ {displayName}
+        </button>
+        <div className="flex items-center gap-2">
+          {saveNote && (
+            <span className="text-xs text-slate-500" role="status">
+              {saveNote === "saved"
+                ? t("games.trackMaker.build.saved", { defaultValue: "Saved ✓" })
+                : t("games.trackMaker.build.savedLocal", {
+                    defaultValue: "Saved on this device ✓",
+                  })}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => void saveToServer()}
+            className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-semibold text-slate-700 active:scale-95 touch-manipulation"
+          >
+            {t("games.trackMaker.build.save", { defaultValue: "Save" })}
+          </button>
+        </div>
+      </div>
+
+      {/* Soft target — a suggestion, never a requirement */}
+      {currentTarget && (
+        <p className="text-sm text-slate-600" role="status">
+          💡{" "}
+          {t(`games.trackMaker.target.${currentTarget.id}`, {
+            defaultValue:
+              "Try this: can you build a track with 2 curves the bike survives?",
+          })}
+        </p>
+      )}
+
+      {/* The build grid */}
+      <div
+        className="grid w-full max-w-[520px] gap-0.5 rounded-2xl bg-emerald-100 p-1 touch-manipulation"
+        style={{ gridTemplateColumns: `repeat(${grid.w}, minmax(0, 1fr))` }}
+        role="group"
+        aria-label={t("games.trackMaker.build.gridAria", {
+          defaultValue: "Track building grid",
+        })}
+      >
+        {Array.from({ length: grid.w * grid.h }, (_, i) => {
+          const x = i % grid.w;
+          const y = Math.floor(i / grid.w);
+          const piece = pieces.find((p) => p.x === x && p.y === y);
+          const isHint = hintCell?.x === x && hintCell?.y === y;
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => editPiece(x, y)}
+              className={`relative aspect-square min-w-11 min-h-11 rounded-md bg-emerald-50/70 active:scale-95 touch-manipulation ${
+                isHint ? "ring-4 ring-amber-400" : ""
+              }`}
+              aria-label={
+                piece
+                  ? t("games.trackMaker.build.cellPieceAria", {
+                      defaultValue: "{{piece}} — tap to turn it",
+                      piece: t(PALETTE_LABEL_KEYS[piece.type].key, {
+                        defaultValue: PALETTE_LABEL_KEYS[piece.type].en,
+                      }),
+                    })
+                  : t("games.trackMaker.build.cellEmptyAria", {
+                      defaultValue: "Empty spot — tap to place a piece",
+                    })
+              }
+            >
+              {piece && <PieceTile piece={piece} />}
+            </button>
+          );
+        })}
+      </div>
+      {hintCell && (
+        <p className="text-amber-700 font-semibold" role="status">
+          {t("games.trackMaker.build.brokenHint", {
+            defaultValue: "The road ends at the glowing spot — connect it!",
+          })}
+        </p>
+      )}
+
+      {/* Palette */}
+      <div className="flex flex-wrap justify-center gap-2 w-full max-w-[520px]">
+        {[...unlocked, "erase" as const].map((p) => {
+          const isErase = p === "erase";
+          const selected = tool === p;
+          return (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setTool(p)}
+              aria-pressed={selected}
+              className={`flex flex-col items-center justify-center min-w-16 min-h-16 rounded-2xl border-2 p-1 active:scale-95 touch-manipulation ${
+                selected
+                  ? "border-sky-500 bg-sky-50"
+                  : "border-slate-200 bg-white"
+              }`}
+              aria-label={
+                isErase
+                  ? t("games.trackMaker.piece.erase", {
+                      defaultValue: "Eraser",
+                    })
+                  : t(PALETTE_LABEL_KEYS[p].key, {
+                      defaultValue: PALETTE_LABEL_KEYS[p].en,
+                    })
+              }
+            >
+              <span className="w-9 h-9 block">
+                {isErase ? (
+                  <span className="text-2xl" aria-hidden>
+                    🧽
+                  </span>
+                ) : (
+                  <PieceSvg type={p} />
+                )}
+              </span>
+              <span className="text-[10px] font-semibold text-slate-600">
+                {isErase
+                  ? t("games.trackMaker.piece.erase", {
+                      defaultValue: "Eraser",
+                    })
+                  : t(PALETTE_LABEL_KEYS[p].key, {
+                      defaultValue: PALETTE_LABEL_KEYS[p].en,
+                    })}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap justify-center gap-2 w-full max-w-[520px]">
+        {/* Always tappable: when the track isn't rideable yet, tapping points
+            kindly at the broken spot instead of a dead disabled button. */}
+        <button
+          type="button"
+          onClick={startRide}
+          className={`min-h-14 px-8 rounded-full text-xl font-extrabold shadow-lg active:scale-95 touch-manipulation ${
+            rideable ? "bg-green-600 text-white" : "bg-slate-200 text-slate-500"
+          }`}
+        >
+          {t("games.trackMaker.build.ride", { defaultValue: "Ride! 🏍️" })}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowIdeas(true)}
+          className="min-h-11 px-5 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+        >
+          {t("games.trackMaker.ideas.open", {
+            defaultValue: "Show me ideas 📖",
+          })}
+        </button>
+        {ridesCompleted > 0 && creationId && !shared && (
+          <button
+            type="button"
+            onClick={() => void shareToGallery()}
+            className="min-h-11 px-5 rounded-full bg-violet-600 text-white font-semibold active:scale-95 touch-manipulation"
+          >
+            {t("games.trackMaker.build.share", {
+              defaultValue: "Share to gallery ✨",
+            })}
+          </button>
+        )}
+        {shared && (
+          <span
+            className="min-h-11 px-4 inline-flex items-center text-violet-700 font-semibold"
+            role="status"
+          >
+            {t("games.trackMaker.build.sharedNote", {
+              defaultValue: "In the gallery! ✨",
+            })}
+          </span>
+        )}
+        {ridesCompleted > 0 && (
+          <button
+            type="button"
+            onClick={done}
+            className="min-h-11 px-5 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+          >
+            {t("games.trackMaker.build.done", { defaultValue: "Done for now" })}
+          </button>
+        )}
+      </div>
+
+      {/* Unlock announce beat — scaffolding must announce itself */}
+      {announce.length > 0 && (
+        <div className="fixed inset-0 z-40 bg-slate-900/50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-3xl p-6 max-w-sm w-full text-center flex flex-col gap-4 shadow-2xl bounce-in">
+            <div className="text-5xl" aria-hidden>
+              🎉
+            </div>
+            <h3 className="text-xl font-bold text-slate-800" role="status">
+              {t(`games.trackMaker.unlock.${announce[0]}`, {
+                defaultValue: "You earned a new piece: {{piece}}!",
+                piece: t(PALETTE_LABEL_KEYS[announce[0]].key, {
+                  defaultValue: PALETTE_LABEL_KEYS[announce[0]].en,
+                }),
+              })}
+            </h3>
+            <div className="w-16 h-16 mx-auto">
+              <PieceSvg type={announce[0]} />
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setTool(announce[0]);
+                setAnnounce((q) => q.slice(1));
+              }}
+              className="min-h-12 rounded-full bg-green-600 text-white font-bold text-lg active:scale-95 touch-manipulation"
+            >
+              {t("games.trackMaker.unlock.tryIt", {
+                defaultValue: "Tap to try it!",
+              })}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Pattern book — examples show possibility, never dictate */}
+      {showIdeas && (
+        <div className="fixed inset-0 z-40 bg-slate-900/50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-3xl p-6 max-w-md w-full flex flex-col gap-4 shadow-2xl">
+            <h3 className="text-xl font-bold text-slate-800 text-center">
+              {t("games.trackMaker.ideas.title", {
+                defaultValue: "Track ideas 📖",
+              })}
+            </h3>
+            <div className="flex flex-col gap-2">
+              {PATTERN_BOOK.map((pattern) => (
+                <div
+                  key={pattern.id}
+                  className="flex items-center gap-3 rounded-2xl border-2 border-slate-200 p-2"
+                >
+                  <svg
+                    viewBox="0 0 48 48"
+                    className="w-12 h-12 shrink-0"
+                    aria-hidden
+                  >
+                    <polyline
+                      points={trackToPolylinePoints(pattern, 48)}
+                      fill="none"
+                      stroke={ROAD}
+                      strokeWidth={5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <span className="flex-1 font-semibold text-slate-700">
+                    {pickLocale(pattern.name, pattern.name.en ?? pattern.id)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      pendingPattern === pattern.id
+                        ? applyPattern(pattern.id)
+                        : setPendingPattern(pattern.id)
+                    }
+                    className={`min-h-11 px-4 rounded-full font-semibold active:scale-95 touch-manipulation ${
+                      pendingPattern === pattern.id
+                        ? "bg-amber-500 text-white"
+                        : "bg-sky-600 text-white"
+                    }`}
+                  >
+                    {pendingPattern === pattern.id
+                      ? t("games.trackMaker.ideas.confirm", {
+                          defaultValue: "Replace my track?",
+                        })
+                      : t("games.trackMaker.ideas.use", {
+                          defaultValue: "Build from this",
+                        })}
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setShowIdeas(false);
+                setPendingPattern(null);
+              }}
+              className="min-h-11 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+            >
+              {t("games.trackMaker.ideas.close", {
+                defaultValue: "Keep my track",
+              })}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Name kit — structured choices, no free text */}
+      {showNamePicker && (
+        <div className="fixed inset-0 z-40 bg-slate-900/50 flex items-center justify-center p-4">
+          <NamePicker
+            onPick={applyName}
+            onClose={() => setShowNamePicker(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NamePicker({
+  onPick,
+  onClose,
+}: {
+  onPick: (adj: string, noun: string) => void;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const [adj, setAdj] = useState(NAME_KIT_ADJECTIVES[0]);
+  const [noun, setNoun] = useState(NAME_KIT_NOUNS[0]);
+  return (
+    <div className="bg-white rounded-3xl p-6 max-w-md w-full flex flex-col gap-4 shadow-2xl">
+      <h3 className="text-xl font-bold text-slate-800 text-center">
+        {t("games.trackMaker.name.title", { defaultValue: "Name your track!" })}
+      </h3>
+      <p
+        className="text-center text-2xl font-extrabold text-sky-700"
+        role="status"
+      >
+        {pickLocale(adj.label, adj.label.en ?? "")}{" "}
+        {pickLocale(noun.label, noun.label.en ?? "")}
+      </p>
+      <div className="flex flex-wrap justify-center gap-2">
+        {NAME_KIT_ADJECTIVES.map((a) => (
+          <button
+            key={a.id}
+            type="button"
+            onClick={() => setAdj(a)}
+            aria-pressed={adj.id === a.id}
+            className={`min-h-11 px-4 rounded-full border-2 font-semibold active:scale-95 touch-manipulation ${
+              adj.id === a.id
+                ? "border-sky-500 bg-sky-50 text-sky-800"
+                : "border-slate-200 bg-white text-slate-700"
+            }`}
+          >
+            {pickLocale(a.label, a.label.en ?? a.id)}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap justify-center gap-2">
+        {NAME_KIT_NOUNS.map((n) => (
+          <button
+            key={n.id}
+            type="button"
+            onClick={() => setNoun(n)}
+            aria-pressed={noun.id === n.id}
+            className={`min-h-11 px-4 rounded-full border-2 font-semibold active:scale-95 touch-manipulation ${
+              noun.id === n.id
+                ? "border-green-500 bg-green-50 text-green-800"
+                : "border-slate-200 bg-white text-slate-700"
+            }`}
+          >
+            {pickLocale(n.label, n.label.en ?? n.id)}
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2 justify-center">
+        <button
+          type="button"
+          onClick={() =>
+            onPick(
+              pickLocale(adj.label, adj.label.en ?? adj.id),
+              pickLocale(noun.label, noun.label.en ?? noun.id),
+            )
+          }
+          className="min-h-12 px-8 rounded-full bg-green-600 text-white font-bold text-lg active:scale-95 touch-manipulation"
+        >
+          {t("games.trackMaker.name.keep", { defaultValue: "That's it!" })}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="min-h-11 px-5 rounded-full bg-white border-2 border-slate-300 text-slate-700 font-semibold active:scale-95 touch-manipulation"
+        >
+          {t("games.trackMaker.name.later", { defaultValue: "Later" })}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Shell wrapper ───────────────────────────────────────────────────────────
+
+export default function TrackMakerGame({
+  config,
+  onComplete,
+  secondaryAction,
+}: {
+  config?: unknown;
+  onComplete?: (result: GameResult) => void;
+  secondaryAction?: {
+    label: string;
+    icon?: React.ReactNode;
+    onClick: () => void;
+  };
+}) {
+  const band = getGradeBand(config);
+  const { t } = useTranslation();
+  // Peer-ride mode (ChallengePlayer passes the saved track as config.raceTrack).
+  const rawTrack = (config as { raceTrack?: unknown } | undefined)?.raceTrack;
+  const fixedTrack = useMemo(() => {
+    if (rawTrack === undefined || rawTrack === null) return null;
+    const v = validateRaceTrackContent(rawTrack);
+    return v.ok ? v.content : null;
+  }, [rawTrack]);
+  const badPeerTrack =
+    rawTrack !== undefined && rawTrack !== null && !fixedTrack;
+  const briefing = useMemo(
+    () => ({
+      title: pickLocale(
+        {
+          en: "Boost Track Builder",
+          es: "Constructor de Pistas de Boost",
+        },
+        "Boost Track Builder",
+      ),
+      story: pickLocale(
+        {
+          en: "Boost got a motorcycle — but there's no track to ride! Build one for Boost, then hop on. Too fast into a sharp curve and the bike wobbles… your design decides the ride!",
+          es: "¡Boost tiene una moto, pero no hay pista! Construye una para Boost y súbete. Si entras muy rápido a una curva cerrada, la moto se tambalea… ¡tu diseño decide el paseo!",
+        },
+        "Boost got a motorcycle — but there's no track to ride! Build one for Boost, then hop on. Too fast into a sharp curve and the bike wobbles… your design decides the ride!",
+      ),
+      icon: "🏍️",
+      tips: [
+        pickLocale(
+          {
+            en: "Hold LEAN before sharp curves to slow down.",
+            es: "Mantén INCLINAR antes de las curvas cerradas para frenar.",
+          },
+          "Hold LEAN before sharp curves to slow down.",
+        ),
+        pickLocale(
+          {
+            en: "Spin-outs are okay — they show you where to tweak your track!",
+            es: "Los trompos están bien: ¡te muestran dónde mejorar tu pista!",
+          },
+          "Spin-outs are okay — they show you where to tweak your track!",
+        ),
+      ],
+    }),
+    [],
+  );
+  if (badPeerTrack) {
+    // Server-side validation makes this unreachable in practice, but a peer
+    // ride must degrade kindly, never crash.
+    return (
+      <div className="p-6 text-center text-slate-600">
+        {t("games.trackMaker.rideOnly.notRideable", {
+          defaultValue:
+            "This track can't be ridden right now. Try another one!",
+        })}
+      </div>
+    );
+  }
+  return (
+    <GameShell
+      gameKey="track_maker"
+      title={briefing.title}
+      briefing={briefing}
+      onComplete={onComplete ?? (() => {})}
+      formatBest={(b) => `⭐ ${b.bestScore}/6`}
+      secondaryAction={secondaryAction}
+    >
+      {({ onFinish, reducedEffects }) => (
+        <TrackMakerCore
+          onFinish={onFinish}
+          reducedEffects={reducedEffects}
+          band={band}
+          fixedTrack={fixedTrack}
+        />
+      )}
+    </GameShell>
+  );
+}

--- a/src/components/games/__tests__/TrackMaker.test.ts
+++ b/src/components/games/__tests__/TrackMaker.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURVE_TOLERANCE,
+  DEFAULT_GRID,
+  DEFAULT_RIDE_TUNING,
+  PATTERN_BOOK,
+  TRACK_MAKER_TOTAL,
+  buildTrackMakerResult,
+  initialRideState,
+  newlyUnlocked,
+  pickReflectPrompt,
+  starterTrack,
+  stepRide,
+  suggestUniqueName,
+  trackToPolylinePoints,
+  unlockedPieceTypes,
+  validateRaceTrackContent,
+  walkTrack,
+  type RideState,
+  type TrackPiece,
+} from "../trackMakerModel";
+
+const K2_TOL = CURVE_TOLERANCE.k2;
+
+function track(pieces: TrackPiece[], grid = DEFAULT_GRID) {
+  return { v: 1 as const, name: "Test Track", grid, pieces };
+}
+
+// A straight run into a sharp curve, then a finish — the spin-out testbed.
+const SHARP_RUN: TrackPiece[] = [
+  { x: 1, y: 3, type: "start", rot: 0 },
+  { x: 2, y: 3, type: "straight", rot: 0 },
+  { x: 3, y: 3, type: "sharpCurve", rot: 180 }, // enter W, exit S
+  { x: 3, y: 4, type: "finish", rot: 0 },
+];
+
+/** Drive the ride to completion (or a step cap) with a fixed lean policy. */
+function rideToEnd(
+  path: TrackPiece[],
+  leaning: boolean,
+  start: RideState = initialRideState(),
+): RideState {
+  let state = start;
+  for (let i = 0; i < 2000 && !state.finished; i++) {
+    state = stepRide(state, path, 1 / 60, leaning, K2_TOL).state;
+  }
+  return state;
+}
+
+// ── Connectivity walk ───────────────────────────────────────────────────────
+
+describe("walkTrack", () => {
+  it("walks the starter track start → finish", () => {
+    const walk = walkTrack(track(starterTrack()));
+    expect(walk.ok).toBe(true);
+    if (walk.ok) {
+      expect(walk.path[0].type).toBe("start");
+      expect(walk.path[walk.path.length - 1].type).toBe("finish");
+    }
+  });
+
+  it("fails with the offending cell when the road dangles", () => {
+    const walk = walkTrack(
+      track([
+        { x: 1, y: 3, type: "start", rot: 0 },
+        { x: 2, y: 3, type: "straight", rot: 0 },
+        // nothing at (3,3) — the road ends
+        { x: 6, y: 6, type: "finish", rot: 0 },
+      ]),
+    );
+    expect(walk).toMatchObject({
+      ok: false,
+      reason: "brokenPath",
+      at: { x: 3, y: 3 },
+    });
+  });
+
+  it("fails on a wrong-way join (touching pieces that do not connect)", () => {
+    const walk = walkTrack(
+      track([
+        { x: 1, y: 3, type: "start", rot: 0 },
+        { x: 2, y: 3, type: "straight", rot: 90 }, // N–S can't accept a W entry
+        { x: 3, y: 3, type: "finish", rot: 0 },
+      ]),
+    );
+    expect(walk).toMatchObject({ ok: false, reason: "brokenPath" });
+  });
+});
+
+describe("validateRaceTrackContent (client mirror)", () => {
+  it("accepts the starter track", () => {
+    expect(validateRaceTrackContent(track(starterTrack())).ok).toBe(true);
+  });
+
+  it("STRICT: rejects unknown keys at root, grid, and piece level", () => {
+    expect(
+      validateRaceTrackContent({ ...track(starterTrack()), extra: 1 }).ok,
+    ).toBe(false);
+    expect(
+      validateRaceTrackContent(
+        track(starterTrack(), { w: 8, h: 8, deep: 1 } as never),
+      ).ok,
+    ).toBe(false);
+    const withExtraPieceKey = track(starterTrack());
+    withExtraPieceKey.pieces[1] = {
+      ...withExtraPieceKey.pieces[1],
+      note: "hi",
+    } as never;
+    expect(validateRaceTrackContent(withExtraPieceKey).ok).toBe(false);
+  });
+
+  it("rejects a broken track and reports the broken cell for the UI hint", () => {
+    const r = validateRaceTrackContent(
+      track([
+        { x: 1, y: 3, type: "start", rot: 0 },
+        { x: 6, y: 6, type: "finish", rot: 0 },
+      ]),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.at).toEqual({ x: 2, y: 3 });
+  });
+});
+
+// ── Ride physics ────────────────────────────────────────────────────────────
+
+describe("stepRide", () => {
+  it("finishes the starter track (finish detection)", () => {
+    const walk = walkTrack(track(starterTrack()));
+    if (!walk.ok) throw new Error("starter must walk");
+    const end = rideToEnd(walk.path, false);
+    expect(end.finished).toBe(true);
+    expect(end.spinOuts).toBe(0);
+  });
+
+  it("spins out entering a sharp curve at full throttle", () => {
+    const walk = walkTrack(track(SHARP_RUN));
+    if (!walk.ok) throw new Error("sharp run must walk");
+    // Never leaning: throttle climbs to 1.0 — far above the 0.4 tolerance.
+    const end = rideToEnd(walk.path, false);
+    expect(end.finished).toBe(true); // remounts mean the ride still finishes
+    expect(end.spinOuts).toBeGreaterThanOrEqual(1);
+  });
+
+  it("survives the sharp curve when leaning (hold-to-lean always works)", () => {
+    const walk = walkTrack(track(SHARP_RUN));
+    if (!walk.ok) throw new Error("sharp run must walk");
+    // Leaning the whole way: speed settles at leanTarget (0.2) ≤ 0.4 tolerance.
+    const end = rideToEnd(walk.path, true);
+    expect(end.finished).toBe(true);
+    expect(end.spinOuts).toBe(0);
+  });
+
+  it("K-2 CONTRACT: a sharp curve is survivable at ≤40% throttle", () => {
+    const walk = walkTrack(track(SHARP_RUN));
+    if (!walk.ok) throw new Error("sharp run must walk");
+    const state: RideState = {
+      ...initialRideState(),
+      pieceIndex: 1,
+      progress: 0.99,
+      speed: 0.4,
+    };
+    // Hold lean so throttle can't climb past 0.4 during the entry step.
+    const { state: next, events } = stepRide(
+      state,
+      walk.path,
+      1 / 60,
+      true,
+      K2_TOL,
+    );
+    expect(events.spunOut).toBeUndefined();
+    expect(next.spinOuts).toBe(0);
+  });
+
+  it("g3_5 tolerance is tighter than K-2 (band-scaled difficulty)", () => {
+    expect(CURVE_TOLERANCE.g3_5.sharpCurve).toBeLessThan(
+      CURVE_TOLERANCE.k2.sharpCurve,
+    );
+    expect(CURVE_TOLERANCE.g3_5.gentleCurve).toBeLessThan(
+      CURVE_TOLERANCE.k2.gentleCurve,
+    );
+    // The lean target must sit below every sharp tolerance so "hold to lean"
+    // is always a valid survival strategy in every band.
+    expect(DEFAULT_RIDE_TUNING.leanTarget).toBeLessThanOrEqual(
+      CURVE_TOLERANCE.g3_5.sharpCurve,
+    );
+  });
+
+  it("spin-out remounts at the start of the curve with zero speed — no lost progress", () => {
+    const walk = walkTrack(track(SHARP_RUN));
+    if (!walk.ok) throw new Error("sharp run must walk");
+    const state: RideState = {
+      ...initialRideState(),
+      pieceIndex: 1,
+      progress: 0.99,
+      speed: 1,
+    };
+    const { state: next, events } = stepRide(
+      state,
+      walk.path,
+      1 / 60,
+      false,
+      K2_TOL,
+    );
+    expect(events.spunOut).toBe(true);
+    expect(next.pieceIndex).toBe(2); // at the curve, not sent back to start
+    expect(next.progress).toBe(0);
+    expect(next.speed).toBe(0);
+    expect(next.spinOuts).toBe(1);
+  });
+
+  it("boost pads kick the throttle to full", () => {
+    const boostRun: TrackPiece[] = [
+      { x: 1, y: 3, type: "start", rot: 0 },
+      { x: 2, y: 3, type: "boost", rot: 0 },
+      { x: 3, y: 3, type: "straight", rot: 0 },
+      { x: 4, y: 3, type: "finish", rot: 0 },
+    ];
+    const walk = walkTrack(track(boostRun));
+    if (!walk.ok) throw new Error("boost run must walk");
+    const state: RideState = {
+      ...initialRideState(),
+      pieceIndex: 0,
+      progress: 0.99,
+      speed: 0.3,
+    };
+    const { state: next, events } = stepRide(
+      state,
+      walk.path,
+      1 / 60,
+      true,
+      K2_TOL,
+    );
+    expect(events.boosted).toBe(true);
+    expect(next.speed).toBe(1);
+    expect(next.boostsHit).toBe(1);
+  });
+
+  it("boost placed right before a sharp curve teaches its lesson (spin-out)", () => {
+    const trap: TrackPiece[] = [
+      { x: 1, y: 3, type: "start", rot: 0 },
+      { x: 2, y: 3, type: "boost", rot: 0 },
+      { x: 3, y: 3, type: "sharpCurve", rot: 180 },
+      { x: 3, y: 4, type: "finish", rot: 0 },
+    ];
+    const walk = walkTrack(track(trap));
+    if (!walk.ok) throw new Error("trap must walk");
+    const end = rideToEnd(walk.path, false);
+    expect(end.spinOuts).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── Unlocks (one completed ride per unlock; spin-outs never gate) ──────────
+
+describe("piece unlocks", () => {
+  it("starts with the constrained palette (no sharp curve, no boost)", () => {
+    const palette = unlockedPieceTypes(0);
+    expect(palette).toContain("straight");
+    expect(palette).toContain("gentleCurve");
+    expect(palette).toContain("finish");
+    expect(palette).not.toContain("sharpCurve");
+    expect(palette).not.toContain("boost");
+  });
+
+  it("unlocks sharp curve after 1 completed ride, boost after 2", () => {
+    expect(unlockedPieceTypes(1)).toContain("sharpCurve");
+    expect(unlockedPieceTypes(1)).not.toContain("boost");
+    expect(unlockedPieceTypes(2)).toContain("boost");
+  });
+
+  it("reports newly unlocked pieces exactly once (drives the announce beat)", () => {
+    expect(newlyUnlocked(0, 1)).toEqual(["sharpCurve"]);
+    expect(newlyUnlocked(1, 2)).toEqual(["boost"]);
+    expect(newlyUnlocked(2, 3)).toEqual([]);
+    expect(newlyUnlocked(0, 2)).toEqual(["sharpCurve", "boost"]);
+  });
+});
+
+// ── Pattern book + starter: the solvability guard for authored content ─────
+
+describe("pattern book", () => {
+  it("PROGRAMMATIC GUARD: every pattern-book shape is rideable", () => {
+    for (const pattern of PATTERN_BOOK) {
+      const result = validateRaceTrackContent({
+        v: 1,
+        name: pattern.name.en,
+        grid: pattern.grid,
+        pieces: pattern.pieces,
+      });
+      expect(result.ok, `pattern "${pattern.id}" must be rideable`).toBe(true);
+    }
+  });
+
+  it("every pattern has real EN + ES names", () => {
+    for (const pattern of PATTERN_BOOK) {
+      expect(pattern.name.en?.length).toBeGreaterThan(0);
+      expect(pattern.name.es?.length).toBeGreaterThan(0);
+      expect(pattern.name.es).not.toBe(pattern.name.en);
+    }
+  });
+
+  it("the starter segment is rideable (the floor never opens broken)", () => {
+    expect(validateRaceTrackContent(track(starterTrack())).ok).toBe(true);
+  });
+});
+
+// ── Name kit ────────────────────────────────────────────────────────────────
+
+describe("suggestUniqueName", () => {
+  it("keeps a free name as-is", () => {
+    expect(suggestUniqueName("Big Loop", ["Zippy Trail"])).toBe("Big Loop");
+  });
+
+  it("auto-suffixes duplicates (case-insensitive) instead of blocking", () => {
+    expect(suggestUniqueName("Big Loop", ["big loop"])).toBe("Big Loop 2");
+    expect(suggestUniqueName("Big Loop", ["Big Loop", "Big Loop 2"])).toBe(
+      "Big Loop 3",
+    );
+  });
+
+  it("ignores null/undefined titles from unnamed creations", () => {
+    expect(suggestUniqueName("Big Loop", [null, undefined, ""])).toBe(
+      "Big Loop",
+    );
+  });
+});
+
+// ── Reflect pool (context-aware, 6 keys) ────────────────────────────────────
+
+describe("pickReflectPrompt", () => {
+  it("prioritizes a newly ridden unlocked piece", () => {
+    expect(
+      pickReflectPrompt({
+        spinOuts: 3,
+        boostsHit: 1,
+        newPieceRidden: "sharpCurve",
+      }).key,
+    ).toBe("games.trackMaker.reflect.newPiece");
+  });
+
+  it("varies by spin-outs, boost, and clean rides", () => {
+    expect(pickReflectPrompt({ spinOuts: 2, boostsHit: 0 })).toMatchObject({
+      key: "games.trackMaker.reflect.spinOuts",
+      params: { count: 2 },
+    });
+    expect(pickReflectPrompt({ spinOuts: 1, boostsHit: 0 }).key).toBe(
+      "games.trackMaker.reflect.oneSpin",
+    );
+    expect(pickReflectPrompt({ spinOuts: 0, boostsHit: 2 }).key).toBe(
+      "games.trackMaker.reflect.boost",
+    );
+    expect(
+      pickReflectPrompt({ spinOuts: 0, boostsHit: 0 }, () => 0.1).key,
+    ).toBe("games.trackMaker.reflect.clean");
+    expect(
+      pickReflectPrompt({ spinOuts: 0, boostsHit: 0 }, () => 0.9).key,
+    ).toBe("games.trackMaker.reflect.proud");
+  });
+});
+
+// ── Scoring: measures creation, never speed ────────────────────────────────
+
+describe("buildTrackMakerResult", () => {
+  const base = {
+    rideable: true,
+    ridesCompleted: 0,
+    iterated: false,
+    targetsMet: 0,
+    bestCleanStreak: 0,
+    spinOuts: 0,
+    tweaks: 0,
+    sharedToGallery: false,
+  };
+
+  it("scores creation milestones with integer score/total", () => {
+    const r = buildTrackMakerResult({
+      ...base,
+      ridesCompleted: 3,
+      iterated: true,
+      targetsMet: 2,
+      bestCleanStreak: 2,
+      spinOuts: 4,
+      tweaks: 9,
+    });
+    expect(r.gameKey).toBe("track_maker");
+    expect(r.score).toBe(6); // 2 rideable + 2 rode + 1 iterated + 1 target
+    expect(r.total).toBe(TRACK_MAKER_TOTAL);
+    expect(Number.isInteger(r.score)).toBe(true);
+    expect(r.roundsCompleted).toBe(3);
+    expect(r.streakMax).toBe(2);
+  });
+
+  it("spin-outs never reduce the score (feedback, not failure)", () => {
+    const clean = buildTrackMakerResult({ ...base, ridesCompleted: 1 });
+    const messy = buildTrackMakerResult({
+      ...base,
+      ridesCompleted: 1,
+      spinOuts: 12,
+    });
+    expect(messy.score).toBe(clean.score);
+  });
+
+  it("keeps maker telemetry in gameSpecific (not in the scored fields)", () => {
+    const r = buildTrackMakerResult({ ...base, tweaks: 5, spinOuts: 2 });
+    expect(r.gameSpecific).toMatchObject({ tweaks: 5, spinOuts: 2 });
+  });
+});
+
+// ── Gallery thumbnail ───────────────────────────────────────────────────────
+
+describe("trackToPolylinePoints", () => {
+  it("produces points for a rideable track", () => {
+    const points = trackToPolylinePoints(track(starterTrack()));
+    expect(points.split(" ").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns "" for a broken track so the card falls back to 🏍️ + name', () => {
+    expect(
+      trackToPolylinePoints(
+        track([
+          { x: 1, y: 3, type: "start", rot: 0 },
+          { x: 6, y: 6, type: "finish", rot: 0 },
+        ]),
+      ),
+    ).toBe("");
+  });
+});

--- a/src/components/games/gameRegistry.ts
+++ b/src/components/games/gameRegistry.ts
@@ -14,6 +14,7 @@ import QualifyTuneRaceGame from "./QualifyTuneRaceGame";
 import TankTrekGame from "./TankTrekGame";
 import QuantumQuestGame from "./QuantumQuestGame";
 import DataDashSortDiscoverGame from "./DataDashSortDiscoverGame";
+import TrackMakerGame from "./TrackMakerGame";
 
 type GameProps = {
   config?: any;
@@ -27,20 +28,23 @@ type GameProps = {
  */
 export const GAME_COMPONENTS: Record<string, ComponentType<GameProps>> = {
   // ── Primary keys (current canonical names) ──
-  boost_path_planner: BoostPathPlannerGame,   // "Boost's Lost Steps"
-  rhymo_rhyme_rocket: RhymeRideGame,          // "Rhyme & Ride" (lane-based redesign)
-  buddy_garden_sort: BounceBudsGame,            // "Bounce & Buds" (restored paddle-ball game)
-  gotcha_gears_unity: GotchaGearsGame,         // "Gotcha Gears" (now React)
-  tank_trek: TankTrekGame,                     // "Tank Trek" (Set 1)
-  quantum_quest: QuantumQuestGame,             // "Quantum Quest"
+  boost_path_planner: BoostPathPlannerGame, // "Boost's Lost Steps"
+  rhymo_rhyme_rocket: RhymeRideGame, // "Rhyme & Ride" (lane-based redesign)
+  buddy_garden_sort: BounceBudsGame, // "Bounce & Buds" (restored paddle-ball game)
+  gotcha_gears_unity: GotchaGearsGame, // "Gotcha Gears" (now React)
+  tank_trek: TankTrekGame, // "Tank Trek" (Set 1)
+  quantum_quest: QuantumQuestGame, // "Quantum Quest"
   data_dash_sort_discover: DataDashSortDiscoverGame, // "Data Dash: Sort & Discover" (G3-5)
 
   // ── Set 2 keys ──
-  maze_maps: MazeMapsGame,                      // "Maze Maps & Smart Paths" (Set 2)
-  move_measure: MoveMeasureGame,                // "Move, Measure & Improve" (Set 2)
-  sky_shield: SkyShieldGame,                    // "Sky Shield Patterns" (Set 2)
-  fast_lane: FastLaneGame,                      // "Fast Lane Signals" (Set 2)
-  qualify_tune_race: QualifyTuneRaceGame,       // "Qualify, Tune, Race" (Set 2)
+  maze_maps: MazeMapsGame, // "Maze Maps & Smart Paths" (Set 2)
+  move_measure: MoveMeasureGame, // "Move, Measure & Improve" (Set 2)
+  sky_shield: SkyShieldGame, // "Sky Shield Patterns" (Set 2)
+  fast_lane: FastLaneGame, // "Fast Lane Signals" (Set 2)
+  qualify_tune_race: QualifyTuneRaceGame, // "Qualify, Tune, Race" (Set 2)
+
+  // ── Set 3 keys ──
+  track_maker: TrackMakerGame, // "Boost Track Builder" (Set 3, gated)
 
   // ── Legacy / alias keys → same implementations ──
   sequence_drag_drop: BoostPathPlannerGame,

--- a/src/components/games/trackMakerModel.ts
+++ b/src/components/games/trackMakerModel.ts
@@ -1,0 +1,679 @@
+/**
+ * Boost Track Builder — pure model (Set 3 · game 1 · "mastery through making").
+ *
+ * Everything here is a pure function or constant so the game rules are
+ * unit-testable without React: grid/connectivity walking, ride physics
+ * (curve tolerance, wobble, spin-out, boost, finish), piece unlocks,
+ * the name kit, the pattern book, the reflect-prompt pool, and scoring.
+ *
+ * The kid's track persists as a `Creation` with `type: "race_track"`;
+ * `RaceTrackContent` below IS the `content` JSON shape. The backend twin of
+ * `validateRaceTrackContent` lives in `backend/src/services/raceTrack.ts`
+ * (the security boundary) — keep the schema + rideability rules in sync,
+ * mirroring how Data Dash duplicates its card pool across the boundary.
+ */
+import { z } from "zod";
+import type { GameResult } from "./shared/GameShell";
+import type { GradeBand } from "./gradeBandContent";
+
+// ── Content shape ───────────────────────────────────────────────────────────
+
+export const PIECE_TYPES = [
+  "start",
+  "straight",
+  "gentleCurve",
+  "sharpCurve",
+  "boost",
+  "finish",
+] as const;
+export type PieceType = (typeof PIECE_TYPES)[number];
+export type Rot = 0 | 90 | 180 | 270;
+
+export interface TrackPiece {
+  x: number;
+  y: number;
+  type: PieceType;
+  rot: Rot;
+}
+
+export interface RaceTrackContent {
+  v: 1;
+  name: string;
+  grid: { w: number; h: number };
+  pieces: TrackPiece[];
+}
+
+export const GRID_MIN = 4;
+export const GRID_MAX = 12;
+export const PIECES_MIN = 2;
+export const PIECES_MAX = 64;
+export const NAME_MAX = 24;
+
+// Strict-parsed from day one: unknown keys are REJECTED at every level.
+// Keep this closed-content boundary aligned with the server validator: new
+// creation types must reject unknown fields instead of persisting them.
+const pieceSchema = z
+  .object({
+    x: z
+      .number()
+      .int()
+      .min(0)
+      .max(GRID_MAX - 1),
+    y: z
+      .number()
+      .int()
+      .min(0)
+      .max(GRID_MAX - 1),
+    type: z.enum(PIECE_TYPES),
+    rot: z.union([z.literal(0), z.literal(90), z.literal(180), z.literal(270)]),
+  })
+  .strict();
+
+export const raceTrackSchema = z
+  .object({
+    v: z.literal(1),
+    name: z.string().min(1).max(NAME_MAX),
+    grid: z
+      .object({
+        w: z.number().int().min(GRID_MIN).max(GRID_MAX),
+        h: z.number().int().min(GRID_MIN).max(GRID_MAX),
+      })
+      .strict(),
+    pieces: z.array(pieceSchema).min(PIECES_MIN).max(PIECES_MAX),
+  })
+  .strict();
+
+// ── Grid connectivity ───────────────────────────────────────────────────────
+
+export type Dir = "N" | "E" | "S" | "W";
+const DIRS: Dir[] = ["N", "E", "S", "W"];
+const DELTA: Record<Dir, [number, number]> = {
+  N: [0, -1],
+  E: [1, 0],
+  S: [0, 1],
+  W: [-1, 0],
+};
+const OPPOSITE: Record<Dir, Dir> = { N: "S", E: "W", S: "N", W: "E" };
+
+function rotateDir(d: Dir, rot: Rot): Dir {
+  return DIRS[(DIRS.indexOf(d) + rot / 90) % 4];
+}
+
+/**
+ * Which cell sides a piece connects to. Curves join two adjacent sides
+ * (base rot 0 = N↔E); straights/boosts join opposite sides; the start has
+ * a single exit; the finish accepts entry from ANY side (K-2 friendliness:
+ * a kid never has to rotate the finish flag to make their track work).
+ */
+export function pieceConnections(piece: TrackPiece): Dir[] {
+  switch (piece.type) {
+    case "straight":
+    case "boost":
+      return piece.rot % 180 === 0 ? ["W", "E"] : ["N", "S"];
+    case "gentleCurve":
+    case "sharpCurve":
+      return [rotateDir("N", piece.rot), rotateDir("E", piece.rot)];
+    case "start":
+      return [rotateDir("E", piece.rot)];
+    case "finish":
+      return ["N", "E", "S", "W"];
+  }
+}
+
+export type WalkResult =
+  | { ok: true; path: TrackPiece[] }
+  | {
+      ok: false;
+      reason: "noStart" | "multipleStarts" | "brokenPath" | "loop";
+      at?: { x: number; y: number };
+    };
+
+/**
+ * Rideability walk: from the start's exit, follow piece connections cell by
+ * cell until a finish is reached. Broken/dangling roads, wrong-way joins,
+ * and closed loops that never reach a finish all fail with the offending
+ * cell so the build UI can point at it kindly.
+ */
+export function walkTrack(content: {
+  grid: { w: number; h: number };
+  pieces: TrackPiece[];
+}): WalkResult {
+  const starts = content.pieces.filter((p) => p.type === "start");
+  if (starts.length === 0) return { ok: false, reason: "noStart" };
+  if (starts.length > 1) return { ok: false, reason: "multipleStarts" };
+
+  const byCell = new Map<string, TrackPiece>();
+  for (const p of content.pieces) byCell.set(`${p.x},${p.y}`, p);
+
+  const start = starts[0];
+  const path: TrackPiece[] = [start];
+  const visited = new Set<string>([`${start.x},${start.y}`]);
+  let cur = start;
+  let dir = pieceConnections(start)[0];
+
+  for (let step = 0; step <= content.pieces.length; step++) {
+    const [dx, dy] = DELTA[dir];
+    const nx = cur.x + dx;
+    const ny = cur.y + dy;
+    if (nx < 0 || ny < 0 || nx >= content.grid.w || ny >= content.grid.h) {
+      return { ok: false, reason: "brokenPath", at: { x: cur.x, y: cur.y } };
+    }
+    const next = byCell.get(`${nx},${ny}`);
+    if (!next) {
+      return { ok: false, reason: "brokenPath", at: { x: nx, y: ny } };
+    }
+    if (next.type === "finish") {
+      path.push(next);
+      return { ok: true, path };
+    }
+    const entry = OPPOSITE[dir];
+    const conns = pieceConnections(next);
+    if (next.type === "start" || !conns.includes(entry)) {
+      return { ok: false, reason: "brokenPath", at: { x: nx, y: ny } };
+    }
+    if (visited.has(`${nx},${ny}`)) {
+      return { ok: false, reason: "loop", at: { x: nx, y: ny } };
+    }
+    visited.add(`${nx},${ny}`);
+    const exit = conns.find((c) => c !== entry);
+    if (!exit) {
+      return { ok: false, reason: "brokenPath", at: { x: nx, y: ny } };
+    }
+    path.push(next);
+    cur = next;
+    dir = exit;
+  }
+  return { ok: false, reason: "loop", at: { x: cur.x, y: cur.y } };
+}
+
+// ── Client-side validator (mirror of backend/src/services/raceTrack.ts) ────
+
+export type TrackValidation =
+  | { ok: true; content: RaceTrackContent }
+  | { ok: false; error: string; at?: { x: number; y: number } };
+
+export function validateRaceTrackContent(content: unknown): TrackValidation {
+  const parsed = raceTrackSchema.safeParse(content);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return {
+      ok: false,
+      error: `${issue.path.join(".") || "content"}: ${issue.message}`,
+    };
+  }
+  const track = parsed.data as RaceTrackContent;
+  const seen = new Set<string>();
+  for (const p of track.pieces) {
+    if (p.x >= track.grid.w || p.y >= track.grid.h) {
+      return {
+        ok: false,
+        error: "piece outside the grid",
+        at: { x: p.x, y: p.y },
+      };
+    }
+    const key = `${p.x},${p.y}`;
+    if (seen.has(key)) {
+      return {
+        ok: false,
+        error: "two pieces on the same cell",
+        at: { x: p.x, y: p.y },
+      };
+    }
+    seen.add(key);
+  }
+  if (!track.pieces.some((p) => p.type === "finish")) {
+    return { ok: false, error: "track needs a finish flag" };
+  }
+  const walk = walkTrack(track);
+  if (!walk.ok) {
+    return {
+      ok: false,
+      error: `track is not rideable (${walk.reason})`,
+      at: walk.at,
+    };
+  }
+  return { ok: true, content: track };
+}
+
+// ── Ride physics (tuned for feel; all constants in one place) ──────────────
+
+/**
+ * Curve tolerance = the max throttle (0..1) at which a curve is guaranteed
+ * survivable, per grade band. K-2 Guided: sharp curves survive at ≤40%
+ * throttle; higher bands tighten to ~25% (band-scaled difficulty).
+ * A small grace band above tolerance wobbles-but-survives so K-2 riders
+ * don't hit a knife-edge cliff; beyond the grace it's a spin-out.
+ */
+export const CURVE_TOLERANCE: Record<
+  GradeBand,
+  { gentleCurve: number; sharpCurve: number }
+> = {
+  k2: { gentleCurve: 0.7, sharpCurve: 0.4 },
+  g3_5: { gentleCurve: 0.6, sharpCurve: 0.25 },
+};
+
+export interface RideTuning {
+  /** cells/second at throttle 0 (the bike always creeps forward) */
+  minAdvance: number;
+  /** cells/second at throttle 1 */
+  maxAdvance: number;
+  /** throttle gain per second when NOT leaning */
+  accel: number;
+  /** throttle loss per second while leaning (brakes bite fast) */
+  leanDecel: number;
+  /** throttle the bike settles at while leaning — below every sharp
+   *  tolerance, so "hold to lean" through a curve always works */
+  leanTarget: number;
+  /** wobble-but-survive band above a curve's tolerance */
+  wobbleGrace: number;
+}
+
+export const DEFAULT_RIDE_TUNING: RideTuning = {
+  minAdvance: 0.6,
+  maxAdvance: 2.4,
+  accel: 0.45,
+  leanDecel: 1.3,
+  leanTarget: 0.2,
+  wobbleGrace: 0.1,
+};
+
+export interface RideState {
+  /** index into the walked path */
+  pieceIndex: number;
+  /** 0..1 progress within the current piece */
+  progress: number;
+  /** throttle 0..1 */
+  speed: number;
+  spinOuts: number;
+  boostsHit: number;
+  wobbling: boolean;
+  finished: boolean;
+}
+
+export interface RideEvents {
+  entered?: PieceType;
+  wobbled?: boolean;
+  spunOut?: boolean;
+  boosted?: boolean;
+  finished?: boolean;
+}
+
+export function initialRideState(): RideState {
+  return {
+    pieceIndex: 0,
+    progress: 0,
+    speed: 0.4,
+    spinOuts: 0,
+    boostsHit: 0,
+    wobbling: false,
+    finished: false,
+  };
+}
+
+/**
+ * Advance the ride by dt seconds. Pure: returns the next state + events for
+ * the frame. Spin-outs remount the bike at the START of the offending curve
+ * with zero speed — the kid loses nothing, they just get to feel what their
+ * design did (feedback, not failure).
+ */
+export function stepRide(
+  state: RideState,
+  path: TrackPiece[],
+  dt: number,
+  leaning: boolean,
+  tolerance: { gentleCurve: number; sharpCurve: number },
+  tuning: RideTuning = DEFAULT_RIDE_TUNING,
+): { state: RideState; events: RideEvents } {
+  if (state.finished) return { state, events: {} };
+  const events: RideEvents = {};
+  const next: RideState = { ...state };
+
+  // Throttle: lean pulls speed down toward leanTarget, release accelerates.
+  if (leaning) {
+    next.speed = Math.max(
+      tuning.leanTarget,
+      next.speed - tuning.leanDecel * dt,
+    );
+  } else {
+    next.speed = Math.min(1, next.speed + tuning.accel * dt);
+  }
+
+  const advance =
+    (tuning.minAdvance + next.speed * (tuning.maxAdvance - tuning.minAdvance)) *
+    dt;
+  next.progress += advance;
+
+  while (next.progress >= 1 && !next.finished) {
+    next.progress -= 1;
+    next.pieceIndex += 1;
+    const piece = path[next.pieceIndex];
+    if (!piece) {
+      // Defensive: walked path always ends in a finish, but never crash a ride.
+      next.finished = true;
+      events.finished = true;
+      break;
+    }
+    events.entered = piece.type;
+    next.wobbling = false;
+
+    if (piece.type === "finish") {
+      next.finished = true;
+      next.progress = 0;
+      events.finished = true;
+      break;
+    }
+    if (piece.type === "boost") {
+      next.speed = 1;
+      next.boostsHit += 1;
+      events.boosted = true;
+      continue;
+    }
+    if (piece.type === "gentleCurve" || piece.type === "sharpCurve") {
+      const tol = tolerance[piece.type];
+      if (next.speed > tol + tuning.wobbleGrace) {
+        // Spin-out: remount at the start of this curve, throttle zeroed.
+        next.spinOuts += 1;
+        next.progress = 0;
+        next.speed = 0;
+        next.wobbling = false;
+        events.spunOut = true;
+        break;
+      }
+      if (next.speed > tol) {
+        next.wobbling = true;
+        next.speed = tol;
+        events.wobbled = true;
+      }
+    }
+  }
+
+  return { state: next, events };
+}
+
+// ── Starter track + palette unlocks ────────────────────────────────────────
+
+export const DEFAULT_GRID = { w: 8, h: 8 };
+
+/** The supported floor: the grid never opens blank — this already rides. */
+export function starterTrack(): TrackPiece[] {
+  return [
+    { x: 1, y: 3, type: "start", rot: 0 },
+    { x: 2, y: 3, type: "straight", rot: 0 },
+    { x: 3, y: 3, type: "finish", rot: 0 },
+  ];
+}
+
+/** Base palette available from the first tap. */
+export const BASE_PALETTE: PieceType[] = ["straight", "gentleCurve", "finish"];
+
+/**
+ * Pieces unlock on COMPLETED rides only (crossed the finish — remounts
+ * count, spin-outs never gate progress): one completed ride per unlock.
+ */
+export const PIECE_UNLOCKS: { type: PieceType; ridesRequired: number }[] = [
+  { type: "sharpCurve", ridesRequired: 1 },
+  { type: "boost", ridesRequired: 2 },
+];
+
+export function unlockedPieceTypes(ridesCompleted: number): PieceType[] {
+  return [
+    ...BASE_PALETTE,
+    ...PIECE_UNLOCKS.filter((u) => ridesCompleted >= u.ridesRequired).map(
+      (u) => u.type,
+    ),
+  ];
+}
+
+/** Which pieces unlocked between two ride counts — drives the announce beat. */
+export function newlyUnlocked(
+  ridesBefore: number,
+  ridesAfter: number,
+): PieceType[] {
+  return PIECE_UNLOCKS.filter(
+    (u) => ridesBefore < u.ridesRequired && ridesAfter >= u.ridesRequired,
+  ).map((u) => u.type);
+}
+
+// ── Name kit (structured choices, no free text) ────────────────────────────
+
+type LocalizedLabel = Record<string, string>;
+
+export const NAME_KIT_ADJECTIVES: { id: string; label: LocalizedLabel }[] = [
+  { id: "super", label: { en: "Super", es: "Súper" } },
+  { id: "zippy", label: { en: "Zippy", es: "Veloz" } },
+  { id: "loopy", label: { en: "Loopy", es: "Rulera" } },
+  { id: "mega", label: { en: "Mega", es: "Mega" } },
+  { id: "wiggly", label: { en: "Wiggly", es: "Zigzagueante" } },
+  { id: "turbo", label: { en: "Turbo", es: "Turbo" } },
+];
+
+export const NAME_KIT_NOUNS: { id: string; label: LocalizedLabel }[] = [
+  { id: "track", label: { en: "Track", es: "Pista" } },
+  { id: "loop", label: { en: "Loop", es: "Circuito" } },
+  { id: "speedway", label: { en: "Speedway", es: "Autopista" } },
+  { id: "trail", label: { en: "Trail", es: "Sendero" } },
+  { id: "zigzag", label: { en: "Zigzag", es: "Zigzag" } },
+  { id: "rally", label: { en: "Rally", es: "Rally" } },
+];
+
+/**
+ * Duplicate-name guard: auto-suffix a number rather than blocking a K-2
+ * kid with an error ("Big Loop" → "Big Loop 2").
+ */
+export function suggestUniqueName(
+  base: string,
+  existingTitles: (string | null | undefined)[],
+): string {
+  const taken = new Set(
+    existingTitles
+      .filter((t): t is string => !!t)
+      .map((t) => t.trim().toLowerCase()),
+  );
+  const trimmed = base.trim().slice(0, NAME_MAX);
+  if (!taken.has(trimmed.toLowerCase())) return trimmed;
+  for (let n = 2; n < 100; n++) {
+    const candidate = `${trimmed} ${n}`.slice(0, NAME_MAX);
+    if (!taken.has(candidate.toLowerCase())) return candidate;
+  }
+  return trimmed;
+}
+
+// ── Pattern book (examples show possibility, never dictate solutions) ──────
+
+export interface TrackPattern {
+  id: string;
+  name: LocalizedLabel;
+  grid: { w: number; h: number };
+  pieces: TrackPiece[];
+}
+
+export const PATTERN_BOOK: TrackPattern[] = [
+  {
+    id: "bigLoop",
+    name: { en: "The Big Loop", es: "El Gran Circuito" },
+    grid: { ...DEFAULT_GRID },
+    pieces: [
+      { x: 2, y: 1, type: "start", rot: 0 },
+      { x: 3, y: 1, type: "straight", rot: 0 },
+      { x: 4, y: 1, type: "straight", rot: 0 },
+      { x: 5, y: 1, type: "gentleCurve", rot: 180 },
+      { x: 5, y: 2, type: "straight", rot: 90 },
+      { x: 5, y: 3, type: "straight", rot: 90 },
+      { x: 5, y: 4, type: "gentleCurve", rot: 270 },
+      { x: 4, y: 4, type: "straight", rot: 0 },
+      { x: 3, y: 4, type: "straight", rot: 0 },
+      { x: 2, y: 4, type: "gentleCurve", rot: 0 },
+      { x: 2, y: 3, type: "straight", rot: 90 },
+      { x: 2, y: 2, type: "finish", rot: 0 },
+    ],
+  },
+  {
+    id: "zigZag",
+    name: { en: "The Zigzag", es: "El Zigzag" },
+    grid: { ...DEFAULT_GRID },
+    pieces: [
+      { x: 1, y: 2, type: "start", rot: 0 },
+      { x: 2, y: 2, type: "straight", rot: 0 },
+      { x: 3, y: 2, type: "gentleCurve", rot: 180 },
+      { x: 3, y: 3, type: "gentleCurve", rot: 0 },
+      { x: 4, y: 3, type: "straight", rot: 0 },
+      { x: 5, y: 3, type: "gentleCurve", rot: 180 },
+      { x: 5, y: 4, type: "gentleCurve", rot: 0 },
+      { x: 6, y: 4, type: "finish", rot: 0 },
+    ],
+  },
+  {
+    id: "speedway",
+    name: { en: "The Speedway", es: "La Autopista" },
+    grid: { ...DEFAULT_GRID },
+    pieces: [
+      { x: 0, y: 3, type: "start", rot: 0 },
+      { x: 1, y: 3, type: "straight", rot: 0 },
+      { x: 2, y: 3, type: "straight", rot: 0 },
+      { x: 3, y: 3, type: "straight", rot: 0 },
+      { x: 4, y: 3, type: "straight", rot: 0 },
+      { x: 5, y: 3, type: "straight", rot: 0 },
+      { x: 6, y: 3, type: "gentleCurve", rot: 180 },
+      { x: 6, y: 4, type: "finish", rot: 0 },
+    ],
+  },
+];
+
+// ── Soft targets (suggestions, never requirements) ─────────────────────────
+
+export interface SoftTargetContext {
+  path: TrackPiece[];
+  boostsHit: number;
+  piecesOnTrack: number;
+}
+
+export const SOFT_TARGETS: {
+  id: string;
+  met: (ctx: SoftTargetContext) => boolean;
+}[] = [
+  {
+    id: "twoCurves",
+    met: (ctx) =>
+      ctx.path.filter(
+        (p) => p.type === "gentleCurve" || p.type === "sharpCurve",
+      ).length >= 2,
+  },
+  {
+    id: "useBoost",
+    met: (ctx) => ctx.boostsHit >= 1,
+  },
+  {
+    id: "eightPieces",
+    met: (ctx) => ctx.piecesOnTrack >= 8,
+  },
+];
+
+// ── Reflect pool (context-aware; curious, never corrective) ────────────────
+
+export interface ReflectContext {
+  spinOuts: number;
+  boostsHit: number;
+  /** a piece type ridden for the first time since its unlock, if any */
+  newPieceRidden?: PieceType;
+}
+
+export interface ReflectPrompt {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Pick ONE wondering question for the post-ride Reflect beat. Priority:
+ * a just-unlocked piece that shaped the ride > repeated spin-outs > a single
+ * spin-out > a boost moment > a clean ride > the evergreen fallback.
+ * All six keys live under games.trackMaker.reflect.* with EN + ES copy.
+ */
+export function pickReflectPrompt(
+  ctx: ReflectContext,
+  rand: () => number = Math.random,
+): ReflectPrompt {
+  if (ctx.newPieceRidden) {
+    return { key: "games.trackMaker.reflect.newPiece" };
+  }
+  if (ctx.spinOuts >= 2) {
+    return {
+      key: "games.trackMaker.reflect.spinOuts",
+      params: { count: ctx.spinOuts },
+    };
+  }
+  if (ctx.spinOuts === 1) {
+    return { key: "games.trackMaker.reflect.oneSpin" };
+  }
+  if (ctx.boostsHit >= 1) {
+    return { key: "games.trackMaker.reflect.boost" };
+  }
+  return rand() < 0.5
+    ? { key: "games.trackMaker.reflect.clean" }
+    : { key: "games.trackMaker.reflect.proud" };
+}
+
+// ── Scoring (measures creation, not completion — and never speed) ──────────
+
+export interface TrackMakerSummary {
+  rideable: boolean;
+  ridesCompleted: number;
+  /** edited the track after a ride, then completed another ride */
+  iterated: boolean;
+  targetsMet: number;
+  /** longest run of completed rides with zero spin-outs */
+  bestCleanStreak: number;
+  spinOuts: number;
+  tweaks: number;
+  sharedToGallery: boolean;
+}
+
+export const TRACK_MAKER_TOTAL = 6;
+
+/**
+ * Creation-milestone score (integer, byte-compatible with the platform
+ * contract): built a rideable track (+2), completed a ride (+2), iterated
+ * after riding (+1), met a soft target (+1). No time, no ranking.
+ */
+export function buildTrackMakerResult(s: TrackMakerSummary): GameResult {
+  const score =
+    (s.rideable ? 2 : 0) +
+    (s.ridesCompleted > 0 ? 2 : 0) +
+    (s.iterated ? 1 : 0) +
+    (s.targetsMet > 0 ? 1 : 0);
+  return {
+    gameKey: "track_maker",
+    score,
+    total: TRACK_MAKER_TOTAL,
+    streakMax: s.bestCleanStreak,
+    roundsCompleted: s.ridesCompleted,
+    // Maker telemetry (iteration signals, not rankings). NOTE: the server
+    // currently strips gameSpecific from complete-activity payloads (#672);
+    // the durable artifact is the Creation row, so nothing here depends on
+    // this persisting.
+    gameSpecific: {
+      ridesCompleted: s.ridesCompleted,
+      tweaks: s.tweaks,
+      spinOuts: s.spinOuts,
+      targetsMet: s.targetsMet,
+      sharedToGallery: s.sharedToGallery,
+    },
+  };
+}
+
+// ── Gallery thumbnail (mini SVG polyline; "" = caller falls back to 🏍️) ───
+
+export function trackToPolylinePoints(
+  content: { grid: { w: number; h: number }; pieces: TrackPiece[] },
+  size = 48,
+): string {
+  const walk = walkTrack(content);
+  if (!walk.ok || walk.path.length < 2) return "";
+  const pad = 4;
+  const scale = (size - pad * 2) / Math.max(content.grid.w, content.grid.h);
+  return walk.path
+    .map(
+      (p) =>
+        `${(pad + (p.x + 0.5) * scale).toFixed(1)},${(pad + (p.y + 0.5) * scale).toFixed(1)}`,
+    )
+    .join(" ");
+}

--- a/src/constants/__tests__/stemSets.test.ts
+++ b/src/constants/__tests__/stemSets.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   STEM_SET_1_IDS,
   STEM_SET_2_IDS,
+  STEM_SET_3_IDS,
   isSet1Complete,
   isSet2Locked,
+  isSet3Locked,
 } from "../stemSets";
 
 describe("STEM set canon and gating", () => {
@@ -29,9 +31,24 @@ describe("STEM set canon and gating", () => {
     ]);
   });
 
+  it("reserves five Set 3 slots and assigns Track Builder to the first", () => {
+    expect(STEM_SET_3_IDS).toEqual([
+      "track-maker",
+      "set3-game-2",
+      "set3-game-3",
+      "set3-game-4",
+      "set3-game-5",
+    ]);
+  });
+
   it("returns false for Set 1 completion when only 4 canonical activities are completed", () => {
     expect(
-      isSet1Complete(["bounce-buds", "gotcha-gears", "rhyme-ride", "tank-trek"]),
+      isSet1Complete([
+        "bounce-buds",
+        "gotcha-gears",
+        "rhyme-ride",
+        "tank-trek",
+      ]),
     ).toBe(false);
   });
 
@@ -75,5 +92,10 @@ describe("STEM set canon and gating", () => {
         "lost-steps",
       ]),
     ).toBe(true);
+  });
+
+  it("unlocks Set 3 only after every canonical Set 2 activity is complete", () => {
+    expect(isSet3Locked(STEM_SET_2_IDS.slice(0, 4))).toBe(true);
+    expect(isSet3Locked([...STEM_SET_2_IDS])).toBe(false);
   });
 });

--- a/src/constants/stemSets.ts
+++ b/src/constants/stemSets.ts
@@ -40,8 +40,12 @@ export const STEM_SET_1_STRANDS: Record<StemSet1GameId, string> = {
 
 /** Module slugs that should NOT appear in student-facing UI. */
 export const HIDDEN_MODULE_SLUGS = new Set([
-  "stem-1-intro",      // Legacy "Quantum Explorers" — archived
+  "stem-1-intro", // Legacy "Quantum Explorers" — archived
   "k2-stem-sequencing", // "Fix the Order" / "Lost Steps" — removed from canon
+  // GATED (not removed): Set 3 game 1 is fully wired (registry, seed,
+  // race_track creation type) but held back until Set 3 has more games /
+  // leads sign off. Ungating = delete the next line. See #676.
+  "k2-stem-track-maker",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -82,23 +86,48 @@ export const STEM_SET_2_PERKS: Record<StemSet2GameId, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Set 3 — Mastery (placeholder, gates specialization)
+// Set 3 — Mastery ("mastery through making"; completion gates specialization)
+// Game 1 (track-maker) is implemented but GATED from students via
+// HIDDEN_MODULE_SLUGS above; slots 2-5 are still placeholders (slot 2 is
+// earmarked for the machine-programming game in design). See #676.
 // ---------------------------------------------------------------------------
 export const STEM_SET_3_IDS = [
-  "set3-game-1",
+  "track-maker",
   "set3-game-2",
   "set3-game-3",
   "set3-game-4",
   "set3-game-5",
 ] as const;
 
+export type StemSet3GameId = (typeof STEM_SET_3_IDS)[number];
+
+// Partial until all five Set 3 games exist — placeholders have no name/strand.
+export const STEM_SET_3_NAMES: Partial<Record<StemSet3GameId, string>> = {
+  "track-maker": "Boost Track Builder",
+};
+
+export const STEM_SET_3_STRANDS: Partial<Record<StemSet3GameId, string>> = {
+  "track-maker": "Quantum",
+};
+
+/** Module slugs for Set 3 (grows as the set is built out). */
+export const STEM_SET_3_MODULE_SLUGS = ["k2-stem-track-maker"] as const;
+
 // ---------------------------------------------------------------------------
 // Aggregate constants
 // ---------------------------------------------------------------------------
-export const ALL_STEM_SETS = [STEM_SET_1_IDS, STEM_SET_2_IDS, STEM_SET_3_IDS] as const;
+export const ALL_STEM_SETS = [
+  STEM_SET_1_IDS,
+  STEM_SET_2_IDS,
+  STEM_SET_3_IDS,
+] as const;
 export const TOTAL_SETS = 3;
 
-export const SET_LABELS = ["Set 1: Foundation", "Set 2: Exploration", "Set 3: Mastery"] as const;
+export const SET_LABELS = [
+  "Set 1: Foundation",
+  "Set 2: Exploration",
+  "Set 3: Mastery",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -113,15 +142,17 @@ export function countCompletedInSet(
 }
 
 /** A set is complete when all its IDs are completed. */
-function isSetComplete(completedIds: string[], setIds: readonly string[]): boolean {
+function isSetComplete(
+  completedIds: string[],
+  setIds: readonly string[],
+): boolean {
   return countCompletedInSet(completedIds, setIds) >= setIds.length;
 }
 
 /** Count how many full sets the player has completed. */
 export function countCompletedSets(completedIds: string[]): number {
-  return ALL_STEM_SETS.filter(
-    (setIds) => isSetComplete(completedIds, setIds),
-  ).length;
+  return ALL_STEM_SETS.filter((setIds) => isSetComplete(completedIds, setIds))
+    .length;
 }
 
 /** True when all Set 1 activities are completed. */
@@ -134,14 +165,36 @@ export function isSet2Locked(completedIds: string[]): boolean {
   return !isSet1Complete(completedIds);
 }
 
+/** True when all Set 2 activities are completed. */
+export function isSet2Complete(completedIds: string[]): boolean {
+  return isSetComplete(completedIds, STEM_SET_2_IDS);
+}
+
+/** True when Set 3 is still locked (Set 2 not yet complete) — mirrors the
+ *  Set 1 → Set 2 unlock. */
+export function isSet3Locked(completedIds: string[]): boolean {
+  return !isSet2Complete(completedIds);
+}
+
 /** Type guard: is this activity ID a Set 1 game? */
-export function isStemSet1Game(activityId: string): activityId is StemSet1GameId {
+export function isStemSet1Game(
+  activityId: string,
+): activityId is StemSet1GameId {
   return (STEM_SET_1_IDS as readonly string[]).includes(activityId);
 }
 
 /** Type guard: is this activity ID a Set 2 game? */
-export function isStemSet2Game(activityId: string): activityId is StemSet2GameId {
+export function isStemSet2Game(
+  activityId: string,
+): activityId is StemSet2GameId {
   return (STEM_SET_2_IDS as readonly string[]).includes(activityId);
+}
+
+/** Type guard: is this activity ID a Set 3 game? */
+export function isStemSet3Game(
+  activityId: string,
+): activityId is StemSet3GameId {
+  return (STEM_SET_3_IDS as readonly string[]).includes(activityId);
 }
 
 /** Module slugs for Set 2. */

--- a/src/lib/moduleAccess.ts
+++ b/src/lib/moduleAccess.ts
@@ -10,7 +10,12 @@
  * 4. Specialization choice is gated behind completing STEM Set 3
  *    (enforced in Avatar.tsx + backend POST /avatar/select-archetype).
  */
-import { STEM_SET_2_MODULE_SLUGS, isSet2Locked } from "@/constants/stemSets";
+import {
+  STEM_SET_2_MODULE_SLUGS,
+  STEM_SET_3_MODULE_SLUGS,
+  isSet2Locked,
+  isSet3Locked,
+} from "@/constants/stemSets";
 
 // ── Specialization-gated module slugs ────────────────────────────────────
 // Add future specialization-only modules here.
@@ -58,6 +63,19 @@ export function isSet2ModuleSlug(slug: string): boolean {
  */
 export function checkSet2Locked(completedActivityIds: string[]): boolean {
   return isSet2Locked(completedActivityIds);
+}
+
+/** True when `slug` is a Set 3 module. */
+export function isSet3ModuleSlug(slug: string): boolean {
+  return (STEM_SET_3_MODULE_SLUGS as readonly string[]).includes(slug);
+}
+
+/**
+ * Whether Set 3 is currently locked for the student — mirrors the
+ * Set 1 → Set 2 gate (Set 3 unlocks when all Set 2 activities are complete).
+ */
+export function checkSet3Locked(completedActivityIds: string[]): boolean {
+  return isSet3Locked(completedActivityIds);
 }
 
 /**

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -870,6 +870,8 @@
     "set2LockedMessage": "Complete Set 1 STEM Games to unlock the next challenge set.",
     "set2LockedToastTitle": "Set 2 is Locked",
     "set3Label": "Set 3",
+    "set3LockedMessage": "Complete Set 2 STEM Games to unlock the mastery set.",
+    "set3LockedToastTitle": "Set 3 is Locked",
     "set3ComingSoon": "Set 3: Mastery \u2014 Coming Soon",
     "set3ComingSoonDesc": "New challenges are being built. Stay tuned!",
     "detail": {
@@ -1440,6 +1442,87 @@
     "learning": {
       "wordsToKnow": "Words to know"
     },
+    "trackMaker": {
+      "imagine": {
+        "prompt": "What kind of track will you build — loopy, zoomy, twisty?",
+        "hint": "Build a track for Boost's motorcycle, then ride it!",
+        "start": "Start building!"
+      },
+      "build": {
+        "unnamed": "My Track",
+        "renameAria": "Track name — tap to change",
+        "save": "Save",
+        "saved": "Saved ✓",
+        "savedLocal": "Saved on this device ✓",
+        "gridAria": "Track building grid",
+        "cellPieceAria": "{{piece}} — tap to turn it",
+        "cellEmptyAria": "Empty spot — tap to place a piece",
+        "brokenHint": "The road ends at the glowing spot — connect it!",
+        "ride": "Ride! 🏍️",
+        "share": "Share to gallery ✨",
+        "sharedNote": "In the gallery! ✨",
+        "done": "Done for now"
+      },
+      "piece": {
+        "start": "Start",
+        "straight": "Straight",
+        "gentleCurve": "Gentle curve",
+        "sharpCurve": "Sharp curve",
+        "boost": "Boost pad",
+        "finish": "Finish flag",
+        "erase": "Eraser"
+      },
+      "unlock": {
+        "sharpCurve": "You earned the Sharp Curve! 🎉",
+        "boost": "You earned the Boost Pad! 🎉",
+        "tryIt": "Tap to try it!"
+      },
+      "ideas": {
+        "open": "Show me ideas 📖",
+        "title": "Track ideas 📖",
+        "use": "Build from this",
+        "confirm": "Replace my track?",
+        "close": "Keep my track"
+      },
+      "target": {
+        "twoCurves": "Try this: can you build a track with 2 curves the bike survives?",
+        "useBoost": "Try this: can you use a boost pad and still finish the ride?",
+        "eightPieces": "Try this: can you build a track with 8 or more pieces?",
+        "twoCurvesMet": "Two curves and you made it — that was a try-this idea! ⭐",
+        "useBoostMet": "You used a boost and finished — that was a try-this idea! ⭐",
+        "eightPiecesMet": "Eight pieces built and ridden — that was a try-this idea! ⭐"
+      },
+      "ride": {
+        "lean": "leaning",
+        "zoom": "zooming",
+        "sharpAhead": "Sharp curve ahead!",
+        "curveAhead": "Curve ahead",
+        "holdButton": "HOLD to lean 🏍️",
+        "holdToLean": "Hold to lean into curves",
+        "wobble": "Wobbly! Just made it!",
+        "spinOut": "Whoa — too fast for that curve! Boost is okay. Try holding LEAN before the turn.",
+        "finished": "You finished your track!",
+        "tweak": "Tweak my track 🔧",
+        "again": "Ride again 🏍️",
+        "done": "Done for now"
+      },
+      "reflect": {
+        "newPiece": "Your new piece changed the ride! Where else could it go?",
+        "spinOuts": "You spun out {{count}} times and still finished! Which curve was trickiest?",
+        "oneSpin": "One wipeout, one comeback! What would you change about that curve?",
+        "boost": "That boost made Boost ZOOM! What happens if you move it somewhere else?",
+        "clean": "A clean ride the whole way! What would make your track even more exciting?",
+        "proud": "What part of your track are you most proud of?"
+      },
+      "name": {
+        "title": "Name your track!",
+        "keep": "That's it!",
+        "later": "Later"
+      },
+      "rideOnly": {
+        "notRideable": "This track can't be ridden right now. Try another one!"
+      }
+    },
     "boostPath": {
       "title": "Boost's Path Planner",
       "level1": "Reach the solar charger",
@@ -1907,7 +1990,8 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "ride": "Ride"
   },
   "parents": {
     "docTitle": "Bright Boost for Parents & Families",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1440,6 +1440,87 @@
     "learning": {
       "wordsToKnow": "Palabras para aprender"
     },
+    "trackMaker": {
+      "imagine": {
+        "prompt": "¿Qué clase de pista vas a construir — con rulos, rápida, zigzagueante?",
+        "hint": "¡Construye una pista para la moto de Boost y luego móntala!",
+        "start": "¡A construir!"
+      },
+      "build": {
+        "unnamed": "Mi Pista",
+        "renameAria": "Nombre de la pista — toca para cambiarlo",
+        "save": "Guardar",
+        "saved": "Guardado ✓",
+        "savedLocal": "Guardado en este dispositivo ✓",
+        "gridAria": "Cuadrícula para construir la pista",
+        "cellPieceAria": "{{piece}} — toca para girarla",
+        "cellEmptyAria": "Espacio vacío — toca para colocar una pieza",
+        "brokenHint": "El camino termina en el punto que brilla — ¡conéctalo!",
+        "ride": "¡A rodar! 🏍️",
+        "share": "Compartir en la galería ✨",
+        "sharedNote": "¡En la galería! ✨",
+        "done": "Por ahora, listo"
+      },
+      "piece": {
+        "start": "Salida",
+        "straight": "Recta",
+        "gentleCurve": "Curva suave",
+        "sharpCurve": "Curva cerrada",
+        "boost": "Acelerador",
+        "finish": "Bandera de meta",
+        "erase": "Borrador"
+      },
+      "unlock": {
+        "sharpCurve": "¡Ganaste la Curva Cerrada! 🎉",
+        "boost": "¡Ganaste el Acelerador! 🎉",
+        "tryIt": "¡Toca para probarla!"
+      },
+      "ideas": {
+        "open": "Muéstrame ideas 📖",
+        "title": "Ideas de pistas 📖",
+        "use": "Construir desde esta",
+        "confirm": "¿Reemplazar mi pista?",
+        "close": "Conservar mi pista"
+      },
+      "target": {
+        "twoCurves": "Prueba esto: ¿puedes construir una pista con 2 curvas que la moto supere?",
+        "useBoost": "Prueba esto: ¿puedes usar un acelerador y aun así llegar a la meta?",
+        "eightPieces": "Prueba esto: ¿puedes construir una pista con 8 piezas o más?",
+        "twoCurvesMet": "Dos curvas y lo lograste — ¡era una de las ideas! ⭐",
+        "useBoostMet": "Usaste un acelerador y terminaste — ¡era una de las ideas! ⭐",
+        "eightPiecesMet": "Ocho piezas construidas y recorridas — ¡era una de las ideas! ⭐"
+      },
+      "ride": {
+        "lean": "inclinando",
+        "zoom": "a toda velocidad",
+        "sharpAhead": "¡Curva cerrada adelante!",
+        "curveAhead": "Curva adelante",
+        "holdButton": "MANTÉN para inclinar 🏍️",
+        "holdToLean": "Mantén presionado para inclinarte en las curvas",
+        "wobble": "¡Tambaleo! ¡Por poquito!",
+        "spinOut": "¡Uy — demasiado rápido para esa curva! Boost está bien. Intenta mantener INCLINAR antes del giro.",
+        "finished": "¡Terminaste tu pista!",
+        "tweak": "Ajustar mi pista 🔧",
+        "again": "Rodar otra vez 🏍️",
+        "done": "Por ahora, listo"
+      },
+      "reflect": {
+        "newPiece": "¡Tu pieza nueva cambió el paseo! ¿En qué otro lugar podría ir?",
+        "spinOuts": "¡Diste {{count}} trompos y aun así terminaste! ¿Cuál curva fue la más difícil?",
+        "oneSpin": "¡Un trompo y una remontada! ¿Qué cambiarías de esa curva?",
+        "boost": "¡Ese acelerador hizo a Boost VOLAR! ¿Qué pasa si lo mueves a otro lugar?",
+        "clean": "¡Un paseo limpio de principio a fin! ¿Qué haría tu pista aún más emocionante?",
+        "proud": "¿De qué parte de tu pista estás más orgulloso?"
+      },
+      "name": {
+        "title": "¡Ponle nombre a tu pista!",
+        "keep": "¡Ese es!",
+        "later": "Después"
+      },
+      "rideOnly": {
+        "notRideable": "Esta pista no se puede recorrer ahora. ¡Prueba otra!"
+      }
+    },
     "boostPath": {
       "title": "Planificador de Boost",
       "level1": "Llega al cargador solar",
@@ -1742,7 +1823,8 @@
     "by": "por {{name}}",
     "boosts": "Ánimos",
     "giveBoost": "Dar ánimo ⭐",
-    "play": "Jugar"
+    "play": "Jugar",
+    "ride": "Montar"
   },
   "parents": {
     "docTitle": "Bright Boost para padres y familias",

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -943,32 +943,127 @@
       "r7": { "prompt": "boat", "correct": "coat", "d1": "cat", "d2": "bug" }
     },
     "bounceGame": {
-      "r1": { "clue": "Một cây con nhỏ là ____.", "correct": "hạt giống", "d1": "lá", "d2": "đá", "hint": "Hạt giống có thể mọc!" },
-      "r2": { "clue": "Phần này uống nước.", "correct": "rễ", "d1": "lá", "d2": "mặt trời", "hint": "Rễ nằm dưới đất." },
-      "r3": { "clue": "Lá giúp cây sử dụng ____.", "correct": "ánh sáng", "d1": "pizza", "d2": "giày", "hint": "Ánh sáng giúp cây phát triển." },
-      "r4": { "clue": "Những người giúp đỡ nhỏ xíu trong đất là ____.", "correct": "vi sinh vật", "d1": "xe hơi", "d2": "mây", "hint": "Vi sinh vật rất nhỏ và sống." },
-      "r5": { "clue": "Những khối xây dựng nhỏ xíu gọi là ____.", "correct": "tế bào", "d1": "ghế", "d2": "bánh", "hint": "Tế bào rất nhỏ." },
-      "r6": { "clue": "Cây cần nước và ____.", "correct": "ánh sáng", "d1": "tivi", "d2": "kẹo", "hint": "Cây cần ánh sáng." },
-      "r7": { "clue": "Một bông hoa có thể giúp tạo ____.", "correct": "hạt giống", "d1": "tất", "d2": "đá", "hint": "Hoa giúp cây tạo hạt giống." }
+      "r1": {
+        "clue": "Một cây con nhỏ là ____.",
+        "correct": "hạt giống",
+        "d1": "lá",
+        "d2": "đá",
+        "hint": "Hạt giống có thể mọc!"
+      },
+      "r2": {
+        "clue": "Phần này uống nước.",
+        "correct": "rễ",
+        "d1": "lá",
+        "d2": "mặt trời",
+        "hint": "Rễ nằm dưới đất."
+      },
+      "r3": {
+        "clue": "Lá giúp cây sử dụng ____.",
+        "correct": "ánh sáng",
+        "d1": "pizza",
+        "d2": "giày",
+        "hint": "Ánh sáng giúp cây phát triển."
+      },
+      "r4": {
+        "clue": "Những người giúp đỡ nhỏ xíu trong đất là ____.",
+        "correct": "vi sinh vật",
+        "d1": "xe hơi",
+        "d2": "mây",
+        "hint": "Vi sinh vật rất nhỏ và sống."
+      },
+      "r5": {
+        "clue": "Những khối xây dựng nhỏ xíu gọi là ____.",
+        "correct": "tế bào",
+        "d1": "ghế",
+        "d2": "bánh",
+        "hint": "Tế bào rất nhỏ."
+      },
+      "r6": {
+        "clue": "Cây cần nước và ____.",
+        "correct": "ánh sáng",
+        "d1": "tivi",
+        "d2": "kẹo",
+        "hint": "Cây cần ánh sáng."
+      },
+      "r7": {
+        "clue": "Một bông hoa có thể giúp tạo ____.",
+        "correct": "hạt giống",
+        "d1": "tất",
+        "d2": "đá",
+        "hint": "Hoa giúp cây tạo hạt giống."
+      }
     },
     "gotchaGame": {
-      "r1": { "clue": "Robot cứ mắc lỗi. Nó nên làm gì?", "correct": "gỡ lỗi", "d1": "đoán", "d2": "bỏ qua", "hint": "Gỡ lỗi nghĩa là sửa lỗi." },
-      "r2": { "clue": "Chúng ta muốn robot học. Điều gì giúp nhiều nhất?", "correct": "luyện tập", "d1": "bỏ qua", "d2": "ngủ", "hint": "Luyện tập nghĩa là thử lại." },
-      "r3": { "clue": "Chúng ta cần phân loại. Chúng ta chọn gì trước?", "correct": "quy tắc", "d1": "ngẫu nhiên", "d2": "tiếng ồn", "hint": "Quy tắc cho biết cách nhóm đồ vật." },
-      "r4": { "clue": "Robot cần các bước để làm theo. Đó là gì?", "correct": "kế hoạch", "d1": "vội", "d2": "bừa bộn", "hint": "Kế hoạch là các bước theo thứ tự." },
-      "r5": { "clue": "Chúng ta nhìn manh mối để tìm câu trả lời. Đó gọi là…", "correct": "mẫu hình", "d1": "may mắn", "d2": "phép thuật", "hint": "Mẫu hình lặp lại hoặc khớp nhau." },
-      "r6": { "clue": "Robot thử điều gì đó mới. Nó đang làm gì?", "correct": "thử nghiệm", "d1": "ngủ", "d2": "trốn", "hint": "Thử nghiệm nghĩa là thử xem có được không." },
-      "r7": { "clue": "Chúng ta dạy robot bằng cách cho nó…", "correct": "dữ liệu", "d1": "kẹo", "d2": "đồ chơi", "hint": "Dữ liệu là thông tin robot dùng để học." }
+      "r1": {
+        "clue": "Robot cứ mắc lỗi. Nó nên làm gì?",
+        "correct": "gỡ lỗi",
+        "d1": "đoán",
+        "d2": "bỏ qua",
+        "hint": "Gỡ lỗi nghĩa là sửa lỗi."
+      },
+      "r2": {
+        "clue": "Chúng ta muốn robot học. Điều gì giúp nhiều nhất?",
+        "correct": "luyện tập",
+        "d1": "bỏ qua",
+        "d2": "ngủ",
+        "hint": "Luyện tập nghĩa là thử lại."
+      },
+      "r3": {
+        "clue": "Chúng ta cần phân loại. Chúng ta chọn gì trước?",
+        "correct": "quy tắc",
+        "d1": "ngẫu nhiên",
+        "d2": "tiếng ồn",
+        "hint": "Quy tắc cho biết cách nhóm đồ vật."
+      },
+      "r4": {
+        "clue": "Robot cần các bước để làm theo. Đó là gì?",
+        "correct": "kế hoạch",
+        "d1": "vội",
+        "d2": "bừa bộn",
+        "hint": "Kế hoạch là các bước theo thứ tự."
+      },
+      "r5": {
+        "clue": "Chúng ta nhìn manh mối để tìm câu trả lời. Đó gọi là…",
+        "correct": "mẫu hình",
+        "d1": "may mắn",
+        "d2": "phép thuật",
+        "hint": "Mẫu hình lặp lại hoặc khớp nhau."
+      },
+      "r6": {
+        "clue": "Robot thử điều gì đó mới. Nó đang làm gì?",
+        "correct": "thử nghiệm",
+        "d1": "ngủ",
+        "d2": "trốn",
+        "hint": "Thử nghiệm nghĩa là thử xem có được không."
+      },
+      "r7": {
+        "clue": "Chúng ta dạy robot bằng cách cho nó…",
+        "correct": "dữ liệu",
+        "d1": "kẹo",
+        "d2": "đồ chơi",
+        "hint": "Dữ liệu là thông tin robot dùng để học."
+      }
     },
     "seqGame": {
       "l1": {
-        "c1": "Đổ", "c2": "Nướng", "c3": "Phủ kem", "c4": "Ăn"
+        "c1": "Đổ",
+        "c2": "Nướng",
+        "c3": "Phủ kem",
+        "c4": "Ăn"
       },
       "l2": {
-        "c1": "Mở vòi nước", "c2": "Rửa", "c3": "Xà phòng", "c4": "Tráng", "c5": "Lau khô"
+        "c1": "Mở vòi nước",
+        "c2": "Rửa",
+        "c3": "Xà phòng",
+        "c4": "Tráng",
+        "c5": "Lau khô"
       },
       "l3": {
-        "c1": "Lên kế hoạch", "c2": "Lập trình", "c3": "Thử", "c4": "Sửa", "c5": "Chia sẻ"
+        "c1": "Lên kế hoạch",
+        "c2": "Lập trình",
+        "c3": "Thử",
+        "c4": "Sửa",
+        "c5": "Chia sẻ"
       }
     }
   },
@@ -1341,6 +1436,87 @@
     "learning": {
       "wordsToKnow": "Từ cần biết"
     },
+    "trackMaker": {
+      "imagine": {
+        "prompt": "What kind of track will you build — loopy, zoomy, twisty?",
+        "hint": "Build a track for Boost's motorcycle, then ride it!",
+        "start": "Start building!"
+      },
+      "build": {
+        "unnamed": "My Track",
+        "renameAria": "Track name — tap to change",
+        "save": "Save",
+        "saved": "Saved ✓",
+        "savedLocal": "Saved on this device ✓",
+        "gridAria": "Track building grid",
+        "cellPieceAria": "{{piece}} — tap to turn it",
+        "cellEmptyAria": "Empty spot — tap to place a piece",
+        "brokenHint": "The road ends at the glowing spot — connect it!",
+        "ride": "Ride! 🏍️",
+        "share": "Share to gallery ✨",
+        "sharedNote": "In the gallery! ✨",
+        "done": "Done for now"
+      },
+      "piece": {
+        "start": "Start",
+        "straight": "Straight",
+        "gentleCurve": "Gentle curve",
+        "sharpCurve": "Sharp curve",
+        "boost": "Boost pad",
+        "finish": "Finish flag",
+        "erase": "Eraser"
+      },
+      "unlock": {
+        "sharpCurve": "You earned the Sharp Curve! 🎉",
+        "boost": "You earned the Boost Pad! 🎉",
+        "tryIt": "Tap to try it!"
+      },
+      "ideas": {
+        "open": "Show me ideas 📖",
+        "title": "Track ideas 📖",
+        "use": "Build from this",
+        "confirm": "Replace my track?",
+        "close": "Keep my track"
+      },
+      "target": {
+        "twoCurves": "Try this: can you build a track with 2 curves the bike survives?",
+        "useBoost": "Try this: can you use a boost pad and still finish the ride?",
+        "eightPieces": "Try this: can you build a track with 8 or more pieces?",
+        "twoCurvesMet": "Two curves and you made it — that was a try-this idea! ⭐",
+        "useBoostMet": "You used a boost and finished — that was a try-this idea! ⭐",
+        "eightPiecesMet": "Eight pieces built and ridden — that was a try-this idea! ⭐"
+      },
+      "ride": {
+        "lean": "leaning",
+        "zoom": "zooming",
+        "sharpAhead": "Sharp curve ahead!",
+        "curveAhead": "Curve ahead",
+        "holdButton": "HOLD to lean 🏍️",
+        "holdToLean": "Hold to lean into curves",
+        "wobble": "Wobbly! Just made it!",
+        "spinOut": "Whoa — too fast for that curve! Boost is okay. Try holding LEAN before the turn.",
+        "finished": "You finished your track!",
+        "tweak": "Tweak my track 🔧",
+        "again": "Ride again 🏍️",
+        "done": "Done for now"
+      },
+      "reflect": {
+        "newPiece": "Your new piece changed the ride! Where else could it go?",
+        "spinOuts": "You spun out {{count}} times and still finished! Which curve was trickiest?",
+        "oneSpin": "One wipeout, one comeback! What would you change about that curve?",
+        "boost": "That boost made Boost ZOOM! What happens if you move it somewhere else?",
+        "clean": "A clean ride the whole way! What would make your track even more exciting?",
+        "proud": "What part of your track are you most proud of?"
+      },
+      "name": {
+        "title": "Name your track!",
+        "keep": "That's it!",
+        "later": "Later"
+      },
+      "rideOnly": {
+        "notRideable": "This track can't be ridden right now. Try another one!"
+      }
+    },
     "boostPath": {
       "title": "Bản Đồ Của Boost",
       "level1": "Đến bộ sạc năng lượng mặt trời",
@@ -1533,6 +1709,7 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "ride": "Ride"
   }
 }

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -943,32 +943,127 @@
       "r7": { "prompt": "boat", "correct": "coat", "d1": "cat", "d2": "bug" }
     },
     "bounceGame": {
-      "r1": { "clue": "小小的植物宝宝是____。", "correct": "种子", "d1": "叶子", "d2": "石头", "hint": "种子可以长大！" },
-      "r2": { "clue": "这个部分喝水。", "correct": "根", "d1": "叶子", "d2": "太阳", "hint": "根在地下面。" },
-      "r3": { "clue": "叶子帮助植物利用____。", "correct": "阳光", "d1": "比萨", "d2": "鞋子", "hint": "阳光帮助植物生长。" },
-      "r4": { "clue": "土壤里小小的活帮手是____。", "correct": "微生物", "d1": "汽车", "d2": "云朵", "hint": "微生物很小，而且是活的。" },
-      "r5": { "clue": "小小的积木块叫做____。", "correct": "细胞", "d1": "椅子", "d2": "零食", "hint": "细胞非常小。" },
-      "r6": { "clue": "植物需要水和____。", "correct": "阳光", "d1": "电视", "d2": "糖果", "hint": "植物需要光。" },
-      "r7": { "clue": "花可以帮助产生____。", "correct": "种子", "d1": "袜子", "d2": "石头", "hint": "花帮助植物产生种子。" }
+      "r1": {
+        "clue": "小小的植物宝宝是____。",
+        "correct": "种子",
+        "d1": "叶子",
+        "d2": "石头",
+        "hint": "种子可以长大！"
+      },
+      "r2": {
+        "clue": "这个部分喝水。",
+        "correct": "根",
+        "d1": "叶子",
+        "d2": "太阳",
+        "hint": "根在地下面。"
+      },
+      "r3": {
+        "clue": "叶子帮助植物利用____。",
+        "correct": "阳光",
+        "d1": "比萨",
+        "d2": "鞋子",
+        "hint": "阳光帮助植物生长。"
+      },
+      "r4": {
+        "clue": "土壤里小小的活帮手是____。",
+        "correct": "微生物",
+        "d1": "汽车",
+        "d2": "云朵",
+        "hint": "微生物很小，而且是活的。"
+      },
+      "r5": {
+        "clue": "小小的积木块叫做____。",
+        "correct": "细胞",
+        "d1": "椅子",
+        "d2": "零食",
+        "hint": "细胞非常小。"
+      },
+      "r6": {
+        "clue": "植物需要水和____。",
+        "correct": "阳光",
+        "d1": "电视",
+        "d2": "糖果",
+        "hint": "植物需要光。"
+      },
+      "r7": {
+        "clue": "花可以帮助产生____。",
+        "correct": "种子",
+        "d1": "袜子",
+        "d2": "石头",
+        "hint": "花帮助植物产生种子。"
+      }
     },
     "gotchaGame": {
-      "r1": { "clue": "机器人一直犯错。它应该怎么做？", "correct": "调试", "d1": "猜", "d2": "不管", "hint": "调试就是修复错误。" },
-      "r2": { "clue": "我们想让机器人学习。什么最有帮助？", "correct": "练习", "d1": "跳过", "d2": "睡觉", "hint": "练习就是再试一次。" },
-      "r3": { "clue": "我们要分类东西。先选什么？", "correct": "规则", "d1": "随便", "d2": "噪音", "hint": "规则告诉我们怎么分类。" },
-      "r4": { "clue": "机器人需要按步骤做。那叫什么？", "correct": "计划", "d1": "着急", "d2": "乱七八糟", "hint": "计划是按顺序排列的步骤。" },
-      "r5": { "clue": "我们看线索来找答案。这叫做……", "correct": "规律", "d1": "运气", "d2": "魔法", "hint": "规律就是重复或匹配的东西。" },
-      "r6": { "clue": "机器人尝试新东西。它在做什么？", "correct": "测试", "d1": "睡觉", "d2": "躲起来", "hint": "测试就是试试看它能不能用。" },
-      "r7": { "clue": "我们通过给机器人……来教它。", "correct": "数据", "d1": "糖果", "d2": "玩具", "hint": "数据是机器人用来学习的信息。" }
+      "r1": {
+        "clue": "机器人一直犯错。它应该怎么做？",
+        "correct": "调试",
+        "d1": "猜",
+        "d2": "不管",
+        "hint": "调试就是修复错误。"
+      },
+      "r2": {
+        "clue": "我们想让机器人学习。什么最有帮助？",
+        "correct": "练习",
+        "d1": "跳过",
+        "d2": "睡觉",
+        "hint": "练习就是再试一次。"
+      },
+      "r3": {
+        "clue": "我们要分类东西。先选什么？",
+        "correct": "规则",
+        "d1": "随便",
+        "d2": "噪音",
+        "hint": "规则告诉我们怎么分类。"
+      },
+      "r4": {
+        "clue": "机器人需要按步骤做。那叫什么？",
+        "correct": "计划",
+        "d1": "着急",
+        "d2": "乱七八糟",
+        "hint": "计划是按顺序排列的步骤。"
+      },
+      "r5": {
+        "clue": "我们看线索来找答案。这叫做……",
+        "correct": "规律",
+        "d1": "运气",
+        "d2": "魔法",
+        "hint": "规律就是重复或匹配的东西。"
+      },
+      "r6": {
+        "clue": "机器人尝试新东西。它在做什么？",
+        "correct": "测试",
+        "d1": "睡觉",
+        "d2": "躲起来",
+        "hint": "测试就是试试看它能不能用。"
+      },
+      "r7": {
+        "clue": "我们通过给机器人……来教它。",
+        "correct": "数据",
+        "d1": "糖果",
+        "d2": "玩具",
+        "hint": "数据是机器人用来学习的信息。"
+      }
     },
     "seqGame": {
       "l1": {
-        "c1": "倒入", "c2": "烘烤", "c3": "抹奶油", "c4": "吃"
+        "c1": "倒入",
+        "c2": "烘烤",
+        "c3": "抹奶油",
+        "c4": "吃"
       },
       "l2": {
-        "c1": "打开水龙头", "c2": "洗", "c3": "抹肥皂", "c4": "冲洗", "c5": "擦干"
+        "c1": "打开水龙头",
+        "c2": "洗",
+        "c3": "抹肥皂",
+        "c4": "冲洗",
+        "c5": "擦干"
       },
       "l3": {
-        "c1": "计划", "c2": "编写代码", "c3": "测试", "c4": "修复", "c5": "分享"
+        "c1": "计划",
+        "c2": "编写代码",
+        "c3": "测试",
+        "c4": "修复",
+        "c5": "分享"
       }
     }
   },
@@ -1341,6 +1436,87 @@
     "learning": {
       "wordsToKnow": "需要认识的词"
     },
+    "trackMaker": {
+      "imagine": {
+        "prompt": "What kind of track will you build — loopy, zoomy, twisty?",
+        "hint": "Build a track for Boost's motorcycle, then ride it!",
+        "start": "Start building!"
+      },
+      "build": {
+        "unnamed": "My Track",
+        "renameAria": "Track name — tap to change",
+        "save": "Save",
+        "saved": "Saved ✓",
+        "savedLocal": "Saved on this device ✓",
+        "gridAria": "Track building grid",
+        "cellPieceAria": "{{piece}} — tap to turn it",
+        "cellEmptyAria": "Empty spot — tap to place a piece",
+        "brokenHint": "The road ends at the glowing spot — connect it!",
+        "ride": "Ride! 🏍️",
+        "share": "Share to gallery ✨",
+        "sharedNote": "In the gallery! ✨",
+        "done": "Done for now"
+      },
+      "piece": {
+        "start": "Start",
+        "straight": "Straight",
+        "gentleCurve": "Gentle curve",
+        "sharpCurve": "Sharp curve",
+        "boost": "Boost pad",
+        "finish": "Finish flag",
+        "erase": "Eraser"
+      },
+      "unlock": {
+        "sharpCurve": "You earned the Sharp Curve! 🎉",
+        "boost": "You earned the Boost Pad! 🎉",
+        "tryIt": "Tap to try it!"
+      },
+      "ideas": {
+        "open": "Show me ideas 📖",
+        "title": "Track ideas 📖",
+        "use": "Build from this",
+        "confirm": "Replace my track?",
+        "close": "Keep my track"
+      },
+      "target": {
+        "twoCurves": "Try this: can you build a track with 2 curves the bike survives?",
+        "useBoost": "Try this: can you use a boost pad and still finish the ride?",
+        "eightPieces": "Try this: can you build a track with 8 or more pieces?",
+        "twoCurvesMet": "Two curves and you made it — that was a try-this idea! ⭐",
+        "useBoostMet": "You used a boost and finished — that was a try-this idea! ⭐",
+        "eightPiecesMet": "Eight pieces built and ridden — that was a try-this idea! ⭐"
+      },
+      "ride": {
+        "lean": "leaning",
+        "zoom": "zooming",
+        "sharpAhead": "Sharp curve ahead!",
+        "curveAhead": "Curve ahead",
+        "holdButton": "HOLD to lean 🏍️",
+        "holdToLean": "Hold to lean into curves",
+        "wobble": "Wobbly! Just made it!",
+        "spinOut": "Whoa — too fast for that curve! Boost is okay. Try holding LEAN before the turn.",
+        "finished": "You finished your track!",
+        "tweak": "Tweak my track 🔧",
+        "again": "Ride again 🏍️",
+        "done": "Done for now"
+      },
+      "reflect": {
+        "newPiece": "Your new piece changed the ride! Where else could it go?",
+        "spinOuts": "You spun out {{count}} times and still finished! Which curve was trickiest?",
+        "oneSpin": "One wipeout, one comeback! What would you change about that curve?",
+        "boost": "That boost made Boost ZOOM! What happens if you move it somewhere else?",
+        "clean": "A clean ride the whole way! What would make your track even more exciting?",
+        "proud": "What part of your track are you most proud of?"
+      },
+      "name": {
+        "title": "Name your track!",
+        "keep": "That's it!",
+        "later": "Later"
+      },
+      "rideOnly": {
+        "notRideable": "This track can't be ridden right now. Try another one!"
+      }
+    },
     "boostPath": {
       "title": "Boost的路线规划",
       "level1": "到达太阳能充电器",
@@ -1532,6 +1708,7 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "ride": "Ride"
   }
 }

--- a/src/pages/ChallengePlayer.tsx
+++ b/src/pages/ChallengePlayer.tsx
@@ -4,10 +4,12 @@ import { useTranslation } from "react-i18next";
 import { Sparkles } from "lucide-react";
 import { useApi } from "../services/api";
 import DataDashSortDiscoverGame from "../components/games/DataDashSortDiscoverGame";
+import TrackMakerGame from "../components/games/TrackMakerGame";
 
-// Phase 0 — play a saved (group-shared) Data Dash challenge. Fetches the single
-// creation (group-scoped + visibility enforced server-side) and renders the
-// game with config.challenge. Playing a peer challenge is for fun, so the
+// Phase 0 — play a saved (group-shared) creation. Fetches the single creation
+// (group-scoped + visibility enforced server-side) and renders the matching
+// game for its type: Data Dash challenges get config.challenge, race tracks
+// get config.raceTrack (ride-only). Playing a peer creation is for fun, so the
 // completion result is not recorded as module progress — Finish and the
 // "View My Gallery" affordance both return the player to /student/gallery,
 // where they launched from (see #680).
@@ -16,15 +18,22 @@ export default function ChallengePlayer() {
   const api = useApi();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [content, setContent] = useState<unknown | null>(null);
+  const [creation, setCreation] = useState<{
+    type: string;
+    content: unknown;
+  } | null>(null);
   const [state, setState] = useState<"loading" | "error" | "ready">("loading");
 
   useEffect(() => {
     if (!id) return;
     api
       .get(`/creations/${id}`)
-      .then((res: { content?: unknown } | null) => {
-        setContent(res?.content ?? null);
+      .then((res: { type?: string; content?: unknown } | null) => {
+        setCreation(
+          res?.content !== undefined && res?.content !== null
+            ? { type: res.type ?? "", content: res.content }
+            : null,
+        );
         setState("ready");
       })
       .catch(() => setState("error"));
@@ -33,24 +42,40 @@ export default function ChallengePlayer() {
   const goToGallery = () => navigate("/student/gallery");
 
   if (state === "loading") {
-    return <div className="p-6 text-center text-gray-500">{t("challengePlayer.loading")}</div>;
+    return (
+      <div className="p-6 text-center text-gray-500">
+        {t("challengePlayer.loading")}
+      </div>
+    );
   }
-  if (state === "error" || !content) {
+  if (state === "error" || !creation) {
     return (
       <div className="p-6 text-center text-gray-600">
         {t("challengePlayer.notFound")}
       </div>
     );
   }
+  const secondaryAction = {
+    label: t("challengePlayer.viewMyGallery", {
+      defaultValue: "View My Gallery",
+    }),
+    icon: <Sparkles className="w-4 h-4 mr-1" />,
+    onClick: goToGallery,
+  };
+  if (creation.type === "race_track") {
+    return (
+      <TrackMakerGame
+        config={{ raceTrack: creation.content }}
+        onComplete={goToGallery}
+        secondaryAction={secondaryAction}
+      />
+    );
+  }
   return (
     <DataDashSortDiscoverGame
-      config={{ challenge: content }}
+      config={{ challenge: creation.content }}
       onComplete={goToGallery}
-      secondaryAction={{
-        label: t("challengePlayer.viewMyGallery", { defaultValue: "View My Gallery" }),
-        icon: <Sparkles className="w-4 h-4 mr-1" />,
-        onClick: goToGallery,
-      }}
+      secondaryAction={secondaryAction}
     />
   );
 }

--- a/src/pages/Modules.tsx
+++ b/src/pages/Modules.tsx
@@ -12,11 +12,26 @@ import { AlertCircle } from "lucide-react";
 import { ActivityThumb } from "@/components/shared/ActivityThumb";
 import { ImageKey } from "@/theme/activityIllustrations";
 import { translateContentName } from "@/utils/localizedContent";
-import { getStudentArchetype, canAccessModule, isSet2ModuleSlug, checkSet2Locked } from "@/lib/moduleAccess";
 import {
-  STEM_SET_1_IDS, STEM_SET_2_IDS, STEM_SET_1_STRANDS, STEM_SET_2_STRANDS,
-  HIDDEN_MODULE_SLUGS, countCompletedInSet,
-  type StemSet1GameId, type StemSet2GameId,
+  getStudentArchetype,
+  canAccessModule,
+  isSet2ModuleSlug,
+  isSet3ModuleSlug,
+  checkSet2Locked,
+  checkSet3Locked,
+} from "@/lib/moduleAccess";
+import {
+  STEM_SET_1_IDS,
+  STEM_SET_2_IDS,
+  STEM_SET_3_IDS,
+  STEM_SET_1_STRANDS,
+  STEM_SET_2_STRANDS,
+  STEM_SET_3_STRANDS,
+  HIDDEN_MODULE_SLUGS,
+  countCompletedInSet,
+  type StemSet1GameId,
+  type StemSet2GameId,
+  type StemSet3GameId,
 } from "@/constants/stemSets";
 import { useToast } from "@/hooks/use-toast";
 
@@ -31,6 +46,7 @@ const MODULE_THUMBNAILS: Record<string, ImageKey> = {
   "k2-stem-sky-shield": "type_game",
   "k2-stem-fast-lane": "type_game",
   "k2-stem-qualify-tune-race": "type_game",
+  "k2-stem-track-maker": "type_game",
   "stem-1-intro": "type_game",
 };
 
@@ -47,6 +63,8 @@ const MODULE_ORDER: Record<string, number> = {
   "k2-stem-sky-shield": 12,
   "k2-stem-fast-lane": 13,
   "k2-stem-qualify-tune-race": 14,
+  // Set 3
+  "k2-stem-track-maker": 20,
   // Legacy / hidden
   "k2-stem-sequencing": 90,
   // Specialization modules come after public content
@@ -69,6 +87,10 @@ const SLUG_TO_SET2_ID: Record<string, StemSet2GameId> = {
   "k2-stem-qualify-tune-race": "qualify-tune-race",
 };
 
+const SLUG_TO_SET3_ID: Record<string, StemSet3GameId> = {
+  "k2-stem-track-maker": "track-maker",
+};
+
 const STRAND_COLORS: Record<string, string> = {
   AI: "bg-blue-100 text-blue-800",
   Biotech: "bg-green-100 text-green-800",
@@ -85,8 +107,10 @@ export default function Modules() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [set2Locked, setSet2Locked] = useState(true);
+  const [set3Locked, setSet3Locked] = useState(true);
   const [set1Done, setSet1Done] = useState(0);
   const [set2Done, setSet2Done] = useState(0);
+  const [set3Done, setSet3Done] = useState(0);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -105,11 +129,15 @@ export default function Modules() {
 
         const locked = checkSet2Locked(completedIds);
         setSet2Locked(locked);
+        setSet3Locked(checkSet3Locked(completedIds));
         setSet1Done(countCompletedInSet(completedIds, STEM_SET_1_IDS));
         setSet2Done(countCompletedInSet(completedIds, STEM_SET_2_IDS));
+        setSet3Done(countCompletedInSet(completedIds, STEM_SET_3_IDS));
 
-        const visible = (data as any[]).filter((m: any) =>
-          canAccessModule({ slug: m.slug, archetype }) && !HIDDEN_MODULE_SLUGS.has(m.slug),
+        const visible = (data as any[]).filter(
+          (m: any) =>
+            canAccessModule({ slug: m.slug, archetype }) &&
+            !HIDDEN_MODULE_SLUGS.has(m.slug),
         );
 
         visible.sort(
@@ -129,14 +157,31 @@ export default function Modules() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const set1Modules = modules.filter((m) => !isSet2ModuleSlug(m.slug));
+  const set1Modules = modules.filter(
+    (m) => !isSet2ModuleSlug(m.slug) && !isSet3ModuleSlug(m.slug),
+  );
   const set2Modules = modules.filter((m) => isSet2ModuleSlug(m.slug));
+  const set3Modules = modules.filter((m) => isSet3ModuleSlug(m.slug));
 
   const handleLockedClick = () => {
     toast({
-      title: t("modules.set2LockedToastTitle", { defaultValue: "Set 2 is Locked" }),
+      title: t("modules.set2LockedToastTitle", {
+        defaultValue: "Set 2 is Locked",
+      }),
       description: t("modules.set2LockedMessage", {
-        defaultValue: "Complete Set 1 STEM Games to unlock the next challenge set.",
+        defaultValue:
+          "Complete Set 1 STEM Games to unlock the next challenge set.",
+      }),
+    });
+  };
+
+  const handleSet3LockedClick = () => {
+    toast({
+      title: t("modules.set3LockedToastTitle", {
+        defaultValue: "Set 3 is Locked",
+      }),
+      description: t("modules.set3LockedMessage", {
+        defaultValue: "Complete Set 2 STEM Games to unlock the mastery set.",
       }),
     });
   };
@@ -161,14 +206,28 @@ export default function Modules() {
             label={t("modules.set2Label", { defaultValue: "Set 2" })}
             done={set2Done}
             total={STEM_SET_2_IDS.length}
-            status={set2Locked ? "locked" : set2Done >= STEM_SET_2_IDS.length ? "complete" : "active"}
+            status={
+              set2Locked
+                ? "locked"
+                : set2Done >= STEM_SET_2_IDS.length
+                  ? "complete"
+                  : "active"
+            }
           />
           <div className="w-8 h-0.5 bg-slate-200" />
           <SetStep
             label={t("modules.set3Label", { defaultValue: "Set 3" })}
-            done={0}
-            total={5}
-            status="coming"
+            done={set3Done}
+            total={STEM_SET_3_IDS.length}
+            status={
+              set3Modules.length === 0
+                ? "coming"
+                : set3Locked
+                  ? "locked"
+                  : set3Done >= STEM_SET_3_IDS.length
+                    ? "complete"
+                    : "active"
+            }
           />
         </div>
       )}
@@ -197,8 +256,18 @@ export default function Modules() {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {set1Modules.map((m) => {
                   const set1Id = SLUG_TO_SET1_ID[m.slug];
-                  const strand = set1Id ? STEM_SET_1_STRANDS[set1Id] : undefined;
-                  return <ModuleCard key={m.id} module={m} navigate={navigate} t={t} strand={strand} />;
+                  const strand = set1Id
+                    ? STEM_SET_1_STRANDS[set1Id]
+                    : undefined;
+                  return (
+                    <ModuleCard
+                      key={m.id}
+                      module={m}
+                      navigate={navigate}
+                      t={t}
+                      strand={strand}
+                    />
+                  );
                 })}
               </div>
             </>
@@ -223,7 +292,8 @@ export default function Modules() {
               {set2Locked && (
                 <p className="text-sm text-slate-500 -mt-2 mb-4">
                   {t("modules.set2LockedMessage", {
-                    defaultValue: "Complete Set 1 STEM Games to unlock the next challenge set.",
+                    defaultValue:
+                      "Complete Set 1 STEM Games to unlock the next challenge set.",
                   })}
                 </p>
               )}
@@ -231,7 +301,9 @@ export default function Modules() {
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {set2Modules.map((m) => {
                   const set2Id = SLUG_TO_SET2_ID[m.slug];
-                  const strand = set2Id ? STEM_SET_2_STRANDS[set2Id] : undefined;
+                  const strand = set2Id
+                    ? STEM_SET_2_STRANDS[set2Id]
+                    : undefined;
                   return (
                     <ModuleCard
                       key={m.id}
@@ -248,34 +320,85 @@ export default function Modules() {
             </>
           )}
 
-          {/* Set 3: Coming Soon */}
-          <div className="mt-8 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/50 p-6 text-center">
-            <div className="flex items-center justify-center gap-2 text-slate-400 mb-2">
-              <Lock className="h-5 w-5" />
-              <span className="text-lg font-bold">
-                {t("modules.set3ComingSoon", { defaultValue: "Set 3: Mastery — Coming Soon" })}
-              </span>
-            </div>
-            <p className="text-sm text-slate-400">
-              {t("modules.set3ComingSoonDesc", {
-                defaultValue: "New challenges are being built. Stay tuned!",
-              })}
-            </p>
-          </div>
-
-          {set1Modules.length === 0 && set2Modules.length === 0 && !error && (
-            <div className="text-center py-12 px-4 rounded-lg bg-gray-50 border-2 border-dashed border-gray-200">
-              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 text-blue-600 mb-4">
-                <BookOpen size={32} />
-              </div>
-              <h2 className="text-xl font-semibold text-gray-900 mb-2">
-                {t("modules.noModules")}
+          {/* Set 3 */}
+          {set3Modules.length > 0 ? (
+            <>
+              <h2 className="text-lg font-bold text-brightboost-navy flex items-center gap-2 mt-8">
+                {t("modules.set3Label", { defaultValue: "Set 3: Mastery" })}
+                {set3Locked && (
+                  <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 bg-slate-100 px-2 py-0.5 rounded-full">
+                    <Lock className="h-3 w-3" />
+                    {t("modules.locked", { defaultValue: "Locked" })}
+                  </span>
+                )}
+                {!set3Locked && set3Done >= STEM_SET_3_IDS.length && (
+                  <CheckCircle2 className="h-5 w-5 text-green-500" />
+                )}
               </h2>
-              <p className="text-gray-500 max-w-md mx-auto">
-                {t("modules.noModulesDesc")}
+
+              {set3Locked && (
+                <p className="text-sm text-slate-500 -mt-2 mb-4">
+                  {t("modules.set3LockedMessage", {
+                    defaultValue:
+                      "Complete Set 2 STEM Games to unlock the mastery set.",
+                  })}
+                </p>
+              )}
+
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {set3Modules.map((m) => {
+                  const set3Id = SLUG_TO_SET3_ID[m.slug];
+                  const strand = set3Id
+                    ? STEM_SET_3_STRANDS[set3Id]
+                    : undefined;
+                  return (
+                    <ModuleCard
+                      key={m.id}
+                      module={m}
+                      navigate={navigate}
+                      t={t}
+                      locked={set3Locked}
+                      strand={strand}
+                      onLockedClick={handleSet3LockedClick}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="mt-8 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/50 p-6 text-center">
+              <div className="flex items-center justify-center gap-2 text-slate-400 mb-2">
+                <Lock className="h-5 w-5" />
+                <span className="text-lg font-bold">
+                  {t("modules.set3ComingSoon", {
+                    defaultValue: "Set 3: Mastery — Coming Soon",
+                  })}
+                </span>
+              </div>
+              <p className="text-sm text-slate-400">
+                {t("modules.set3ComingSoonDesc", {
+                  defaultValue: "New challenges are being built. Stay tuned!",
+                })}
               </p>
             </div>
           )}
+
+          {set1Modules.length === 0 &&
+            set2Modules.length === 0 &&
+            set3Modules.length === 0 &&
+            !error && (
+              <div className="text-center py-12 px-4 rounded-lg bg-gray-50 border-2 border-dashed border-gray-200">
+                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 text-blue-600 mb-4">
+                  <BookOpen size={32} />
+                </div>
+                <h2 className="text-xl font-semibold text-gray-900 mb-2">
+                  {t("modules.noModules")}
+                </h2>
+                <p className="text-gray-500 max-w-md mx-auto">
+                  {t("modules.noModulesDesc")}
+                </p>
+              </div>
+            )}
         </>
       )}
     </div>
@@ -295,27 +418,37 @@ function SetStep({
   total: number;
   status: "complete" | "active" | "locked" | "coming";
 }) {
-  const ring = status === "complete"
-    ? "border-green-500 bg-green-50 text-green-700"
-    : status === "active"
-      ? "border-brightboost-blue bg-blue-50 text-brightboost-blue animate-pulse"
-      : "border-slate-200 bg-slate-50 text-slate-400";
+  const ring =
+    status === "complete"
+      ? "border-green-500 bg-green-50 text-green-700"
+      : status === "active"
+        ? "border-brightboost-blue bg-blue-50 text-brightboost-blue animate-pulse"
+        : "border-slate-200 bg-slate-50 text-slate-400";
 
-  const icon = status === "complete"
-    ? <CheckCircle2 className="h-5 w-5" />
-    : status === "active"
-      ? <span className="text-xs font-extrabold">{done}/{total}</span>
-      : status === "coming"
-        ? <Clock className="h-4 w-4" />
-        : <Lock className="h-4 w-4" />;
+  const icon =
+    status === "complete" ? (
+      <CheckCircle2 className="h-5 w-5" />
+    ) : status === "active" ? (
+      <span className="text-xs font-extrabold">
+        {done}/{total}
+      </span>
+    ) : status === "coming" ? (
+      <Clock className="h-4 w-4" />
+    ) : (
+      <Lock className="h-4 w-4" />
+    );
 
   return (
     <div className="flex items-center gap-2">
-      <div className={`w-10 h-10 rounded-full border-2 flex items-center justify-center ${ring}`}>
+      <div
+        className={`w-10 h-10 rounded-full border-2 flex items-center justify-center ${ring}`}
+      >
         {icon}
       </div>
       <div className="text-xs">
-        <p className={`font-bold ${status === "locked" || status === "coming" ? "text-slate-400" : "text-slate-700"}`}>
+        <p
+          className={`font-bold ${status === "locked" || status === "coming" ? "text-slate-400" : "text-slate-700"}`}
+        >
           {label}
         </p>
         <p className="text-slate-400">
@@ -397,7 +530,10 @@ function ModuleCard({
           </Button>
         ) : (
           <Button
-            onClick={(e) => { e.stopPropagation(); navigate(`/student/modules/${m.slug}`); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/student/modules/${m.slug}`);
+            }}
             className="w-full sm:w-auto"
             aria-label={`${t("modules.startLearning")} ${translateContentName(m.title)}`}
           >

--- a/src/pages/__tests__/Modules.test.tsx
+++ b/src/pages/__tests__/Modules.test.tsx
@@ -1,9 +1,10 @@
 // src/pages/__tests__/Modules.test.tsx
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Modules from "../Modules";
 import { BrowserRouter } from "react-router-dom";
 import { api } from "../../services/api";
+import { HIDDEN_MODULE_SLUGS, STEM_SET_2_IDS } from "@/constants/stemSets";
 
 // Mock the API
 vi.mock("../../services/api", () => ({
@@ -41,6 +42,11 @@ vi.mock("@/components/ModulesSkeleton", () => ({
 describe("Modules Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    HIDDEN_MODULE_SLUGS.add("k2-stem-track-maker");
+  });
+
+  afterEach(() => {
+    HIDDEN_MODULE_SLUGS.add("k2-stem-track-maker");
   });
 
   it("shows loading skeleton initially", async () => {
@@ -131,5 +137,36 @@ describe("Modules Page", () => {
     expect(
       screen.getByText("Failed to load modules. Please try again later."),
     ).toBeDefined();
+  });
+
+  it("places Track Builder in unlocked Set 3 after the hidden release flag is removed", async () => {
+    HIDDEN_MODULE_SLUGS.delete("k2-stem-track-maker");
+    (api.getModules as any).mockResolvedValue([
+      {
+        id: "track-module",
+        title: "Boost Track Builder",
+        description: "Build and ride a track",
+        slug: "k2-stem-track-maker",
+        level: "K-2",
+      },
+    ]);
+    (api.getProgress as any).mockResolvedValue({
+      progress: STEM_SET_2_IDS.map((activityId) => ({
+        activityId,
+        status: "COMPLETED",
+      })),
+    });
+
+    render(
+      <BrowserRouter>
+        <Modules />
+      </BrowserRouter>,
+    );
+
+    expect(await screen.findByText("Boost Track Builder")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Start Learning Boost Track Builder"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Set 3: Mastery — Coming Soon")).toBeNull();
   });
 });


### PR DESCRIPTION
**Rebuilt on the current `main` and ready for final review.** This lands the first creation-first Set 3 game against #676 while keeping it hidden from students until the Set 3 release decision is made.

## What ships

- **Boost Track Builder:** children imagine, build, ride, revise, name, save, share, and reflect on a motorcycle track they created.
- **Safe persistence:** `race_track` is a closed creation type with strict server validation and a start-to-finish rideability check.
- **Safe sharing:** the group gallery receives only the projected track fields it needs for the thumbnail; classmates get a ride-only path.
- **Real Set 3 progression:** removing `k2-stem-track-maker` from `HIDDEN_MODULE_SLUGS` now places the game in Set 3 and locks it until Set 2 is complete.
- **No schema or migration change:** machines use the existing `Creation` model.
- **Localized UI:** English and Spanish content are included; Vietnamese and Chinese currently use the documented English fallback placeholders.

## Deterministic team test data

Both required seed trees now create the same shared fixture:

- Class code: `STARS1`
- Author: Nova ⭐
- Creation: **Star Sprint**
- Status: `SHARED`

After running the seed, log in as Comet 🚀 or Luna 🌙, open the student gallery, and choose **Ride**. The full creator studio remains intentionally gated; local reviewers can remove the hidden slug to test build → save → share.

## Verification

- Frontend typecheck: pass
- Backend typecheck: pass
- Lint: pass
- Production build: pass
- PR-scoped Prettier check: pass across all 27 changed files
- PR security scan: pass
- Focused Track Builder, creation-route, gallery, serializer, progression, and seed guards: **107 passed**
- Full local unit run: **704 passed / 19 skipped**; the only failure was the unchanged #702 W-10 process-tree harness, which cannot observe nested child processes in this container. GitHub's Ubuntu run is the authoritative result for that live harness.
- Seed files: syntax-valid and byte-identical; the exact Star Sprint payload passes the server validator.

## Release gate

The module remains in `HIDDEN_MODULE_SLUGS`. Merging this PR makes the implementation and test fixture available without exposing the game to students. Activation remains a separate product decision.

## Follow-ups

- Builder drafts in local storage are device-scoped rather than student-scoped.
- A fuller grade 3–5 content variant can follow the Set 2 closeout.
