### PR TITLE
feat(set3): Echo Avenue — live two-performer sound-and-motion studio, gated at slot 3 (#676)

### DIFF
--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -1071,6 +1071,114 @@ async function main() {
     console.log("Seeded Set 2 module:", s2.slug, "(story + game + quiz)");
   }
 
+  // ---------------------------------------------------------------------
+  // SET 3 — Mastery (slot 3: Echo Avenue, GATED from students via
+  // HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts — seeded + published
+  // so ungating is a one-line frontend change). See #676.
+  // ---------------------------------------------------------------------
+  const set3Modules = [
+    {
+      slug: "k2-stem-echo-avenue",
+      title: "Echo Avenue",
+      description: "Make a two-performer sound-and-motion duet! 🎙️🕺",
+      activityId: "echo-avenue",
+      gameKey: "echo_avenue",
+      strand: "AI",
+      story: {
+        title: "Story: The Quiet Street",
+        slides: [
+          { id: "ea-s1", text: { en: "Echo Avenue used to be the loudest street in town — every step, clap, and chime made the whole block dance. But lately it's gone quiet. The stage is empty!", es: "La Avenida del Eco era la calle más ruidosa de la ciudad: cada paso, palmada y campanada hacía bailar a toda la cuadra. ¡Pero últimamente está en silencio. El escenario está vacío!" }, icon: "🎙️" },
+          { id: "ea-s2", text: { en: "Two performers are waiting for a director — that's YOU. Every pad you tap makes a move AND a sound at the same time. Record a phrase, and it loops around and around.", es: "Dos artistas esperan a su director: ¡ese eres TÚ! Cada botón que tocas hace un movimiento Y un sonido a la vez. Graba una frase y se repetirá una y otra vez." }, icon: "🕺" },
+          { id: "ea-s3", text: { en: "There's no wrong beat on Echo Avenue. Layer your two performers, leave quiet spaces, let them answer each other — and share your duet when YOU decide it's ready!", es: "En la Avenida del Eco no hay ritmo equivocado. Combina a tus dos artistas, deja espacios de silencio, haz que se respondan — ¡y comparte tu dúo cuando TÚ decidas que está listo!" }, icon: "⭐" },
+        ],
+        questions: [
+          { id: "ea-q1", prompt: { en: "What happens when you tap a pad on Echo Avenue?", es: "¿Qué pasa cuando tocas un botón en la Avenida del Eco?" }, choices: [{ en: "A performer moves and sounds at the same time", es: "Un artista se mueve y suena a la vez" }, { en: "You lose a point", es: "Pierdes un punto" }, { en: "Nothing happens", es: "No pasa nada" }, { en: "The game ends", es: "El juego termina" }], answerIndex: 0 },
+        ],
+      },
+      quiz: [
+        { id: "eaz-q1", prompt: { en: "Your loop plays the same phrase again and again. What is that called?", es: "Tu bucle toca la misma frase una y otra vez. ¿Cómo se llama eso?" }, choices: [{ en: "A repeating pattern", es: "Un patrón que se repite" }, { en: "A mistake", es: "Un error" }, { en: "A race", es: "Una carrera" }, { en: "A test", es: "una prueba" }], answerIndex: 0 },
+        { id: "eaz-q2", prompt: { en: "One performer plays, then the other answers in the quiet spaces. What did you make?", es: "Un artista toca y el otro responde en los espacios de silencio. ¿Qué creaste?" }, choices: [{ en: "Call-and-response", es: "Llamada y respuesta" }, { en: "A traffic jam", es: "Un atasco" }, { en: "A countdown", es: "Una cuenta regresiva" }, { en: "An echo error", es: "Un error de eco" }], answerIndex: 0 },
+        { id: "eaz-q3", prompt: { en: "When is your duet finished?", es: "¿Cuándo está terminado tu dúo?" }, choices: [{ en: "When YOU decide it's ready", es: "Cuando TÚ decides que está listo" }, { en: "When the timer runs out", es: "Cuando se acaba el tiempo" }, { en: "When you get all the beats right", es: "Cuando aciertas todos los ritmos" }, { en: "When the game says so", es: "Cuando el juego lo dice" }], answerIndex: 0 },
+      ],
+    },
+  ];
+
+  for (const s3 of set3Modules) {
+    const mod = await prisma.module.upsert({
+      where: { slug: s3.slug },
+      update: { title: s3.title, description: s3.description, level: "K-2", published: true },
+      create: { slug: s3.slug, title: s3.title, description: s3.description, level: "K-2", published: true },
+    });
+
+    // Get or create unit — use first unit of this module (not by title, which may have changed)
+    let s3Unit = await prisma.unit.findFirst({ where: { moduleId: mod.id }, orderBy: { order: "asc" } });
+    if (!s3Unit) {
+      s3Unit = await prisma.unit.create({ data: { title: "Unit 1", order: 1, Module: { connect: { id: mod.id } }, teacher: { connect: { id: teacher.id } } } });
+    }
+
+    // Get or create lesson — use first lesson of this unit
+    let s3Lesson = await prisma.lesson.findFirst({ where: { unitId: s3Unit.id }, orderBy: { order: "asc" } });
+    if (!s3Lesson) {
+      s3Lesson = await prisma.lesson.create({ data: { title: s3.title, order: 1, Unit: { connect: { id: s3Unit.id } } } });
+    }
+
+    // Clean up duplicate lessons (from previous seed runs with different titles)
+    const allS3Lessons = await prisma.lesson.findMany({ where: { unitId: s3Unit.id } });
+    for (const dup of allS3Lessons) {
+      if (dup.id !== s3Lesson.id) {
+        await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
+        await prisma.lesson.delete({ where: { id: dup.id } }).catch(() => {});
+      }
+    }
+
+    // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
+    const existingS3Acts = await prisma.activity.findMany({ where: { lessonId: s3Lesson.id }, orderBy: { order: "asc" } });
+    for (const act of existingS3Acts) {
+      if (act.order > 3) {
+        await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
+      }
+    }
+
+    // Activity 1: Story (INFO)
+    const s3StoryContent = JSON.stringify({
+      type: "story_quiz",
+      slides: s3.story.slides,
+      questions: s3.story.questions,
+      review: { keyIdea: { en: s3.description }, vocab: [s3.strand.toLowerCase()] },
+    });
+
+    let s3StoryAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, kind: INFO, order: 1 } });
+    if (s3StoryAct) {
+      await prisma.activity.update({ where: { id: s3StoryAct.id }, data: { title: s3.story.title, content: s3StoryContent } });
+    } else {
+      await prisma.activity.create({ data: { title: s3.story.title, kind: INFO, order: 1, content: s3StoryContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    // Activity 2: Game (INTERACT)
+    const s3GameContent = JSON.stringify({ gameKey: s3.gameKey });
+    let s3GameAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, kind: INTERACT, order: 2 } });
+    if (s3GameAct) {
+      await prisma.activity.update({ where: { id: s3GameAct.id }, data: { id: s3.activityId, title: `Game: ${s3.title}`, content: s3GameContent } });
+    } else {
+      await prisma.activity.create({ data: { id: s3.activityId, title: `Game: ${s3.title}`, kind: INTERACT, order: 2, content: s3GameContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    // Activity 3: Quiz (INFO with quiz questions)
+    const s3QuizContent = JSON.stringify({
+      type: "story_quiz",
+      slides: [],
+      questions: s3.quiz ?? [],
+    });
+    let s3QuizAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, order: 3 } });
+    if (s3QuizAct) {
+      await prisma.activity.update({ where: { id: s3QuizAct.id }, data: { title: `Quiz: ${s3.title}`, kind: INFO, content: s3QuizContent } });
+    } else {
+      await prisma.activity.create({ data: { title: `Quiz: ${s3.title}`, kind: INFO, order: 3, content: s3QuizContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    console.log("Seeded Set 3 module:", s3.slug, "(story + game + quiz — gated)");
+  }
+
   console.log("Seeding units...");
   let unit = await prisma.unit.findFirst({
     where: { moduleId: module.id, title: "Unit 1: The Basics" },

--- a/backend/src/routes/creations.test.ts
+++ b/backend/src/routes/creations.test.ts
@@ -66,6 +66,20 @@ const dbCreation = {
   author: { name: "Ada Lovelace" },
 };
 
+// A minimal valid Echo Avenue duet (see soundDuet.test.ts).
+const validDuet = {
+  v: 1,
+  name: "Midnight Parade",
+  band: "k2",
+  pulses: 4,
+  layers: {
+    lead: [{ t: 0, soundId: "step" }],
+    partner: [{ t: 4, soundId: "clap" }],
+  },
+  spots: [],
+  coverPose: "sideBySide",
+};
+
 describe("Creations routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -167,6 +181,46 @@ describe("Creations routes", () => {
           })
         )
     })
+
+    // ── sound_duet (Set 3 · Echo Avenue) ──
+
+    it("lets an enrolled kid save a valid sound_duet (201, token title derived)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+      prismaMock.creation.create.mockResolvedValue({
+        ...dbCreation,
+        type: "sound_duet",
+        title: "Midnight Parade",
+        content: validDuet,
+      });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({ courseId: COURSE, type: "sound_duet", content: validDuet });
+
+      expect(res.status).toBe(201);
+      expect(prismaMock.creation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ title: "Midnight Parade" }),
+        }),
+      );
+    });
+
+    it("rejects sound_duet content with unknown keys (422 — strict parse, #668 stance)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "sound_duet",
+          content: { ...validDuet, smuggled: "extra key" },
+        });
+
+      expect(res.status).toBe(422);
+      expect(prismaMock.creation.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("PATCH /api/creations/:id", () => {

--- a/backend/src/routes/creations.ts
+++ b/backend/src/routes/creations.ts
@@ -278,7 +278,13 @@ router.get(
       orderBy: { updatedAt: "desc" },
     });
 
-    return res.json(creations.map(toDTO));
+    // sound_duet cards render a cover pose, which needs the (small, capped)
+    // content; other types keep the lean content-free DTO.
+    return res.json(
+      creations.map((c) =>
+        c.type === "sound_duet" ? { ...toDTO(c), content: c.content } : toDTO(c),
+      ),
+    );
   },
 );
 

--- a/backend/src/services/creationContent.ts
+++ b/backend/src/services/creationContent.ts
@@ -12,8 +12,9 @@
 // correct answer) — see the marked extension point below.
 
 import { validateDataDashChallenge } from "./dataDashChallenge";
+import { deriveSoundDuetTitle, validateSoundDuet } from "./soundDuet";
 
-export const CREATION_TYPES = ["data_dash_challenge"] as const;
+export const CREATION_TYPES = ["data_dash_challenge", "sound_duet"] as const;
 export type CreationType = (typeof CREATION_TYPES)[number];
 
 const dataDashSortRuleLabels: Record<string, string> = {
@@ -60,6 +61,12 @@ export function validateCreationContent(
       // moderate — only to verify the challenge is actually winnable.
       return validateDataDashChallenge(content);
 
+    case "sound_duet":
+      // Strict-parsed (zod .strict() at every level — unknown keys rejected,
+      // deliberately diverging from Data Dash per #668) + validity guard
+      // (≥1 event, band-grid bounds, event + payload caps).
+      return validateSoundDuet(content);
+
     default:
       // Exhaustiveness guard — a new CreationType must declare its rules here.
       return { ok: false, error: `unsupported creation type: ${type}` };
@@ -83,7 +90,11 @@ export function deriveCreationTitle(
       return label ? `Sort by ${label}` : null;
     }
 
-    default: 
+    case "sound_duet":
+      // The kid's token-built name (approved pools only; schema-bounded).
+      return deriveSoundDuetTitle(content);
+
+    default:
       return null;
   }
 }

--- a/backend/src/services/soundDuet.test.ts
+++ b/backend/src/services/soundDuet.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_DUET_PAYLOAD_CHARS,
+  deriveSoundDuetTitle,
+  exceedsDuetPayloadCap,
+  validateSoundDuet,
+} from "./soundDuet";
+
+const valid = () => ({
+  v: 1,
+  name: "Midnight Parade",
+  band: "k2",
+  pulses: 4,
+  layers: {
+    lead: [
+      { t: 0, soundId: "step" },
+      { t: 4, soundId: "chime" },
+    ],
+    partner: [{ t: 2, soundId: "clap" }],
+  },
+  spots: ["tunnel"],
+});
+
+describe("validateSoundDuet — schema", () => {
+  it("accepts a minimal valid duet", () => {
+    expect(validateSoundDuet(valid())).toEqual({ ok: true });
+  });
+
+  it("rejects non-objects and bad versions", () => {
+    expect(validateSoundDuet("nope").ok).toBe(false);
+    expect(validateSoundDuet(null).ok).toBe(false);
+    expect(validateSoundDuet({ ...valid(), v: 2 }).ok).toBe(false);
+  });
+
+  it("rejects missing/empty/oversized names", () => {
+    expect(validateSoundDuet({ ...valid(), name: "" }).ok).toBe(false);
+    expect(validateSoundDuet({ ...valid(), name: "x".repeat(25) }).ok).toBe(false);
+  });
+
+  // ── The #668 divergence, tested explicitly at EVERY level ──
+
+  it("STRICT: rejects unknown keys at the root", () => {
+    const r = validateSoundDuet({ ...valid(), smuggled: "extra" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("smuggled");
+  });
+
+  it("STRICT: rejects unknown keys inside layers", () => {
+    const c = valid();
+    (c.layers as Record<string, unknown>).chorus = [];
+    expect(validateSoundDuet(c).ok).toBe(false);
+  });
+
+  it("STRICT: rejects unknown keys inside an event", () => {
+    const c = valid();
+    c.layers.lead[0] = { ...c.layers.lead[0], velocity: 127 } as never;
+    expect(validateSoundDuet(c).ok).toBe(false);
+  });
+
+  it("rejects sound ids outside the allowlist", () => {
+    const c = valid();
+    c.layers.lead[0] = { t: 0, soundId: "airhorn" as never };
+    expect(validateSoundDuet(c).ok).toBe(false);
+  });
+});
+
+describe("validateSoundDuet — validity guard", () => {
+  it("rejects a duet with zero recorded events", () => {
+    const r = validateSoundDuet({ ...valid(), layers: { lead: [], partner: [] } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("at least one");
+  });
+
+  it("rejects events outside the band's cycle grid (k2 slots are 0..7)", () => {
+    const c = valid();
+    c.layers.partner = [{ t: 9, soundId: "clap" }]; // legal for g35, not k2
+    const r = validateSoundDuet(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("outside the cycle grid");
+    // the same slot IS valid on the g35 grid
+    const g35 = { ...valid(), band: "g35", pulses: 8 };
+    g35.layers.partner = [{ t: 9, soundId: "clap" }];
+    expect(validateSoundDuet(g35)).toEqual({ ok: true });
+  });
+
+  it("rejects a band/pulses mismatch", () => {
+    expect(validateSoundDuet({ ...valid(), pulses: 8 }).ok).toBe(false);
+  });
+
+  it("rejects layers over the event cap (64)", () => {
+    const c = valid();
+    c.layers.lead = Array.from({ length: 65 }, () => ({ t: 0, soundId: "step" as const }));
+    expect(validateSoundDuet(c).ok).toBe(false);
+  });
+
+  it("rejects spot lists over the two-spot cap and unknown spots", () => {
+    expect(
+      validateSoundDuet({ ...valid(), spots: ["tunnel", "puddle", "tunnel"] }).ok,
+    ).toBe(false);
+    expect(validateSoundDuet({ ...valid(), spots: ["disco"] }).ok).toBe(false);
+  });
+});
+
+describe("payload-size cap (defense-in-depth)", () => {
+  it("a worst-case VALID duet stays under the cap", () => {
+    const maxed = {
+      ...valid(),
+      band: "g35",
+      pulses: 8,
+      name: "x".repeat(24),
+      layers: {
+        lead: Array.from({ length: 64 }, (_, i) => ({ t: i % 16, soundId: "twinkle" as const })),
+        partner: Array.from({ length: 64 }, (_, i) => ({ t: i % 16, soundId: "twinkle" as const })),
+      },
+      spots: ["tunnel", "puddle"],
+    };
+    expect(JSON.stringify(maxed).length).toBeLessThan(MAX_DUET_PAYLOAD_CHARS);
+    expect(validateSoundDuet(maxed)).toEqual({ ok: true });
+  });
+
+  it("rejects oversized and unserializable payloads before parsing", () => {
+    expect(exceedsDuetPayloadCap({ blob: "y".repeat(MAX_DUET_PAYLOAD_CHARS + 1) })).toBe(true);
+    const oversized = validateSoundDuet({ blob: "y".repeat(MAX_DUET_PAYLOAD_CHARS + 1) });
+    expect(oversized.ok).toBe(false);
+    if (!oversized.ok) expect(oversized.error).toContain("too large");
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(exceedsDuetPayloadCap(cyclic)).toBe(true);
+  });
+});
+
+describe("deriveSoundDuetTitle", () => {
+  it("returns the token-built name, trimmed; null when absent", () => {
+    expect(deriveSoundDuetTitle({ name: " Sunny Echo " })).toBe("Sunny Echo");
+    expect(deriveSoundDuetTitle({})).toBeNull();
+    expect(deriveSoundDuetTitle(null)).toBeNull();
+  });
+});

--- a/backend/src/services/soundDuet.test.ts
+++ b/backend/src/services/soundDuet.test.ts
@@ -19,6 +19,7 @@ const valid = () => ({
     partner: [{ t: 2, soundId: "clap" }],
   },
   spots: ["tunnel"],
+  coverPose: "sideBySide",
 });
 
 describe("validateSoundDuet — schema", () => {
@@ -93,6 +94,11 @@ describe("validateSoundDuet — validity guard", () => {
     expect(validateSoundDuet(c).ok).toBe(false);
   });
 
+  it("rejects an unknown cover pose", () => {
+    expect(validateSoundDuet({ ...valid(), coverPose: "tPose" }).ok).toBe(false);
+    expect(validateSoundDuet({ ...valid(), coverPose: undefined }).ok).toBe(false);
+  });
+
   it("rejects spot lists over the two-spot cap and unknown spots", () => {
     expect(
       validateSoundDuet({ ...valid(), spots: ["tunnel", "puddle", "tunnel"] }).ok,
@@ -113,6 +119,7 @@ describe("payload-size cap (defense-in-depth)", () => {
         partner: Array.from({ length: 64 }, (_, i) => ({ t: i % 16, soundId: "twinkle" as const })),
       },
       spots: ["tunnel", "puddle"],
+      coverPose: "backToBack",
     };
     expect(JSON.stringify(maxed).length).toBeLessThan(MAX_DUET_PAYLOAD_CHARS);
     expect(validateSoundDuet(maxed)).toEqual({ ok: true });

--- a/backend/src/services/soundDuet.ts
+++ b/backend/src/services/soundDuet.ts
@@ -1,0 +1,107 @@
+/**
+ * sound_duet content validator — the security boundary for Echo Avenue
+ * creations (Set 3 · slot 3).
+ *
+ * STRICT-PARSED FROM DAY ONE: every object level uses zod `.strict()`, so
+ * unknown/extra JSON keys are REJECTED, not stored — the same deliberate
+ * divergence from the key-tolerant Data Dash validator (#668) that
+ * raceTrack.ts made. Do not replicate that gap in new creation types.
+ *
+ * Validity guard: ≥1 recorded event, all events on the declared band's grid,
+ * sound ids in the closed allowlist, per-layer event caps, and a
+ * payload-size cap as defense-in-depth.
+ *
+ * Mirror note: SOUND_IDS and the band grid sizes duplicate
+ * src/components/games/echoAvenue/echoAvenueModel.ts across the boundary
+ * (the Data Dash card-pool pattern) — keep them in sync.
+ */
+import { z } from "zod";
+import type { ContentValidation } from "./creationContent";
+
+const SOUND_IDS = [
+  "step",
+  "stomp",
+  "clap",
+  "tap",
+  "chime",
+  "twinkle",
+  "whoosh",
+  "breeze",
+] as const;
+
+const MAX_EVENTS_PER_LAYER = 64;
+export const MAX_DUET_PAYLOAD_CHARS = 8192;
+
+// k2 = 4 pulses × 2 subdivisions = slots 0..7; g35 = 8 × 2 = 0..15
+const GRID_SLOTS: Record<"k2" | "g35", number> = { k2: 8, g35: 16 };
+const BAND_PULSES: Record<"k2" | "g35", number> = { k2: 4, g35: 8 };
+
+const eventSchema = z
+  .object({
+    t: z.number().int().min(0).max(15),
+    soundId: z.enum(SOUND_IDS),
+  })
+  .strict();
+
+const soundDuetSchema = z
+  .object({
+    v: z.literal(1),
+    name: z.string().min(1).max(24),
+    band: z.enum(["k2", "g35"]),
+    pulses: z.union([z.literal(4), z.literal(8)]),
+    layers: z
+      .object({
+        lead: z.array(eventSchema).max(MAX_EVENTS_PER_LAYER),
+        partner: z.array(eventSchema).max(MAX_EVENTS_PER_LAYER),
+      })
+      .strict(),
+    spots: z.array(z.enum(["tunnel", "puddle"])).max(2),
+  })
+  .strict();
+
+/** Defense-in-depth: the strict schema already bounds every field, but a cap
+ *  on serialized size guards against anything the schema math missed. */
+export function exceedsDuetPayloadCap(content: unknown): boolean {
+  try {
+    return JSON.stringify(content).length > MAX_DUET_PAYLOAD_CHARS;
+  } catch {
+    return true; // unserializable (cycles) → reject
+  }
+}
+
+export function validateSoundDuet(content: unknown): ContentValidation {
+  if (exceedsDuetPayloadCap(content)) {
+    return { ok: false, error: "duet payload too large" };
+  }
+  const parsed = soundDuetSchema.safeParse(content);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue.path.join(".") || "content";
+    return { ok: false, error: `${path}: ${issue.message}` };
+  }
+  const duet = parsed.data;
+
+  if (duet.pulses !== BAND_PULSES[duet.band]) {
+    return { ok: false, error: "pulses do not match the band's cycle" };
+  }
+  const slots = GRID_SLOTS[duet.band];
+  const events = [...duet.layers.lead, ...duet.layers.partner];
+  if (events.length === 0) {
+    return { ok: false, error: "duet needs at least one recorded event" };
+  }
+  for (const ev of events) {
+    if (ev.t >= slots) {
+      return { ok: false, error: "event outside the cycle grid" };
+    }
+  }
+  return { ok: true };
+}
+
+/** Server-authoritative title: the kid's token-built name (schema-bounded;
+ *  tokens come from approved pools client-side — no free text reaches here
+ *  that the 24-char schema cap doesn't already bound). */
+export function deriveSoundDuetTitle(content: unknown): string | null {
+  if (typeof content !== "object" || content === null) return null;
+  const name = (content as { name?: unknown }).name;
+  return typeof name === "string" && name.trim() ? name.trim() : null;
+}

--- a/backend/src/services/soundDuet.ts
+++ b/backend/src/services/soundDuet.ts
@@ -56,6 +56,7 @@ const soundDuetSchema = z
       })
       .strict(),
     spots: z.array(z.enum(["tunnel", "puddle"])).max(2),
+    coverPose: z.enum(["sideBySide", "highFive", "backToBack"]),
   })
   .strict();
 

--- a/docs/games/echo-avenue-design.md
+++ b/docs/games/echo-avenue-design.md
@@ -1,132 +1,173 @@
 # Echo Avenue — live two-performer sound-and-motion studio (design doc)
 
-> Status: **approved design, build in progress.** Externally designed, founder-reviewed; this file is
-> the repo transcription of that design with the founder-review rulings applied. Lands against #676
-> (Set 3 "Mastery"), slot **`set3-game-3`**. Bar: `docs/design-principles.md`.
-> Provenance: inspired by classic side-scrolling two-player cooperation patterns (see the
-> transformation table, §2). All characters, sounds, names, and art are original.
+> Status: **source-reconciled** — this file now carries the externally authored, founder-reviewed
+> design (reconciled against the original commission document on 2026-07-11), with the founder
+> rulings and hardware-test additions kept as the clearly-marked delta layer (§11). Where the earlier
+> repo transcription had drifted from the source, the source won (K–2 opening pads, Watch-the-Take
+> actions, Reflect wording, cover pose at share) — and the code was aligned in the same commit.
+> Lands against #676 (Set 3 "Mastery"), slot **`set3-game-3`**. Bar: `docs/design-principles.md`.
 
-## 1. Concept (one paragraph)
+## 1. Concept
 
-The child taps large action pads; each tap makes one of two original performers **move and sound at
-the same instant** — step, clap, turn, bounce, chime, whoosh. Taps record into a repeating pulse
-loop: the Lead's take loops while the child overdubs the Partner, creating call-and-response,
-overlaps, and rests. Replay ("Watch the Take"), revise a layer, name it from structured tokens,
-share the audiovisual duet to the group gallery. **No scores, stars, timers, verdicts, win/lose, or
-correct rhythms anywhere.** Creation and feedback are simultaneous — a live instrument, not a batch
-simulation.
+**Echo Avenue** is a live sound-and-motion studio in a side-scrolling neighborhood. Tapping a large
+action pad makes one of two original Bright Boost performers move and sound at the same instant —
+step, clap, turn, bounce, chime, or whoosh. The Lead's take repeats while the child overdubs the
+Partner, creating call-and-response, overlaps, and pauses. The child replays, revises, names, and
+shares the resulting audiovisual duet. There are no enemies, scores, stars, timers, leaderboards,
+win/lose state, or correct rhythms; **the child decides when it is ready.**
 
-## 2. Transformation table (classic pattern → Echo Avenue)
+**Theme-free litmus line:** *Kids improvise and layer a live two-performer sound-and-motion loop,
+experience every choice immediately, and save the resulting performance for others to experience.*
 
-| Classic two-player side-scroller pattern | Echo Avenue |
-|---|---|
-| Two characters advance through a level | Two performers hold a stage; **the loop advances, not a level** |
-| Timing judged: mistimed input = failure | **No judgment**: every tap lands (quantized); a "miss" cannot exist |
-| Players compete or race | Lead and Partner **cooperate by construction** — the child is both |
-| Progress = distance/score | Progress = **a made thing** (the duet) that persists and is shared |
-| Sound reacts to gameplay | **Sound IS the gameplay**; motion and sound are one gesture |
-| Levels authored by designers | The **phrase is authored by the child**; two curated sound spots are the only stagecraft |
+## 2. Provenance (trimmed) + transformation table
 
-## 3. Spike verdict + the hardware-sensitivity hedge (REQUIRED reading)
+Inspired by **classic side-scrolling two-player cooperation patterns** — the kinetic interaction
+DNA, not any protected expression or combat premise. That general DNA transforms as follows:
 
-The Phase 1 latency spike (`/dev/echo-spike`, kept in-tree as the **audio regression harness** for
-the whole build) passed on founder hardware: **est. audible ≈13 ms** (+ ~30–45 ms touch input),
-**feels live**; loop ran with **0 underruns**, worst pump gap 34 ms.
+| Reference DNA | Echo Avenue translation |
+| --- | --- |
+| Continuous side-view action stage | A freely explorable, bidirectional performance canvas — no forced march, encounter gates, or stage clear |
+| Two-character cooperation | Lead + Partner overdub; distinct original silhouettes, not twins/siblings or red/blue counterparts |
+| Action buttons used alone or together | Movement-sound gestures that form phrases and harmonies |
+| Chained actions and positioning | Call-and-response, simultaneous beats, pauses, and movement patterns |
+| Responsive scenery | Curated sound spots such as a tunnel echo or puddle percussion |
+| Enemies, damage, stage clear, score, timer | None; the child chooses when the take is ready |
 
-**Hedge:** live-tap feel is **device-dependent** (Bluetooth audio, cheap Android tablets, and
-throttled browsers can add 100 ms+). Mitigations, in order: (a) **quantization is the shock
-absorber** — taps snap to the grid, so replay is always musical even when the live monitor lags;
-(b) the studio **pre-warms the AudioContext on the Start screen's first interaction** so the engine
-wake (~1 s) is never paid by the child's first musical tap; (c) a **budget-device spike is a
-required gate before any classroom pilot** (not before build). If budget hardware fails the feel
-test, the K–2 mode leans further into quantized playback-first interaction.
+**Original-IP boundary:** no third-party names, characters, story, moves, costumes, enemies,
+weapons, stages, audiovisual assets, logos, combat aesthetics, health-bar HUD, combo notation, or
+"for fans of" comparisons anywhere. All child-facing expression is original Bright Boost work.
+Final naming and logo require launch-market trademark, app-store, and domain clearance.
 
-## 4. The engine (specified to unit-test precision)
+## 3. Differentiation case
 
-- **Cycle model:** K–2 Guided = **4 pulses** @ 100 BPM (0.6 s/pulse), snap grid = **half-pulse**
-  (8 subdivisions/cycle); 3–5 = **8 pulses**, half-pulse snap (16 subdivisions). Grades 6–8 is a
-  **documented future mode** (finer grids, swing, longer cycles) — designed, not built in v1.
-- **Events:** `{ t: subdivision index (integer), soundId, performer: "lead" | "partner" }` — integer
-  grid positions, never float seconds, so persistence is exact and drift-impossible.
-- **Quantization as scaffold:** raw tap time → nearest subdivision, **wrapping at the cycle
-  boundary** (a tap a hair before the loop point lands on beat 1, not beat 9). Strength is
-  band-configurable. There is no unquantized mode in v1.
-- **Layers:** Lead and Partner record independently; re-record replaces one layer only; mute per
-  layer; layer independence is a tested invariant.
-- **Scheduling:** the spike's lookahead pattern (25 ms pump, ~120 ms horizon, all events scheduled
-  on the AudioContext clock). Pure scheduling math (`pulsesToSchedule`, `eventTime`) is
-  unit-tested against a mocked clock.
-- **Synth voices:** every sound is a WebAudio node graph — **zero audio assets, zero licensing
-  surface**. Eight sounds in four families (steps / hands / bells / air), loudness-normalized.
-  Every sound is paired with a **motion + pulse-light + trail signature** (see §7, silent mode).
-- **Sound spots:** exactly **two** curated stage spots (tunnel echo, puddle percussion) that color a
-  performer's sound while passing — deliberately capped at two to resist level-builder drift.
+| Activity | Creative medium | Core verb | STEM lens | Feedback relationship |
+| --- | --- | --- | --- | --- |
+| Boost Track Builder | Spatial piece construction | Build → ride | Speed, curves, cause/effect | Build, then test |
+| Machine game | Logical instruction construction | Program → watch | Sequencing, loops, debugging | Program, then execute |
+| Waterworks | Systems construction | Route → storm-test | Flow, protection, tradeoffs | Build, then simulate |
+| Data Dash authoring | Structured challenge authoring | Author → challenge | Categories and sorting | Compose, then peer-play |
+| **Echo Avenue** | **Live audiovisual performance** | **Improvise → layer → listen** | **Rhythm fractions, ratios, repetition, and acoustics** | **Creation and feedback happen simultaneously** |
 
-## 5. Bands, unlock ladder (fast pacing — a founder-review flag), targets
+The three-axis difference is explicit: the **medium** is live performance, the **verb** is
+improvise/overdub, and the **lens** is rhythmic subdivision, cycles, rests, meter, ratios,
+synchronization, and acoustics. There is no board, route, quiz, command list, editable note grid,
+move-card timeline, or "Run" button. Saved data may be structured, but the child's interface
+remains a live instrument: tap, hear, see, layer.
 
-| Band | Cycle | Palette at start | Ladder |
-|---|---|---|---|
-| 🐣 K–2 Guided | 4 pulses | **2 sounds** (step + chime), Lead only | First recorded phrase → **Partner + clap + whoosh** (announced). First layered phrase → **a sound spot + stomp + twinkle** (announced). **~6 sounds within the first session.** |
-| 🌱 3–5 | 8 pulses | all 8 sounds, both performers | Sound spots announced on first layered phrase |
-| 🚀 6–8 | future mode (documented, not built) | — | — |
+## 4. Spike verdict + the hardware-sensitivity hedge (delta layer)
 
-Unlocks respond to **making** (phrases recorded, layers made) — never to accuracy, and prompts are
-ignorable at zero cost (tested: ignoring every suggestion still unlocks everything by making).
-Soft targets are dismissible wonderings ("what would a rest sound like?"), never requirements.
+The Phase 1 latency spike (`/dev/echo-spike`, kept in-tree as the **audio regression harness**)
+passed on founder hardware: **est. audible ≈13 ms** (+ ~30–45 ms touch input), **feels live**;
+loop ran with **0 underruns**, worst pump gap 34 ms.
 
-## 6. Founder-review rulings (all applied)
+**Hedge:** live-tap feel is **device-dependent**. Mitigations, in order: (a) **quantization is the
+shock absorber** — taps snap to the grid, so replay is always musical even when the live monitor
+lags; (b) the studio **pre-warms the AudioContext on the Start screen's first interaction** so the
+engine wake is never paid by the child's first musical tap; (c) a **budget-device spike is a
+required gate before any classroom pilot** (not before build).
 
-1. **Solo overdub guaranteed** (one child is both performers); same-device duet later; **no online co-op**.
-2. **Peer remix deferred** past first release.
-3. **Two** curated sound spots, no more.
-4. **Completion wiring mirrors Boost Track Builder exactly** — standard `GameShell`/`completeActivity`,
-   flat participation-shaped `score/total`, **zero verdict UI in-game**. No new completion policy.
-5. **6–8 is documented future intent** (this table), not built.
-6. Gallery follows the existing creation-gallery pattern (group-scoped, read-only, **never
-   autoplay**, first-name-only).
-7. Slot **`set3-game-3`** (slot 2 stays reserved for the machine game in design).
-8. **K–2 unlock pacing opens the palette fast** (§5) — review flag honored.
-9. **Silent-mode is first-class** (§7) — review flag honored.
-10. **AudioContext pre-warms on the Start screen's first interaction** — the engine wake is never
-    paid by the child's first musical tap (tested in Phase 4).
-11. The **spike route stays** through the build as the audio regression harness.
+## 5. The engine (specified to unit-test precision)
 
-## 7. Silent mode is first-class (not fallback)
+- **Cycle model:** K–2 Guided = **4 pulses** @ 100 BPM, half-pulse snap (8 subdivisions);
+  3–5 = **8 pulses** (16 subdivisions). 6–8 is a documented future mode (§7).
+- **Events:** integer subdivision indices, never float seconds — persistence is exact, drift
+  impossible by construction.
+- **Quantization as scaffold:** "gentle automatic alignment keeps taps musical" — nearest
+  subdivision with cycle-boundary wrap; band-configurable strength; no unquantized mode in v1.
+- **Layers:** Lead/Partner record independently; re-record replaces one layer; per-layer volume;
+  layer independence is a tested invariant.
+- **Scheduling:** the spike's lookahead pattern (25 ms pump, ~120 ms horizon, AudioContext clock).
+- **Sounds:** *(founder constraint — supersedes the source's "curated sample" wording)* every sound
+  is **synthesized** from WebAudio primitives — zero audio assets, zero licensing surface — and
+  loudness-normalized. Eight sounds in four families (steps / hands / bells / air), each paired
+  with a distinct motion + pulse-light + trail signature (§8 silent mode).
+- **Sound spots:** exactly **two** (tunnel echo, puddle percussion) — environmental interaction
+  without level-builder drift.
 
-Muted classroom tablets are a primary environment. Every sound has a **distinct motion + pulse-light
-+ trail signature** (step = stride + ground ripple; clap = arm snap + white flash; chime = spin +
-rising sparkle; whoosh = glide + streak; …), and Watch-the-Take must be **watchable and expressive
-with audio off** — the duet's structure (call-and-response, overlap, rest) must read visually.
-This gets its own QA pass in Phase 6 and its own manual-QA step.
+## 6. Creative Learning Spiral (exact UI moments, per source)
 
-## 8. Persistence, safety, accessibility
+| Stage | Exact UI moment |
+| --- | --- |
+| **Imagine** | An icon-led prompt asks, "What will your duo sound like — bouncy, smooth, or surprising?" The child can preview **Together**, **Echo**, and **Space**. Pause/Mute and reduced-sensory controls appear **before Start**; then a gentle starter pulse prevents a blank canvas. |
+| **Create** | Large icon pads with motion previews. Every tap immediately moves the performer, sounds its voice, and (while recording) lands on the repeating pulse. The Partner arrives for a second live overdub while the first continues. Either layer can be re-recorded independently. |
+| **Play / experience** | **Watch the Take** hides the controls and performs the complete routine, with pulse lights and motion trails that make its structure readable without sound. The child can choose **Join In** to improvise over it or **Change a Layer** to loop back to Create. No result or grade appears. |
+| **Share** | The child chooses a structured title **and a cover pose**, then shares to the group. Private autosaves stay `IN_PROGRESS`; the ready-to-share action sets `COMPLETE` (sharing unfinished work would be a separate intentional `SHARED` choice). The gallery card offers **Watch / Listen** and never autoplays. |
+| **Reflect** | After the replay, the mascot asks exactly ONE context-aware wondering question ("Where did your performers answer each other?" / "Where did quiet make the next sound stand out?" / a first-used new sound). The only action is **Back to my studio**; reflection is never graded or published. |
 
-- **`Creation` type `"sound_duet"`** (zero schema changes): `{ v, name, band, pulses, layers:
-  { lead: Event[], partner: Event[] }, spots }` — strict-parsed with zod `.strict()` at every level
-  (#668 divergence cited in code), validity guard (≥1 event, events in bounds, sound ids in the
-  allowlist, per-layer event caps, payload-size cap).
-- **Kid-safety:** titles from approved localized token pools only (no free text); no mic, no camera,
-  no recording of the child — taps move the character, never capture the kid; no autoplay anywhere.
-- **Accessibility floor (testable subset):** one-pointer operation; keyboard operable with visible
-  focus; **≥64 px action pads**, ≥44 px everything else; `touch-action: manipulation`; no
-  multitouch/drag/hold; `prefers-reduced-motion` guard on all animation; master + per-layer volume;
-  loudness-normalized synthesis.
-- **i18n:** every string keyed in the shared locale files; EN + ES real; zh-CN on selected surfaces
-  (title tokens, mascot lines); vi placeholder. **Title-token pools are localized per language**
-  (curated per-locale word pools), not word-by-word translations.
+Naming and reflection are deliberately separate moments. The current title stays visible in the
+studio, saving updates the same creation (never copies), and leaving preserves the draft.
 
-## 9. Spiral mapping
+## 7. Banding and scaffolding
 
-| Stage | Moment |
-|---|---|
-| **Imagine** | Mood previews (Together / Echo / Space) on the title screen; pause/mute + reduced-sensory controls surfaced **before** Start; a starter pulse so the canvas is never blank |
-| **Create** | Tap pads — the performer moves and sounds NOW; record a Lead take, overdub the Partner |
-| **Play** | The loop **is** playback — creation and feedback are simultaneous; Watch-the-Take replays the duet full-stage |
-| **Share** | Token-based naming → save-in-place → group gallery (cover pose card, Watch/Listen, no autoplay) |
-| **Reflect** | Mascot asks ONE context-aware wondering question (call-and-response heard / rests used / a new sound first used) — a separate moment from naming |
+| | K–2 Guided | Grades 3–5 | Grades 6–8 Open *(future mode — documented, not built)* |
+| --- | --- | --- | --- |
+| **Supported start** | Four-pulse cycle, steady starter pulse, Lead on stage, two sounds, one tap input | Eight-pulse cycle, both performers, four sound families | Choice of cycle and meter; open two-performer studio |
+| **Create controls** | Two 64px+ icon pads; no dragging, swiping, required reading, or precision timing | Four pads per performer; re-record, mute, balance layers | Live effects, meter changes, syncopation, layered ratio experiments |
+| **Rhythm support** | Gentle automatic alignment; icon pulse ring; rests happen naturally | Optional subdivision overlay and call-and-response guides | Optional 2:3 / 3:4 views, swing, acoustic comparisons |
+| **Examples** | Animated icon grooves: Together, Echo, Space | Call-and-response, steady/varied, long/short phrases | Polyrhythm, syncopation, texture |
+| **Openness** | Constrained palette opens through exploration | Broad palette, free overdubbing | Full palette, adjustable sound properties |
 
-## 10. Measure creation, not completion
+**K–2 opening sequence (source-reconciled):** a soft four-pulse example establishes the floor. The
+child uses one input — **tap** — on icon-first **Step** and **Clap** pads. A first phrase brings in
+the **Partner** plus **Chime / Whoosh** with an animated announcement; a first layered phrase
+reveals the **tunnel-echo sound spot** plus **Stomp / Twinkle** (~6 sounds within the first
+session — the fast-pacing review flag). Optional prompts ("Can one friend answer the other?" /
+"What happens if one pulse stays quiet?") are ignorable at zero cost. **Unlocks respond to making,
+never accuracy.**
 
-Iteration signals only: takes recorded, layers replaced, return-to-edit, sound families explored,
-shares. **No scores, stars, timers, verdicts, streaks, or leaderboards.** The completion payload is
-participation-shaped (mirrors Track Builder) and drives XP only; nothing in-game displays it.
+**Accessibility floor:** every sound has a distinct motion, icon, and pulse-light pattern. Core
+creation works with one pointer or keyboard; no multitouch, dragging, holding, simultaneous
+presses, or rapid tapping. Accessible names, visible focus, high contrast, lossless pause/restart.
+Loudness normalized; master/layer volume and reduced-motion controls independent. Audio is curated
+and nonverbal — **no microphone, camera, voice, motion capture, or biometric data**; prompts move
+the **character**, never the child. All strings use localization keys (EN/ES authored from day one,
+selected zh-CN, repo-standard fallbacks).
+
+## 8. What the child walks away with
+
+A named, replayable **audiovisual duet**: two live-recorded performer layers; the child's timing,
+rests, overlaps, and call-and-response choices; curated movement/sound selections; a structured
+title, chosen mood, and **cover pose**. Timing makes artifacts meaningfully different — a sparse
+echo, a together-pattern, a dense tunnel texture. The gallery is read-only and group-scoped:
+approved-token titles only, first-name-only labels, **Watch / Listen**, never autoplay — never a
+full name, email, score, rank, play count, or public reaction count.
+
+**Silent mode is first-class:** the replay must be watchable and expressive with audio off (muted
+classroom tablets are a primary environment) — distinct motions, pulse lights, and trails carry the
+structure. This gets its own QA pass.
+
+## 9. What we measure
+
+Creation and iteration only: new drafts and saved duets; live takes recorded and layers replaced;
+return-to-edit after watching; distinct sound/movement families explored; explicit shares; partner
+remixes if that later feature is approved. Do **not** measure or display accuracy, "correct"
+rhythm, speed, time-to-finish, score, stars, completion, rankings, streaks, public reactions, or
+child comparisons. The Creation record supports save/share counts; take/layer signals need later
+instrumentation (game telemetry is not persisted — see #672). Retain aggregate creation events,
+never a child-linked stream of raw tap timing; deleting a creation deletes its replay payload.
+
+## 10. Working-name proposals (from source)
+
+1. **Echo Avenue** — selected; communicates the place and the call-and-response mechanic.
+2. Kinetic Chorus. 3. Soundwalk Studio.
+Working proposals, not trademark clearance (see §2 boundary note).
+
+## 11. Founder rulings + hardware additions (the delta layer)
+
+Replacing the source's open questions Q1–Q7:
+
+1. **Q1 collaboration:** solo overdub guaranteed; same-device duet later; **no online co-op**.
+2. **Q2 peer remix:** deferred past first release (creator-opt-in + facilitator-disableable when it comes).
+3. **Q3 scenery:** **two** curated sound spots.
+4. **Q4 scoreless frame:** completion wiring mirrors Boost Track Builder (standard shell, flat
+   participation score, zero verdict UI in-game); the set-wide creation-shaped-finish question is
+   now tracked as **#693** (leads-level decision).
+5. **Q5 grades 6–8:** documented future mode (§7 column); build K–2 Guided + 3–5 only.
+6. **Q6 gallery encouragement:** follows the **existing** gallery pattern (adult-only curated
+   encouragement, existing visible counter) — no Echo-specific fork.
+7. **Q7 placement:** slot **`set3-game-3`** (slot 1 = Track Builder #691; slot 2 reserved for the
+   machine game; Waterworks placement deferred per #692).
+
+Hardware-test additions: the §4 hedge; AudioContext pre-warm on Start-screen first interaction
+(tested); the `/dev/echo-spike` route stays through the build as the audio regression harness.
+Sounds synthesized, not sampled (supersedes the source's wording, §5).

--- a/docs/games/echo-avenue-design.md
+++ b/docs/games/echo-avenue-design.md
@@ -1,0 +1,132 @@
+# Echo Avenue — live two-performer sound-and-motion studio (design doc)
+
+> Status: **approved design, build in progress.** Externally designed, founder-reviewed; this file is
+> the repo transcription of that design with the founder-review rulings applied. Lands against #676
+> (Set 3 "Mastery"), slot **`set3-game-3`**. Bar: `docs/design-principles.md`.
+> Provenance: inspired by classic side-scrolling two-player cooperation patterns (see the
+> transformation table, §2). All characters, sounds, names, and art are original.
+
+## 1. Concept (one paragraph)
+
+The child taps large action pads; each tap makes one of two original performers **move and sound at
+the same instant** — step, clap, turn, bounce, chime, whoosh. Taps record into a repeating pulse
+loop: the Lead's take loops while the child overdubs the Partner, creating call-and-response,
+overlaps, and rests. Replay ("Watch the Take"), revise a layer, name it from structured tokens,
+share the audiovisual duet to the group gallery. **No scores, stars, timers, verdicts, win/lose, or
+correct rhythms anywhere.** Creation and feedback are simultaneous — a live instrument, not a batch
+simulation.
+
+## 2. Transformation table (classic pattern → Echo Avenue)
+
+| Classic two-player side-scroller pattern | Echo Avenue |
+|---|---|
+| Two characters advance through a level | Two performers hold a stage; **the loop advances, not a level** |
+| Timing judged: mistimed input = failure | **No judgment**: every tap lands (quantized); a "miss" cannot exist |
+| Players compete or race | Lead and Partner **cooperate by construction** — the child is both |
+| Progress = distance/score | Progress = **a made thing** (the duet) that persists and is shared |
+| Sound reacts to gameplay | **Sound IS the gameplay**; motion and sound are one gesture |
+| Levels authored by designers | The **phrase is authored by the child**; two curated sound spots are the only stagecraft |
+
+## 3. Spike verdict + the hardware-sensitivity hedge (REQUIRED reading)
+
+The Phase 1 latency spike (`/dev/echo-spike`, kept in-tree as the **audio regression harness** for
+the whole build) passed on founder hardware: **est. audible ≈13 ms** (+ ~30–45 ms touch input),
+**feels live**; loop ran with **0 underruns**, worst pump gap 34 ms.
+
+**Hedge:** live-tap feel is **device-dependent** (Bluetooth audio, cheap Android tablets, and
+throttled browsers can add 100 ms+). Mitigations, in order: (a) **quantization is the shock
+absorber** — taps snap to the grid, so replay is always musical even when the live monitor lags;
+(b) the studio **pre-warms the AudioContext on the Start screen's first interaction** so the engine
+wake (~1 s) is never paid by the child's first musical tap; (c) a **budget-device spike is a
+required gate before any classroom pilot** (not before build). If budget hardware fails the feel
+test, the K–2 mode leans further into quantized playback-first interaction.
+
+## 4. The engine (specified to unit-test precision)
+
+- **Cycle model:** K–2 Guided = **4 pulses** @ 100 BPM (0.6 s/pulse), snap grid = **half-pulse**
+  (8 subdivisions/cycle); 3–5 = **8 pulses**, half-pulse snap (16 subdivisions). Grades 6–8 is a
+  **documented future mode** (finer grids, swing, longer cycles) — designed, not built in v1.
+- **Events:** `{ t: subdivision index (integer), soundId, performer: "lead" | "partner" }` — integer
+  grid positions, never float seconds, so persistence is exact and drift-impossible.
+- **Quantization as scaffold:** raw tap time → nearest subdivision, **wrapping at the cycle
+  boundary** (a tap a hair before the loop point lands on beat 1, not beat 9). Strength is
+  band-configurable. There is no unquantized mode in v1.
+- **Layers:** Lead and Partner record independently; re-record replaces one layer only; mute per
+  layer; layer independence is a tested invariant.
+- **Scheduling:** the spike's lookahead pattern (25 ms pump, ~120 ms horizon, all events scheduled
+  on the AudioContext clock). Pure scheduling math (`pulsesToSchedule`, `eventTime`) is
+  unit-tested against a mocked clock.
+- **Synth voices:** every sound is a WebAudio node graph — **zero audio assets, zero licensing
+  surface**. Eight sounds in four families (steps / hands / bells / air), loudness-normalized.
+  Every sound is paired with a **motion + pulse-light + trail signature** (see §7, silent mode).
+- **Sound spots:** exactly **two** curated stage spots (tunnel echo, puddle percussion) that color a
+  performer's sound while passing — deliberately capped at two to resist level-builder drift.
+
+## 5. Bands, unlock ladder (fast pacing — a founder-review flag), targets
+
+| Band | Cycle | Palette at start | Ladder |
+|---|---|---|---|
+| 🐣 K–2 Guided | 4 pulses | **2 sounds** (step + chime), Lead only | First recorded phrase → **Partner + clap + whoosh** (announced). First layered phrase → **a sound spot + stomp + twinkle** (announced). **~6 sounds within the first session.** |
+| 🌱 3–5 | 8 pulses | all 8 sounds, both performers | Sound spots announced on first layered phrase |
+| 🚀 6–8 | future mode (documented, not built) | — | — |
+
+Unlocks respond to **making** (phrases recorded, layers made) — never to accuracy, and prompts are
+ignorable at zero cost (tested: ignoring every suggestion still unlocks everything by making).
+Soft targets are dismissible wonderings ("what would a rest sound like?"), never requirements.
+
+## 6. Founder-review rulings (all applied)
+
+1. **Solo overdub guaranteed** (one child is both performers); same-device duet later; **no online co-op**.
+2. **Peer remix deferred** past first release.
+3. **Two** curated sound spots, no more.
+4. **Completion wiring mirrors Boost Track Builder exactly** — standard `GameShell`/`completeActivity`,
+   flat participation-shaped `score/total`, **zero verdict UI in-game**. No new completion policy.
+5. **6–8 is documented future intent** (this table), not built.
+6. Gallery follows the existing creation-gallery pattern (group-scoped, read-only, **never
+   autoplay**, first-name-only).
+7. Slot **`set3-game-3`** (slot 2 stays reserved for the machine game in design).
+8. **K–2 unlock pacing opens the palette fast** (§5) — review flag honored.
+9. **Silent-mode is first-class** (§7) — review flag honored.
+10. **AudioContext pre-warms on the Start screen's first interaction** — the engine wake is never
+    paid by the child's first musical tap (tested in Phase 4).
+11. The **spike route stays** through the build as the audio regression harness.
+
+## 7. Silent mode is first-class (not fallback)
+
+Muted classroom tablets are a primary environment. Every sound has a **distinct motion + pulse-light
++ trail signature** (step = stride + ground ripple; clap = arm snap + white flash; chime = spin +
+rising sparkle; whoosh = glide + streak; …), and Watch-the-Take must be **watchable and expressive
+with audio off** — the duet's structure (call-and-response, overlap, rest) must read visually.
+This gets its own QA pass in Phase 6 and its own manual-QA step.
+
+## 8. Persistence, safety, accessibility
+
+- **`Creation` type `"sound_duet"`** (zero schema changes): `{ v, name, band, pulses, layers:
+  { lead: Event[], partner: Event[] }, spots }` — strict-parsed with zod `.strict()` at every level
+  (#668 divergence cited in code), validity guard (≥1 event, events in bounds, sound ids in the
+  allowlist, per-layer event caps, payload-size cap).
+- **Kid-safety:** titles from approved localized token pools only (no free text); no mic, no camera,
+  no recording of the child — taps move the character, never capture the kid; no autoplay anywhere.
+- **Accessibility floor (testable subset):** one-pointer operation; keyboard operable with visible
+  focus; **≥64 px action pads**, ≥44 px everything else; `touch-action: manipulation`; no
+  multitouch/drag/hold; `prefers-reduced-motion` guard on all animation; master + per-layer volume;
+  loudness-normalized synthesis.
+- **i18n:** every string keyed in the shared locale files; EN + ES real; zh-CN on selected surfaces
+  (title tokens, mascot lines); vi placeholder. **Title-token pools are localized per language**
+  (curated per-locale word pools), not word-by-word translations.
+
+## 9. Spiral mapping
+
+| Stage | Moment |
+|---|---|
+| **Imagine** | Mood previews (Together / Echo / Space) on the title screen; pause/mute + reduced-sensory controls surfaced **before** Start; a starter pulse so the canvas is never blank |
+| **Create** | Tap pads — the performer moves and sounds NOW; record a Lead take, overdub the Partner |
+| **Play** | The loop **is** playback — creation and feedback are simultaneous; Watch-the-Take replays the duet full-stage |
+| **Share** | Token-based naming → save-in-place → group gallery (cover pose card, Watch/Listen, no autoplay) |
+| **Reflect** | Mascot asks ONE context-aware wondering question (call-and-response heard / rests used / a new sound first used) — a separate moment from naming |
+
+## 10. Measure creation, not completion
+
+Iteration signals only: takes recorded, layers replaced, return-to-edit, sound families explored,
+shares. **No scores, stars, timers, verdicts, streaks, or leaderboards.** The completion payload is
+participation-shaped (mirrors Track Builder) and drives XP only; nothing in-game displays it.

--- a/docs/games/echo-avenue-design.md
+++ b/docs/games/echo-avenue-design.md
@@ -57,8 +57,9 @@ remains a live instrument: tap, hear, see, layer.
 ## 4. Spike verdict + the hardware-sensitivity hedge (delta layer)
 
 The Phase 1 latency spike (`/dev/echo-spike`, kept in-tree as the **audio regression harness**)
-passed on founder hardware: **est. audible ≈13 ms** (+ ~30–45 ms touch input), **feels live**;
-loop ran with **0 underruns**, worst pump gap 34 ms.
+passed on founder hardware: **iPhone est. audible ≈13 ms** (+ ~30–45 ms touch input), **feels
+live**; loop ran with **0 underruns over 158 s**, worst pump gap 34 ms; **desktop sub-ms tap
+deltas**. Final QA (2026-07-11) confirmed the feel holds **in the real studio**, not just the spike.
 
 **Hedge:** live-tap feel is **device-dependent**. Mitigations, in order: (a) **quantization is the
 shock absorber** — taps snap to the grid, so replay is always musical even when the live monitor
@@ -134,7 +135,8 @@ full name, email, score, rank, play count, or public reaction count.
 
 **Silent mode is first-class:** the replay must be watchable and expressive with audio off (muted
 classroom tablets are a primary environment) — distinct motions, pulse lights, and trails carry the
-structure. This gets its own QA pass.
+structure. **Muted-run QA passed (founder, 2026-07-11): the replay is readable with audio off —
+call-and-response and rests legible; the shelf tick-strip fix was not needed.**
 
 ## 9. What we measure
 

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -1071,6 +1071,114 @@ async function main() {
     console.log("Seeded Set 2 module:", s2.slug, "(story + game + quiz)");
   }
 
+  // ---------------------------------------------------------------------
+  // SET 3 — Mastery (slot 3: Echo Avenue, GATED from students via
+  // HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts — seeded + published
+  // so ungating is a one-line frontend change). See #676.
+  // ---------------------------------------------------------------------
+  const set3Modules = [
+    {
+      slug: "k2-stem-echo-avenue",
+      title: "Echo Avenue",
+      description: "Make a two-performer sound-and-motion duet! 🎙️🕺",
+      activityId: "echo-avenue",
+      gameKey: "echo_avenue",
+      strand: "AI",
+      story: {
+        title: "Story: The Quiet Street",
+        slides: [
+          { id: "ea-s1", text: { en: "Echo Avenue used to be the loudest street in town — every step, clap, and chime made the whole block dance. But lately it's gone quiet. The stage is empty!", es: "La Avenida del Eco era la calle más ruidosa de la ciudad: cada paso, palmada y campanada hacía bailar a toda la cuadra. ¡Pero últimamente está en silencio. El escenario está vacío!" }, icon: "🎙️" },
+          { id: "ea-s2", text: { en: "Two performers are waiting for a director — that's YOU. Every pad you tap makes a move AND a sound at the same time. Record a phrase, and it loops around and around.", es: "Dos artistas esperan a su director: ¡ese eres TÚ! Cada botón que tocas hace un movimiento Y un sonido a la vez. Graba una frase y se repetirá una y otra vez." }, icon: "🕺" },
+          { id: "ea-s3", text: { en: "There's no wrong beat on Echo Avenue. Layer your two performers, leave quiet spaces, let them answer each other — and share your duet when YOU decide it's ready!", es: "En la Avenida del Eco no hay ritmo equivocado. Combina a tus dos artistas, deja espacios de silencio, haz que se respondan — ¡y comparte tu dúo cuando TÚ decidas que está listo!" }, icon: "⭐" },
+        ],
+        questions: [
+          { id: "ea-q1", prompt: { en: "What happens when you tap a pad on Echo Avenue?", es: "¿Qué pasa cuando tocas un botón en la Avenida del Eco?" }, choices: [{ en: "A performer moves and sounds at the same time", es: "Un artista se mueve y suena a la vez" }, { en: "You lose a point", es: "Pierdes un punto" }, { en: "Nothing happens", es: "No pasa nada" }, { en: "The game ends", es: "El juego termina" }], answerIndex: 0 },
+        ],
+      },
+      quiz: [
+        { id: "eaz-q1", prompt: { en: "Your loop plays the same phrase again and again. What is that called?", es: "Tu bucle toca la misma frase una y otra vez. ¿Cómo se llama eso?" }, choices: [{ en: "A repeating pattern", es: "Un patrón que se repite" }, { en: "A mistake", es: "Un error" }, { en: "A race", es: "Una carrera" }, { en: "A test", es: "una prueba" }], answerIndex: 0 },
+        { id: "eaz-q2", prompt: { en: "One performer plays, then the other answers in the quiet spaces. What did you make?", es: "Un artista toca y el otro responde en los espacios de silencio. ¿Qué creaste?" }, choices: [{ en: "Call-and-response", es: "Llamada y respuesta" }, { en: "A traffic jam", es: "Un atasco" }, { en: "A countdown", es: "Una cuenta regresiva" }, { en: "An echo error", es: "Un error de eco" }], answerIndex: 0 },
+        { id: "eaz-q3", prompt: { en: "When is your duet finished?", es: "¿Cuándo está terminado tu dúo?" }, choices: [{ en: "When YOU decide it's ready", es: "Cuando TÚ decides que está listo" }, { en: "When the timer runs out", es: "Cuando se acaba el tiempo" }, { en: "When you get all the beats right", es: "Cuando aciertas todos los ritmos" }, { en: "When the game says so", es: "Cuando el juego lo dice" }], answerIndex: 0 },
+      ],
+    },
+  ];
+
+  for (const s3 of set3Modules) {
+    const mod = await prisma.module.upsert({
+      where: { slug: s3.slug },
+      update: { title: s3.title, description: s3.description, level: "K-2", published: true },
+      create: { slug: s3.slug, title: s3.title, description: s3.description, level: "K-2", published: true },
+    });
+
+    // Get or create unit — use first unit of this module (not by title, which may have changed)
+    let s3Unit = await prisma.unit.findFirst({ where: { moduleId: mod.id }, orderBy: { order: "asc" } });
+    if (!s3Unit) {
+      s3Unit = await prisma.unit.create({ data: { title: "Unit 1", order: 1, Module: { connect: { id: mod.id } }, teacher: { connect: { id: teacher.id } } } });
+    }
+
+    // Get or create lesson — use first lesson of this unit
+    let s3Lesson = await prisma.lesson.findFirst({ where: { unitId: s3Unit.id }, orderBy: { order: "asc" } });
+    if (!s3Lesson) {
+      s3Lesson = await prisma.lesson.create({ data: { title: s3.title, order: 1, Unit: { connect: { id: s3Unit.id } } } });
+    }
+
+    // Clean up duplicate lessons (from previous seed runs with different titles)
+    const allS3Lessons = await prisma.lesson.findMany({ where: { unitId: s3Unit.id } });
+    for (const dup of allS3Lessons) {
+      if (dup.id !== s3Lesson.id) {
+        await prisma.activity.deleteMany({ where: { lessonId: dup.id } });
+        await prisma.lesson.delete({ where: { id: dup.id } }).catch(() => {});
+      }
+    }
+
+    // Clean up duplicate activities within this lesson (keep only 3: story, game, quiz)
+    const existingS3Acts = await prisma.activity.findMany({ where: { lessonId: s3Lesson.id }, orderBy: { order: "asc" } });
+    for (const act of existingS3Acts) {
+      if (act.order > 3) {
+        await prisma.activity.delete({ where: { id: act.id } }).catch(() => {});
+      }
+    }
+
+    // Activity 1: Story (INFO)
+    const s3StoryContent = JSON.stringify({
+      type: "story_quiz",
+      slides: s3.story.slides,
+      questions: s3.story.questions,
+      review: { keyIdea: { en: s3.description }, vocab: [s3.strand.toLowerCase()] },
+    });
+
+    let s3StoryAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, kind: INFO, order: 1 } });
+    if (s3StoryAct) {
+      await prisma.activity.update({ where: { id: s3StoryAct.id }, data: { title: s3.story.title, content: s3StoryContent } });
+    } else {
+      await prisma.activity.create({ data: { title: s3.story.title, kind: INFO, order: 1, content: s3StoryContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    // Activity 2: Game (INTERACT)
+    const s3GameContent = JSON.stringify({ gameKey: s3.gameKey });
+    let s3GameAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, kind: INTERACT, order: 2 } });
+    if (s3GameAct) {
+      await prisma.activity.update({ where: { id: s3GameAct.id }, data: { id: s3.activityId, title: `Game: ${s3.title}`, content: s3GameContent } });
+    } else {
+      await prisma.activity.create({ data: { id: s3.activityId, title: `Game: ${s3.title}`, kind: INTERACT, order: 2, content: s3GameContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    // Activity 3: Quiz (INFO with quiz questions)
+    const s3QuizContent = JSON.stringify({
+      type: "story_quiz",
+      slides: [],
+      questions: s3.quiz ?? [],
+    });
+    let s3QuizAct = await prisma.activity.findFirst({ where: { lessonId: s3Lesson.id, order: 3 } });
+    if (s3QuizAct) {
+      await prisma.activity.update({ where: { id: s3QuizAct.id }, data: { title: `Quiz: ${s3.title}`, kind: INFO, content: s3QuizContent } });
+    } else {
+      await prisma.activity.create({ data: { title: `Quiz: ${s3.title}`, kind: INFO, order: 3, content: s3QuizContent, Lesson: { connect: { id: s3Lesson.id } } } });
+    }
+
+    console.log("Seeded Set 3 module:", s3.slug, "(story + game + quiz — gated)");
+  }
+
   console.log("Seeding units...");
   let unit = await prisma.unit.findFirst({
     where: { moduleId: module.id, title: "Unit 1: The Basics" },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 // src/App.tsx
+import { lazy, Suspense } from "react";
 import {
   BrowserRouter as Router,
   Routes,
@@ -6,6 +7,13 @@ import {
   Navigate,
   Outlet,
 } from "react-router-dom";
+
+// Dev-only latency spike harness (Echo Avenue, #676 slot 3). The dynamic
+// import lives INSIDE the statically-false DEV branch so production builds
+// emit no chunk for it at all.
+const EchoSpike = import.meta.env.DEV
+  ? lazy(() => import("./pages/dev/EchoSpike"))
+  : () => null;
 import { AuthProvider } from "./contexts/AuthContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
@@ -128,6 +136,16 @@ function App() {
                   lever from docs/audits/k8-engagement-audit.md Part 3.
                   Must stay outside any auth-gated layout. */}
               <Route path="/try" element={<TryDemo />} />
+              {import.meta.env.DEV && (
+                <Route
+                  path="/dev/echo-spike"
+                  element={
+                    <Suspense fallback={null}>
+                      <EchoSpike />
+                    </Suspense>
+                  }
+                />
+              )}
               <Route path="/for-reviewers" element={<ForReviewers />} />
               {/* Free Access Plans detail pages — reached from the homepage
                   "Learn more" buttons. Public, persona-routed CTAs. */}

--- a/src/components/creations/GroupGallery.tsx
+++ b/src/components/creations/GroupGallery.tsx
@@ -17,7 +17,34 @@ type GalleryCreation = {
   encouragements: number;
   authorId: string;
   authorName: string;
+  /** Present for sound_duet only (the list endpoint ships the small duet
+   *  payload so the card can show its cover pose). */
+  content?: unknown;
 };
+
+/**
+ * sound_duet cover pose for the card. Any malformed/missing content falls
+ * back to 🎙️ — the card must NEVER crash on a sound_duet creation.
+ */
+function DuetCover({ content }: { content: unknown }) {
+  const POSES: Record<string, string> = {
+    sideBySide: "🧍🧍",
+    highFive: "🙌",
+    backToBack: "🔄",
+  };
+  let icon = "🎙️";
+  try {
+    const pose = (content as { coverPose?: string } | null)?.coverPose;
+    if (pose && POSES[pose]) icon = `${POSES[pose]}`;
+  } catch {
+    icon = "🎙️";
+  }
+  return (
+    <span className="text-2xl" aria-hidden>
+      {icon}
+    </span>
+  );
+}
 
 export default function GroupGallery({
   courseId,
@@ -72,9 +99,12 @@ export default function GroupGallery({
           className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm flex flex-col gap-2"
         >
           <div className="flex items-start justify-between gap-2">
-            <h3 className="font-semibold text-brightboost-navy">
-              {c.title || t("gallery.untitled")}
-            </h3>
+            <div className="flex items-center gap-2 min-w-0">
+              {c.type === "sound_duet" && <DuetCover content={c.content} />}
+              <h3 className="font-semibold text-brightboost-navy">
+                {c.title || t("gallery.untitled")}
+              </h3>
+            </div>
             <CreationStatusChip status={c.status} />
           </div>
           <p className="text-xs text-gray-500">
@@ -92,12 +122,14 @@ export default function GroupGallery({
               >
                 {t("gallery.giveBoost")}
               </button>
-            ) : c.type === "data_dash_challenge" ? (
+            ) : c.type === "data_dash_challenge" || c.type === "sound_duet" ? (
               <Link
                 to={`/student/challenge/${c.id}`}
                 className="px-3 py-1.5 text-sm rounded-md bg-brightboost-blue text-white font-semibold hover:bg-brightboost-navy"
               >
-                {t("gallery.play")}
+                {c.type === "sound_duet"
+                  ? t("gallery.watchListen", { defaultValue: "Watch / Listen" })
+                  : t("gallery.play")}
               </Link>
             ) : null}
           </div>

--- a/src/components/creations/__tests__/GroupGallery.soundDuet.test.tsx
+++ b/src/components/creations/__tests__/GroupGallery.soundDuet.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import GroupGallery from "../GroupGallery";
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty" as const, init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue || key,
+  }),
+}));
+
+const mockGet = vi.fn();
+vi.mock("../../../services/api", () => ({
+  useApi: () => ({ get: mockGet, post: vi.fn() }),
+}));
+
+function item(overrides: Record<string, unknown>) {
+  return {
+    id: "d1",
+    type: "sound_duet",
+    title: "Midnight Parade",
+    status: "COMPLETE",
+    encouragements: 0,
+    authorId: "u1",
+    authorName: "Ada",
+    ...overrides,
+  };
+}
+
+function renderGallery() {
+  return render(
+    <MemoryRouter>
+      <GroupGallery courseId="course-1" canEncourage={false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("GroupGallery — sound_duet cards (HARD REQUIREMENT: never crash)", () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it("renders a duet card with its cover pose and a Watch / Listen link (never autoplay)", async () => {
+    mockGet.mockResolvedValue([
+      item({ content: { coverPose: "highFive" } }),
+    ]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("Midnight Parade")).toBeTruthy());
+    expect(screen.getByText("🙌")).toBeTruthy();
+    const link = screen.getByText("Watch / Listen");
+    expect(link.closest("a")?.getAttribute("href")).toBe("/student/challenge/d1");
+    // no <audio>, no autoplay anything — the card is inert until tapped
+    expect(document.querySelector("audio, video")).toBeNull();
+  });
+
+  it("does NOT crash on malformed content — falls back to 🎙️", async () => {
+    mockGet.mockResolvedValue([
+      item({ title: "Broken Duet", content: { coverPose: 42, layers: "nope" } }),
+    ]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("Broken Duet")).toBeTruthy());
+    expect(screen.getByText("🎙️")).toBeTruthy();
+  });
+
+  it("does NOT crash on missing content — falls back to 🎙️", async () => {
+    mockGet.mockResolvedValue([item({ title: "No Payload" })]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("No Payload")).toBeTruthy());
+    expect(screen.getByText("🎙️")).toBeTruthy();
+  });
+
+  it("keeps the Play link for data_dash_challenge cards (no regression)", async () => {
+    mockGet.mockResolvedValue([
+      item({ id: "c9", type: "data_dash_challenge", title: "Sort It" }),
+    ]);
+    renderGallery();
+    await waitFor(() => expect(screen.getByText("Sort It")).toBeTruthy());
+    expect(screen.getByText("gallery.play")).toBeTruthy();
+  });
+});

--- a/src/components/games/__tests__/EchoAvenue.test.ts
+++ b/src/components/games/__tests__/EchoAvenue.test.ts
@@ -151,7 +151,7 @@ describe("unlock ladder", () => {
 
   it("newlyUnlockedSounds reports each unlock exactly once (the announce beat)", () => {
     const p1 = advanceEchoProgress(FRESH_ECHO_PROGRESS, summarizeTake(take(1, 0)));
-    expect(newlyUnlockedSounds("k2", FRESH_ECHO_PROGRESS, p1)).toEqual(["clap", "whoosh"]);
+    expect(newlyUnlockedSounds("k2", FRESH_ECHO_PROGRESS, p1)).toEqual(["chime", "whoosh"]);
     expect(newlyUnlockedSounds("k2", p1, p1)).toEqual([]);
   });
 });
@@ -262,6 +262,7 @@ describe("buildDuetContent", () => {
   it("derives pulses from the band (the validator cross-checks this)", () => {
     const c = buildDuetContent("Sunny Echo", "k2", EMPTY_LAYERS, ["tunnel"]);
     expect(c.pulses).toBe(4);
+    expect(c.coverPose).toBe("sideBySide"); // default pose until the child picks
     expect(buildDuetContent("X", "g35", EMPTY_LAYERS, []).pulses).toBe(8);
   });
 });

--- a/src/components/games/__tests__/EchoAvenue.test.ts
+++ b/src/components/games/__tests__/EchoAvenue.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  BAND_CONFIG,
+  ECHO_AVENUE_TOTAL,
+  ECHO_TOKENS_FIRST,
+  ECHO_TOKENS_SECOND,
+  EMPTY_LAYERS,
+  FRESH_ECHO_PROGRESS,
+  K2_START_SOUNDS,
+  SOUND_IDS,
+  SOUND_SET,
+  advanceEchoProgress,
+  buildDuetContent,
+  buildEchoAvenueResult,
+  cycleSec,
+  detectCallAndResponse,
+  detectRests,
+  eventTime,
+  isNameTaken,
+  newlyUnlockedSounds,
+  partnerUnlocked,
+  pickEchoWonder,
+  pulsesToSchedule,
+  quantizeToSubdivision,
+  recordEvent,
+  replaceLayer,
+  spotsUnlocked,
+  subdivisions,
+  summarizeTake,
+  tokenName,
+  unlockedSounds,
+  type DuetLayers,
+} from "../echoAvenue/echoAvenueModel";
+
+const K2 = BAND_CONFIG.k2;
+const G35 = BAND_CONFIG.g35;
+
+// ── Cycle + quantization (the K-2 scaffold) ─────────────────────────────────
+
+describe("quantizeToSubdivision", () => {
+  it("snaps to the nearest half-pulse", () => {
+    // K-2: pulse 0.6s, snap 0.3s, 8 slots (0..7)
+    expect(quantizeToSubdivision(0, K2)).toBe(0);
+    expect(quantizeToSubdivision(0.31, K2)).toBe(1);
+    expect(quantizeToSubdivision(0.44, K2)).toBe(1); // closer to 0.3 than 0.6
+    expect(quantizeToSubdivision(0.46, K2)).toBe(2); // closer to 0.6
+    expect(quantizeToSubdivision(1.2, K2)).toBe(4);
+  });
+
+  it("WRAPS at the cycle boundary: a tap just before the loop point lands on slot 0", () => {
+    // cycle = 2.4s; a tap at 2.31s is nearest to 2.4 → slot 8 → wraps to 0
+    expect(quantizeToSubdivision(2.31, K2)).toBe(0);
+    // and a tap just after 0 stays at 0
+    expect(quantizeToSubdivision(0.05, K2)).toBe(0);
+    // exact midpoint at the top of the cycle rounds up → wrap
+    expect(quantizeToSubdivision(2.25, K2)).toBe(0);
+  });
+
+  it("band grids differ: K-2 has 8 slots, 3-5 has 16", () => {
+    expect(subdivisions(K2)).toBe(8);
+    expect(subdivisions(G35)).toBe(16);
+    expect(cycleSec(K2)).toBeCloseTo(2.4);
+    expect(cycleSec(G35)).toBeCloseTo(4.8);
+  });
+});
+
+// ── Scheduler math (mocked clock) ───────────────────────────────────────────
+
+describe("lookahead scheduler math", () => {
+  it("returns exactly the pulses inside the horizon", () => {
+    // loopStart=10, pulse 0.6, now=10.5, horizon 0.12 → pulses with time < 10.62
+    expect(pulsesToSchedule(0, 10, 10.5, 0.12, 0.6)).toEqual([0, 1]); // 10.0, 10.6
+    // resume from pulse 2: next times 11.2, 11.8 — none inside 10.62
+    expect(pulsesToSchedule(2, 10, 10.5, 0.12, 0.6)).toEqual([]);
+    // wide horizon picks up several
+    expect(pulsesToSchedule(2, 10, 11.5, 0.9, 0.6)).toEqual([2, 3]);
+  });
+
+  it("event replay times are exact grid math per cycle pass (drift-impossible)", () => {
+    // slot 3 of K-2 = 0.9s into each 2.4s cycle
+    expect(eventTime(100, 0, 3, K2)).toBeCloseTo(100.9);
+    expect(eventTime(100, 1, 3, K2)).toBeCloseTo(103.3);
+    expect(eventTime(100, 25, 3, K2)).toBeCloseTo(100 + 25 * 2.4 + 0.9); // 60s+ out, still exact
+  });
+});
+
+// ── Layers ──────────────────────────────────────────────────────────────────
+
+describe("layer independence", () => {
+  const layers: DuetLayers = {
+    lead: [
+      { t: 0, soundId: "step" },
+      { t: 4, soundId: "chime" },
+    ],
+    partner: [{ t: 2, soundId: "clap" }],
+  };
+
+  it("re-recording one layer never touches the other (the overdub invariant)", () => {
+    const next = replaceLayer(layers, "partner", [{ t: 6, soundId: "whoosh" }]);
+    expect(next.lead).toBe(layers.lead); // same reference — untouched
+    expect(next.partner).toEqual([{ t: 6, soundId: "whoosh" }]);
+  });
+
+  it("recordEvent appends to the right performer only", () => {
+    const next = recordEvent(layers, "lead", { t: 6, soundId: "tap" });
+    expect(next.lead).toHaveLength(3);
+    expect(next.partner).toBe(layers.partner);
+  });
+});
+
+// ── Unlock ladder — fast pacing; making, never accuracy ─────────────────────
+
+describe("unlock ladder", () => {
+  const take = (lead: number, partner: number): DuetLayers => ({
+    lead: Array.from({ length: lead }, (_, i) => ({ t: i, soundId: "step" as const })),
+    partner: Array.from({ length: partner }, (_, i) => ({ t: i + 4, soundId: "chime" as const })),
+  });
+
+  it("K-2 starts with two sounds, Lead only; 3-5 starts with everything", () => {
+    expect(unlockedSounds("k2", FRESH_ECHO_PROGRESS)).toEqual(K2_START_SOUNDS);
+    expect(partnerUnlocked("k2", FRESH_ECHO_PROGRESS)).toBe(false);
+    expect(unlockedSounds("g35", FRESH_ECHO_PROGRESS)).toHaveLength(8);
+    expect(partnerUnlocked("g35", FRESH_ECHO_PROGRESS)).toBe(true);
+  });
+
+  it("FAST PACING: first phrase → Partner + 2 sounds; first layered phrase → spot + 2 more (~6 sounds in a first session)", () => {
+    const p1 = advanceEchoProgress(FRESH_ECHO_PROGRESS, summarizeTake(take(2, 0)));
+    expect(partnerUnlocked("k2", p1)).toBe(true);
+    expect(unlockedSounds("k2", p1)).toHaveLength(4);
+    expect(spotsUnlocked("k2", p1)).toBe(false);
+
+    const p2 = advanceEchoProgress(p1, summarizeTake(take(2, 2)));
+    expect(unlockedSounds("k2", p2)).toHaveLength(6); // ~6 sounds, session one
+    expect(spotsUnlocked("k2", p2)).toBe(true);
+  });
+
+  it("unlocks respond to MAKING only — ignoring every prompt still unlocks everything by making", () => {
+    // No prompt/suggestion state exists anywhere in Progress: the ladder is a
+    // pure function of phrases and layers made. Make things → unlocked.
+    let p = FRESH_ECHO_PROGRESS;
+    p = advanceEchoProgress(p, summarizeTake(take(1, 0)));
+    p = advanceEchoProgress(p, summarizeTake(take(1, 1)));
+    expect(unlockedSounds("k2", p)).toHaveLength(6);
+    expect(Object.keys(p)).not.toContain("promptsFollowed"); // accuracy/obedience is not tracked
+  });
+
+  it("an empty take advances nothing (and costs nothing)", () => {
+    const p = advanceEchoProgress(FRESH_ECHO_PROGRESS, summarizeTake(EMPTY_LAYERS));
+    expect(p).toEqual(FRESH_ECHO_PROGRESS);
+  });
+
+  it("newlyUnlockedSounds reports each unlock exactly once (the announce beat)", () => {
+    const p1 = advanceEchoProgress(FRESH_ECHO_PROGRESS, summarizeTake(take(1, 0)));
+    expect(newlyUnlockedSounds("k2", FRESH_ECHO_PROGRESS, p1)).toEqual(["clap", "whoosh"]);
+    expect(newlyUnlockedSounds("k2", p1, p1)).toEqual([]);
+  });
+});
+
+// ── Reflect ─────────────────────────────────────────────────────────────────
+
+describe("wondering question", () => {
+  const callResponse: DuetLayers = {
+    lead: [{ t: 0, soundId: "step" }],
+    partner: [{ t: 4, soundId: "chime" }],
+  };
+
+  it("detects call-and-response (partner plays in the lead's gaps)", () => {
+    expect(detectCallAndResponse(callResponse)).toBe(true);
+    expect(
+      detectCallAndResponse({
+        lead: [{ t: 0, soundId: "step" }],
+        partner: [{ t: 0, soundId: "clap" }], // stacked, not answering
+      }),
+    ).toBe(false);
+    expect(detectCallAndResponse({ lead: [{ t: 0, soundId: "step" }], partner: [] })).toBe(false);
+  });
+
+  it("detects rests and prioritizes: new sound > call-and-response > rests > evergreen", () => {
+    expect(detectRests(callResponse, K2)).toBe(true);
+    expect(
+      pickEchoWonder({ callAndResponse: true, restsUsed: true, newSoundUsed: "whoosh" }).key,
+    ).toBe("echoAvenue.wonder.newSound.whoosh");
+    expect(pickEchoWonder({ callAndResponse: true, restsUsed: true }).key).toBe(
+      "echoAvenue.wonder.callResponse",
+    );
+    expect(pickEchoWonder({ callAndResponse: false, restsUsed: true }).key).toBe(
+      "echoAvenue.wonder.rests",
+    );
+    expect(pickEchoWonder({ callAndResponse: false, restsUsed: false }, () => 0.9).key).toBe(
+      "echoAvenue.wonder.next",
+    );
+  });
+});
+
+// ── Naming tokens (kid-safety: approved pools only) ─────────────────────────
+
+describe("name tokens", () => {
+  it("every token carries real EN + ES and a zh-CN label (localized pools, per ruling)", () => {
+    for (const token of [...ECHO_TOKENS_FIRST, ...ECHO_TOKENS_SECOND]) {
+      expect(token.label.en?.length).toBeGreaterThan(0);
+      expect(token.label.es?.length).toBeGreaterThan(0);
+      expect(token.label["zh-CN"]?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("token names join and cap at 24 chars; duplicates are detected (hint, never error)", () => {
+    expect(tokenName("Midnight", "Parade")).toBe("Midnight Parade");
+    expect(isNameTaken("midnight parade", ["Midnight Parade"])).toBe(true);
+    expect(isNameTaken("Sunny Echo", ["Midnight Parade", null])).toBe(false);
+  });
+});
+
+// ── Silent-mode registry + completion payload ───────────────────────────────
+
+describe("sound registry (silent-mode duty)", () => {
+  it("every sound has a distinct motion signature, a light color, and a trail", () => {
+    const motions = new Set(SOUND_SET.map((s) => s.motion));
+    expect(motions.size).toBe(SOUND_IDS.length); // distinct per sound
+    for (const spec of SOUND_SET) {
+      expect(spec.lightColor).toMatch(/^#/);
+      expect(spec.trail.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("completion payload (mirrors Track Builder; zero verdicts)", () => {
+  it("is flat participation shape with integer score/total", () => {
+    const r = buildEchoAvenueResult({
+      phraseRecorded: true,
+      overdubbed: true,
+      layerReplaced: true,
+      shared: true,
+      takesRecorded: 5,
+      familiesExplored: 3,
+    });
+    expect(r.gameKey).toBe("echo_avenue");
+    expect(r.score).toBe(6);
+    expect(r.total).toBe(ECHO_AVENUE_TOTAL);
+    expect(r.streakMax).toBe(0); // no streak concept — flat by design
+    expect(r.roundsCompleted).toBe(5);
+  });
+
+  it("carries no accuracy, verdict, or timing fields anywhere", () => {
+    const r = buildEchoAvenueResult({
+      phraseRecorded: true,
+      overdubbed: false,
+      layerReplaced: false,
+      shared: false,
+      takesRecorded: 1,
+      familiesExplored: 1,
+    });
+    const flat = JSON.stringify(r).toLowerCase();
+    for (const banned of ["accuracy", "verdict", "correct", "miss", "combo", "grade"]) {
+      expect(flat).not.toContain(banned);
+    }
+  });
+});
+
+// ── Persisted content builder ───────────────────────────────────────────────
+
+describe("buildDuetContent", () => {
+  it("derives pulses from the band (the validator cross-checks this)", () => {
+    const c = buildDuetContent("Sunny Echo", "k2", EMPTY_LAYERS, ["tunnel"]);
+    expect(c.pulses).toBe(4);
+    expect(buildDuetContent("X", "g35", EMPTY_LAYERS, []).pulses).toBe(8);
+  });
+});

--- a/src/components/games/__tests__/EchoAvenueWarmup.test.tsx
+++ b/src/components/games/__tests__/EchoAvenueWarmup.test.tsx
@@ -129,9 +129,10 @@ describe("EchoStudioCore — pre-warm sequencing", () => {
       />,
     );
     fireEvent.click(screen.getByText("Open the studio!"));
+    // Source-reconciled K-2 opening: Step + Clap pads first
     expect(screen.getByLabelText("step")).toBeTruthy();
-    expect(screen.getByLabelText("chime")).toBeTruthy();
-    expect(screen.queryByLabelText("clap")).toBeNull(); // locked until first phrase
+    expect(screen.getByLabelText("clap")).toBeTruthy();
+    expect(screen.queryByLabelText("chime")).toBeNull(); // locked until first phrase
     const partnerTab = screen.getByRole("button", { name: /Partner \(0\)/ });
     expect(partnerTab.hasAttribute("disabled")).toBe(true);
   });

--- a/src/components/games/__tests__/EchoAvenueWarmup.test.tsx
+++ b/src/components/games/__tests__/EchoAvenueWarmup.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * The pre-warm contract (design ruling 10, held-firm requirement):
+ * the AudioContext wakes on the Start screen's FIRST interaction, exactly
+ * once — and after entering the studio, the first pad tap plays
+ * SYNCHRONOUSLY (no wake gap, nothing awaited on the tap path).
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createWarmupGate } from "../echoAvenue/echoAvenueWarmup";
+import { EchoStudioCore } from "../echoAvenue/EchoAvenueGame";
+import type { EchoAudio } from "../echoAvenue/echoAvenueAudio";
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty" as const, init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue || key,
+  }),
+}));
+
+vi.mock("@/services/api", () => ({
+  useApi: () => ({
+    get: vi.fn().mockRejectedValue(new Error("offline test")),
+    post: vi.fn(),
+    patch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/utils/localizedContent", () => ({
+  pickLocale: (map: Record<string, string>, fallback: string) => map.en ?? fallback,
+}));
+
+// ── Gate unit contract ──────────────────────────────────────────────────────
+
+describe("createWarmupGate", () => {
+  it("wakes exactly once no matter how many interactions race", async () => {
+    let resolveWake: () => void = () => {};
+    const prewarm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWake = resolve;
+        }),
+    );
+    const gate = createWarmupGate({ prewarm });
+    void gate.warmOnFirstInteraction();
+    void gate.warmOnFirstInteraction();
+    void gate.warmOnFirstInteraction();
+    expect(prewarm).toHaveBeenCalledTimes(1);
+    expect(gate.isWarm()).toBe(false);
+    resolveWake();
+    await gate.warmOnFirstInteraction();
+    expect(gate.isWarm()).toBe(true);
+    expect(gate.wakeCount()).toBe(1);
+  });
+});
+
+// ── Component contract: title interaction warms; pad tap is synchronous ────
+
+function mockAudio(): EchoAudio & { prewarm: ReturnType<typeof vi.fn>; play: ReturnType<typeof vi.fn> } {
+  let t = 100;
+  return {
+    ctx: {} as AudioContext,
+    master: {} as GainNode,
+    layerGain: { lead: {} as GainNode, partner: {} as GainNode },
+    prewarm: vi.fn(async () => {}),
+    play: vi.fn(),
+    tick: vi.fn(),
+    setMasterVolume: vi.fn(),
+    setLayerVolume: vi.fn(),
+    now: () => (t += 0.01),
+  };
+}
+
+describe("EchoStudioCore — pre-warm sequencing", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("any Start-screen interaction wakes the engine ONCE; the first studio pad tap plays synchronously", () => {
+    const audio = mockAudio();
+    const { container } = render(
+      <EchoStudioCore
+        onFinish={() => {}}
+        reducedEffects={false}
+        band="k2"
+        audioFactory={() => audio}
+      />,
+    );
+
+    // First interaction: a mood-preview tap on the title screen
+    fireEvent.pointerDown(container.firstChild as Element);
+    expect(audio.prewarm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("🔁 Echo")); // more title interactions…
+    fireEvent.pointerDown(container.firstChild as Element);
+    expect(audio.prewarm).toHaveBeenCalledTimes(1); // …still exactly one wake
+
+    // Enter the studio
+    fireEvent.click(screen.getByText("Open the studio!"));
+
+    // The child's first musical tap: play() fires within the tap's own event
+    // dispatch — nothing awaited, no wake gap (prewarm count unchanged).
+    audio.play.mockClear();
+    fireEvent.pointerDown(screen.getByLabelText("step"));
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(audio.play.mock.calls[0][0]).toBe("step");
+    expect(audio.prewarm).toHaveBeenCalledTimes(1); // the tap never pays the wake
+  });
+
+  it("K-2 studio opens with the starter pulse seeded (the canvas is never blank)", () => {
+    const audio = mockAudio();
+    render(
+      <EchoStudioCore
+        onFinish={() => {}}
+        reducedEffects={false}
+        band="k2"
+        audioFactory={() => audio}
+      />,
+    );
+    fireEvent.click(screen.getByText("Open the studio!"));
+    // Lead tab shows its seeded event count > 0
+    expect(screen.getByText(/Lead \([1-9]/)).toBeTruthy();
+  });
+
+  it("Partner starts locked on K-2 and the pads show only the starting pair", () => {
+    const audio = mockAudio();
+    render(
+      <EchoStudioCore
+        onFinish={() => {}}
+        reducedEffects={false}
+        band="k2"
+        audioFactory={() => audio}
+      />,
+    );
+    fireEvent.click(screen.getByText("Open the studio!"));
+    expect(screen.getByLabelText("step")).toBeTruthy();
+    expect(screen.getByLabelText("chime")).toBeTruthy();
+    expect(screen.queryByLabelText("clap")).toBeNull(); // locked until first phrase
+    const partnerTab = screen.getByRole("button", { name: /Partner \(0\)/ });
+    expect(partnerTab.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/src/components/games/echoAvenue/EchoAvenueGame.tsx
+++ b/src/components/games/echoAvenue/EchoAvenueGame.tsx
@@ -1,0 +1,1001 @@
+/**
+ * Echo Avenue — live two-performer sound-and-motion studio (Set 3 · slot 3).
+ * Design: docs/games/echo-avenue-design.md. Engine: ./echoAvenueModel.ts
+ * (pure, tested). Audio: ./echoAvenueAudio.ts (synthesized, zero assets).
+ *
+ * Held-firm requirements this file implements:
+ * - AudioContext pre-warms on the Start screen's FIRST interaction (gate in
+ *   ./echoAvenueWarmup.ts, tested) — the child's first musical tap never
+ *   pays the engine wake.
+ * - Two ORIGINAL performers with clearly distinct silhouettes (round amber
+ *   bobble-bot vs tall sky scarf-bot — different shape, height, and color).
+ * - Reflect (one wondering question) and naming (token picker) are separate
+ *   moments; a starter pulse means the canvas is never blank; mood previews
+ *   + sensory controls surface BEFORE Start.
+ * - ≥64px action pads, reduced-motion guard (echoAvenue.css), keyboard
+ *   operability on the core loop (digits = pads, R = record, W = watch).
+ * - ZERO verdict UI in the studio: no scores, accuracy, streaks, or "right
+ *   rhythm" anywhere. (The platform-standard GameShell finish screen is the
+ *   completion wiring mirror — nothing inside the studio judges.)
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import GameShell, { type GameResult } from "../shared/GameShell";
+import { pickLocale } from "@/utils/localizedContent";
+import { useApi } from "@/services/api";
+import "./echoAvenue.css";
+import {
+  BAND_CONFIG,
+  ECHO_TOKENS_FIRST,
+  ECHO_TOKENS_SECOND,
+  EMPTY_LAYERS,
+  FRESH_ECHO_PROGRESS,
+  advanceEchoProgress,
+  buildDuetContent,
+  buildEchoAvenueResult,
+  cycleSec,
+  detectCallAndResponse,
+  detectRests,
+  eventTime,
+  isNameTaken,
+  newlyUnlockedSounds,
+  partnerUnlocked,
+  pickEchoWonder,
+  pulsesToSchedule,
+  quantizeToSubdivision,
+  recordEvent,
+  soundSpec,
+  spotsUnlocked,
+  summarizeTake,
+  tokenName,
+  unlockedSounds,
+  type DuetLayers,
+  type EchoBand,
+  type EchoProgress,
+  type Performer,
+  type SoundId,
+} from "./echoAvenueModel";
+import { getEchoAudio, type EchoAudio } from "./echoAvenueAudio";
+import { createWarmupGate, type WarmupGate } from "./echoAvenueWarmup";
+
+const PUMP_MS = 25;
+const HORIZON_SEC = 0.12;
+const DRAFT_KEY = "bb_echo_avenue_draft_v1";
+
+type Mood = "together" | "echo" | "space";
+
+const MOOD_SEEDS: Record<Mood, DuetLayers> = {
+  together: { lead: [{ t: 0, soundId: "step" }, { t: 4, soundId: "step" }], partner: [] },
+  echo: { lead: [{ t: 0, soundId: "chime" }, { t: 4, soundId: "step" }], partner: [] },
+  space: { lead: [{ t: 0, soundId: "chime" }], partner: [] },
+};
+
+interface EchoDraft {
+  name: string;
+  band: EchoBand;
+  layers: DuetLayers;
+  progress: EchoProgress;
+  creationId: string | null;
+}
+
+function loadDraft(): EchoDraft | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return null;
+    const d = JSON.parse(raw) as EchoDraft;
+    if (!d?.layers || !Array.isArray(d.layers.lead)) return null;
+    return d;
+  } catch {
+    return null;
+  }
+}
+
+// ── The two ORIGINAL performers (distinct silhouettes, not color-swaps) ─────
+
+function LeadFigure({ motion }: { motion: string | null }) {
+  // Round amber bobble-bot: short, circular body, antenna bobble, stub legs.
+  return (
+    <svg
+      viewBox="0 0 80 100"
+      className={`w-20 h-24 ${motion ? `ea-motion-${motion}` : ""}`}
+      aria-hidden
+    >
+      <line x1="40" y1="18" x2="40" y2="6" stroke="#b45309" strokeWidth="4" />
+      <circle cx="40" cy="6" r="5" fill="#fbbf24" />
+      <circle cx="40" cy="52" r="30" fill="#f59e0b" />
+      <circle cx="30" cy="46" r="5" fill="#78350f" />
+      <circle cx="50" cy="46" r="5" fill="#78350f" />
+      <path d="M 28 62 Q 40 70 52 62" stroke="#78350f" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <rect x="26" y="80" width="9" height="16" rx="4" fill="#b45309" />
+      <rect x="45" y="80" width="9" height="16" rx="4" fill="#b45309" />
+    </svg>
+  );
+}
+
+function PartnerFigure({ motion }: { motion: string | null }) {
+  // Tall sky scarf-bot: angular trapezoid body, zigzag scarf, long legs.
+  return (
+    <svg
+      viewBox="0 0 80 120"
+      className={`w-20 h-28 ${motion ? `ea-motion-${motion}` : ""}`}
+      aria-hidden
+    >
+      <polygon points="28,18 52,18 58,74 22,74" fill="#0ea5e9" />
+      <rect x="30" y="4" width="20" height="16" rx="4" fill="#0284c7" />
+      <circle cx="36" cy="12" r="3" fill="#e0f2fe" />
+      <circle cx="46" cy="12" r="3" fill="#e0f2fe" />
+      <polyline points="24,26 34,32 44,26 54,32" stroke="#facc15" strokeWidth="5" fill="none" strokeLinecap="round" />
+      <rect x="28" y="74" width="8" height="40" rx="4" fill="#0369a1" />
+      <rect x="44" y="74" width="8" height="40" rx="4" fill="#0369a1" />
+    </svg>
+  );
+}
+
+// ── Core studio (named export so the pre-warm contract is mount-testable) ───
+
+export interface EchoStudioCoreProps {
+  onFinish: (result: GameResult) => void;
+  reducedEffects: boolean;
+  band: EchoBand;
+  /** test seam — production uses the real singleton */
+  audioFactory?: () => EchoAudio;
+}
+
+export function EchoStudioCore({
+  onFinish,
+  reducedEffects,
+  band,
+  audioFactory = getEchoAudio,
+}: EchoStudioCoreProps) {
+  const { t } = useTranslation();
+  const api = useApi();
+  const cfg = BAND_CONFIG[band];
+
+  const draft = useMemo(loadDraft, []);
+  const [screen, setScreen] = useState<"title" | "studio">("title");
+  const [mood, setMood] = useState<Mood>("together");
+  const [calmMode, setCalmMode] = useState(false);
+  const [muted, setMuted] = useState(false);
+  const [masterVol, setMasterVol] = useState(0.9);
+
+  const [layers, setLayers] = useState<DuetLayers>(draft?.layers ?? EMPTY_LAYERS);
+  const [progress, setProgress] = useState<EchoProgress>(
+    draft?.progress ?? FRESH_ECHO_PROGRESS,
+  );
+  const [performer, setPerformer] = useState<Performer>("lead");
+  const [recording, setRecording] = useState(false);
+  const [watching, setWatching] = useState(false);
+  const [name, setName] = useState(draft?.name ?? "");
+  const [creationId, setCreationId] = useState<string | null>(draft?.creationId ?? null);
+  const [courseId, setCourseId] = useState<string | null>(null);
+  const [galleryTitles, setGalleryTitles] = useState<string[]>([]);
+  const [saveNote, setSaveNote] = useState<"saved" | "local" | null>(null);
+  const [shared, setShared] = useState(false);
+
+  const [announceQueue, setAnnounceQueue] = useState<string[]>([]);
+  const [wonder, setWonder] = useState<{ key: string; params?: Record<string, unknown> } | null>(null);
+  const [showNaming, setShowNaming] = useState(false);
+  const [tokenFirst, setTokenFirst] = useState(ECHO_TOKENS_FIRST[0]);
+  const [tokenSecond, setTokenSecond] = useState(ECHO_TOKENS_SECOND[0]);
+
+  const [motionNow, setMotionNow] = useState<Record<Performer, string | null>>({
+    lead: null,
+    partner: null,
+  });
+  const [lightFlash, setLightFlash] = useState<{ color: string; key: number } | null>(null);
+  const [trails, setTrails] = useState<{ id: number; performer: Performer; icon: string }[]>([]);
+  const [beat, setBeat] = useState(-1);
+
+  // session telemetry (iteration signals only)
+  const takesRef = useRef(0);
+  const layersReplacedRef = useRef(0);
+  const newSoundCandidatesRef = useRef<Set<SoundId>>(new Set());
+  const trailSeq = useRef(0);
+  const motionTimers = useRef<Record<Performer, ReturnType<typeof setTimeout> | null>>({
+    lead: null,
+    partner: null,
+  });
+
+  const calm = calmMode || reducedEffects;
+
+  // ── Audio + the pre-warm gate (ruling 10; tested) ──
+  const audioRef = useRef<EchoAudio | null>(null);
+  const gateRef = useRef<WarmupGate | null>(null);
+  const getAudio = useCallback(() => {
+    if (!audioRef.current) {
+      audioRef.current = audioFactory();
+      gateRef.current = createWarmupGate(audioRef.current);
+    }
+    return audioRef.current;
+  }, [audioFactory]);
+
+  /** EVERY Start-screen interaction routes through here first. */
+  const titleInteraction = useCallback(() => {
+    getAudio();
+    void gateRef.current!.warmOnFirstInteraction();
+  }, [getAudio]);
+
+  // ── Loop pump (spike-proven pattern; runs while in the studio) ──
+  const layersRef = useRef(layers);
+  layersRef.current = layers;
+  const loopStartRef = useRef(0);
+  const nextPulseRef = useRef(0);
+  const scheduledCycleRef = useRef(-1);
+  const pumpIdRef = useRef<number | null>(null);
+  const lastSlotRef = useRef(-1);
+
+  const triggerMotion = useCallback(
+    (who: Performer, soundId: SoundId) => {
+      const spec = soundSpec(soundId);
+      setMotionNow((m) => ({ ...m, [who]: null }));
+      // restart the CSS animation on consecutive same-motion triggers
+      requestAnimationFrame(() =>
+        setMotionNow((m) => ({ ...m, [who]: spec.motion })),
+      );
+      if (motionTimers.current[who]) clearTimeout(motionTimers.current[who]!);
+      motionTimers.current[who] = setTimeout(
+        () => setMotionNow((m) => ({ ...m, [who]: null })),
+        520,
+      );
+      if (!calm) {
+        setLightFlash({ color: spec.lightColor, key: performance.now() });
+        const id = trailSeq.current++;
+        setTrails((prev) => [...prev.slice(-7), { id, performer: who, icon: spec.icon }]);
+      }
+    },
+    [calm],
+  );
+
+  const stopPump = useCallback(() => {
+    if (pumpIdRef.current !== null) {
+      clearInterval(pumpIdRef.current);
+      pumpIdRef.current = null;
+    }
+  }, []);
+
+  const startPump = useCallback(() => {
+    const audio = getAudio();
+    stopPump();
+    loopStartRef.current = audio.now() + 0.1;
+    nextPulseRef.current = 0;
+    scheduledCycleRef.current = -1;
+    const pump = () => {
+      const now = audio.now();
+      const due = pulsesToSchedule(
+        nextPulseRef.current,
+        loopStartRef.current,
+        now,
+        HORIZON_SEC,
+        cfg.pulseSec,
+      );
+      for (const p of due) {
+        const when = loopStartRef.current + p * cfg.pulseSec;
+        audio.tick(when, p % cfg.pulses === 0);
+        if (p % cfg.pulses === 0) {
+          const cycleIdx = p / cfg.pulses;
+          if (scheduledCycleRef.current < cycleIdx) {
+            scheduledCycleRef.current = cycleIdx;
+            for (const who of ["lead", "partner"] as Performer[]) {
+              for (const ev of layersRef.current[who]) {
+                audio.play(ev.soundId, who, eventTime(loopStartRef.current, cycleIdx, ev.t, cfg));
+              }
+            }
+          }
+        }
+      }
+      nextPulseRef.current += due.length;
+    };
+    pump();
+    pumpIdRef.current = window.setInterval(pump, PUMP_MS);
+  }, [cfg, getAudio, stopPump]);
+
+  useEffect(() => () => stopPump(), [stopPump]);
+
+  // visual clock: beat lights + replay motions, driven off the audio clock
+  useEffect(() => {
+    if (screen !== "studio") return;
+    let raf = 0;
+    const frame = () => {
+      const audio = audioRef.current;
+      if (audio) {
+        const tIn = (audio.now() - loopStartRef.current + cycleSec(cfg)) % cycleSec(cfg);
+        const slot = quantizeToSubdivision(tIn, cfg);
+        const pulse = Math.floor(tIn / cfg.pulseSec) % cfg.pulses;
+        setBeat(pulse);
+        if (slot !== lastSlotRef.current) {
+          lastSlotRef.current = slot;
+          for (const who of ["lead", "partner"] as Performer[]) {
+            const hit = layersRef.current[who].find((ev) => ev.t === slot);
+            if (hit) triggerMotion(who, hit.soundId);
+          }
+        }
+      }
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(raf);
+  }, [cfg, screen, triggerMotion]);
+
+  // ── group context (save mirrors Track Builder; graceful until Phase 5) ──
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const courses = (await api.get("/student/courses")) as { courseId: string }[];
+        if (!cancelled && Array.isArray(courses) && courses.length > 0) {
+          setCourseId(courses[0].courseId);
+          try {
+            const creations = (await api.get(
+              `/creations?courseId=${courses[0].courseId}`,
+            )) as { type: string; title: string | null }[];
+            if (!cancelled)
+              setGalleryTitles(
+                creations.filter((c) => c.type === "sound_duet").map((c) => c.title ?? ""),
+              );
+          } catch {
+            /* dup-name hint degrades gracefully */
+          }
+        }
+      } catch {
+        /* logged-out/dev: local-only mode still works */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // draft autosave (navigate-away safety)
+  const latestRef = useRef({ name, band, layers, progress, creationId });
+  latestRef.current = { name, band, layers, progress, creationId };
+  const persistDraft = useCallback(() => {
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(latestRef.current));
+    } catch {
+      /* quota: in-memory state still stands */
+    }
+  }, []);
+  useEffect(() => {
+    persistDraft();
+  }, [layers, name, progress, creationId, persistDraft]);
+  useEffect(() => () => persistDraft(), [persistDraft]);
+
+  useEffect(() => {
+    if (!saveNote) return;
+    const id = setTimeout(() => setSaveNote(null), 2500);
+    return () => clearTimeout(id);
+  }, [saveNote]);
+
+  // ── actions ──
+  const enterStudio = useCallback(() => {
+    titleInteraction(); // Start is itself a title interaction (idempotent)
+    if (layersRef.current.lead.length === 0 && layersRef.current.partner.length === 0) {
+      setLayers(MOOD_SEEDS[mood]); // starter pulse: the canvas is never blank
+    }
+    setScreen("studio");
+    startPump();
+  }, [mood, startPump, titleInteraction]);
+
+  const previewMood = useCallback(
+    (m: Mood) => {
+      titleInteraction();
+      setMood(m);
+      const audio = audioRef.current;
+      if (!audio || !gateRef.current?.isWarm()) return; // preview plays once warm
+      const seed = MOOD_SEEDS[m].lead;
+      const start = audio.now() + 0.05;
+      for (const ev of seed) {
+        audio.play(ev.soundId, "lead", start + (ev.t * cfg.pulseSec) / cfg.snapPerPulse);
+      }
+    },
+    [cfg, titleInteraction],
+  );
+
+  const onPad = useCallback(
+    (soundId: SoundId) => {
+      const audio = getAudio();
+      audio.play(soundId, performer); // warm path: fully synchronous, no await
+      triggerMotion(performer, soundId);
+      if (recording) {
+        const raw = (audio.now() - loopStartRef.current + cycleSec(cfg)) % cycleSec(cfg);
+        const slot = quantizeToSubdivision(raw, cfg);
+        setLayers((prev) => recordEvent(prev, performer, { t: slot, soundId }));
+      }
+    },
+    [cfg, getAudio, performer, recording, triggerMotion],
+  );
+
+  const stopTake = useCallback(() => {
+    setRecording(false);
+    const take = summarizeTake(layersRef.current);
+    if (!take.hadEvents) return;
+    takesRef.current += 1;
+    const before = latestRef.current.progress;
+    const after = advanceEchoProgress(before, take);
+    setProgress(after);
+
+    const queue: string[] = [];
+    if (!partnerUnlocked(band, before) && partnerUnlocked(band, after)) queue.push("partner");
+    for (const s of newlyUnlockedSounds(band, before, after)) queue.push(`sound.${s}`);
+    if (!spotsUnlocked(band, before) && spotsUnlocked(band, after)) queue.push("spots");
+    if (queue.length > 0) {
+      setAnnounceQueue((q) => [...q, ...queue]);
+      newlyUnlockedSounds(band, before, after).forEach((s) =>
+        newSoundCandidatesRef.current.add(s),
+      );
+    }
+
+    let newSoundUsed: SoundId | undefined;
+    for (const s of take.soundsInTake) {
+      if (newSoundCandidatesRef.current.has(s)) {
+        newSoundUsed = s;
+        newSoundCandidatesRef.current.delete(s);
+        break;
+      }
+    }
+    setWonder(
+      pickEchoWonder({
+        callAndResponse: detectCallAndResponse(layersRef.current),
+        restsUsed: detectRests(layersRef.current, cfg),
+        newSoundUsed,
+      }),
+    );
+  }, [band, cfg]);
+
+  const clearPerformerLayer = useCallback(() => {
+    layersReplacedRef.current += 1;
+    setLayers((prev) => ({ ...prev, [performer]: [] }));
+  }, [performer]);
+
+  const saveDuet = useCallback(async () => {
+    const duetName = latestRef.current.name;
+    if (!duetName) {
+      setShowNaming(true);
+      return;
+    }
+    const content = buildDuetContent(duetName, band, latestRef.current.layers, []);
+    if (!courseId) {
+      setSaveNote("local");
+      return;
+    }
+    try {
+      if (latestRef.current.creationId) {
+        await api.patch(`/creations/${latestRef.current.creationId}`, { content });
+      } else {
+        const created = (await api.post("/creations", {
+          courseId,
+          type: "sound_duet",
+          content,
+        })) as { id: string };
+        setCreationId(created.id);
+      }
+      setSaveNote("saved");
+    } catch {
+      setSaveNote("local"); // Phase 5 wires the allowlist; draft holds everything
+    }
+  }, [api, band, courseId]);
+
+  const shareDuet = useCallback(async () => {
+    if (!latestRef.current.creationId) await saveDuet();
+    const id = latestRef.current.creationId;
+    if (!id) return;
+    try {
+      await api.patch(`/creations/${id}`, { status: "COMPLETE" });
+      setShared(true);
+    } catch {
+      /* stays unshared */
+    }
+  }, [api, saveDuet]);
+
+  const done = useCallback(() => {
+    stopPump();
+    const familiesExplored = new Set(
+      [...latestRef.current.layers.lead, ...latestRef.current.layers.partner].map(
+        (ev) => soundSpec(ev.soundId).family,
+      ),
+    ).size;
+    onFinish(
+      buildEchoAvenueResult({
+        phraseRecorded: latestRef.current.progress.phrasesRecorded > 0,
+        overdubbed: latestRef.current.progress.layeredPhrases > 0,
+        layerReplaced: layersReplacedRef.current > 0,
+        shared,
+        takesRecorded: takesRef.current,
+        familiesExplored,
+      }),
+    );
+  }, [onFinish, shared, stopPump]);
+
+  // keyboard operability on the core loop (digits = pads, R = record, W = watch)
+  const recordingRef = useRef(recording);
+  recordingRef.current = recording;
+  useEffect(() => {
+    if (screen !== "studio") return;
+    const pads = unlockedSounds(band, progress);
+    const down = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement) return;
+      const idx = Number.parseInt(e.key, 10) - 1;
+      if (idx >= 0 && idx < pads.length) {
+        onPad(pads[idx]);
+      } else if (e.key.toLowerCase() === "r" && !watching) {
+        if (recordingRef.current) stopTake();
+        else setRecording(true);
+      } else if (e.key.toLowerCase() === "w") {
+        setWatching((w) => !w);
+      }
+    };
+    window.addEventListener("keydown", down);
+    return () => window.removeEventListener("keydown", down);
+  }, [band, onPad, progress, screen, stopTake, watching]);
+
+  // apply volume/mute
+  useEffect(() => {
+    audioRef.current?.setMasterVolume(muted ? 0 : masterVol);
+  }, [muted, masterVol]);
+
+  const pads = unlockedSounds(band, progress);
+  const hasPartner = partnerUnlocked(band, progress);
+  const nameTaken = isNameTaken(
+    tokenName(
+      pickLocale(tokenFirst.label, tokenFirst.label.en),
+      pickLocale(tokenSecond.label, tokenSecond.label.en),
+    ),
+    galleryTitles,
+  );
+
+  // ── Title / Imagine screen ──
+  if (screen === "title") {
+    return (
+      <div
+        className="flex flex-col items-center gap-4 py-6 px-4 text-center"
+        onPointerDown={titleInteraction}
+      >
+        <div className="flex items-end gap-6" aria-hidden>
+          <LeadFigure motion={null} />
+          <PartnerFigure motion={null} />
+        </div>
+        <h2 className="text-2xl font-extrabold text-slate-800">
+          {t("echoAvenue.title.prompt", {
+            defaultValue: "What will your duet sound like?",
+          })}
+        </h2>
+        <div className="flex flex-wrap justify-center gap-2">
+          {(["together", "echo", "space"] as Mood[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => previewMood(m)}
+              aria-pressed={mood === m}
+              className={`min-h-12 px-5 rounded-2xl border-[3px] font-extrabold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-4 focus-visible:outline-sky-500 ${
+                mood === m ? "border-sky-500 bg-sky-50" : "border-slate-200 bg-white"
+              }`}
+            >
+              {m === "together"
+                ? t("echoAvenue.title.moodTogether", { defaultValue: "🤝 Together" })
+                : m === "echo"
+                  ? t("echoAvenue.title.moodEcho", { defaultValue: "🔁 Echo" })
+                  : t("echoAvenue.title.moodSpace", { defaultValue: "🌙 Space" })}
+            </button>
+          ))}
+        </div>
+
+        {/* Sensory controls BEFORE Start (held-firm #3) */}
+        <div className="flex flex-wrap items-center justify-center gap-3 bg-white/70 rounded-2xl px-4 py-3">
+          <button
+            type="button"
+            onClick={() => setMuted((v) => !v)}
+            aria-pressed={muted}
+            className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+          >
+            {muted
+              ? t("echoAvenue.sensory.unmute", { defaultValue: "🔇 Sound off" })
+              : t("echoAvenue.sensory.mute", { defaultValue: "🔊 Sound on" })}
+          </button>
+          <label className="flex items-center gap-2 font-bold text-slate-700 text-sm">
+            {t("echoAvenue.sensory.volume", { defaultValue: "Volume" })}
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.1}
+              value={masterVol}
+              onChange={(e) => setMasterVol(Number(e.target.value))}
+              className="w-28 min-h-11"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => setCalmMode((v) => !v)}
+            aria-pressed={calmMode}
+            className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+          >
+            {t("echoAvenue.sensory.calm", { defaultValue: "🕊️ Calm lights" })}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={enterStudio}
+          className="min-h-14 px-10 rounded-full bg-green-600 text-white text-xl font-extrabold shadow-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-4 focus-visible:outline-green-300"
+        >
+          {t("echoAvenue.title.start", { defaultValue: "Open the studio!" })}
+        </button>
+        {draft && (
+          <p className="text-sm text-slate-500 font-semibold">
+            {t("echoAvenue.title.resume", { defaultValue: "Your last take is waiting inside." })}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ── Studio ──
+  return (
+    <div className="flex flex-col items-center gap-3 w-full px-2 pb-4">
+      {/* Stage */}
+      <div className="relative w-full max-w-xl rounded-3xl bg-gradient-to-b from-indigo-100 to-indigo-200 p-4 overflow-hidden">
+        <div className="flex items-end justify-around min-h-36">
+          <div className="flex flex-col items-center">
+            <div className="h-6 flex gap-1" aria-hidden>
+              {trails
+                .filter((tr) => tr.performer === "lead")
+                .map((tr) => (
+                  <span key={tr.id} className="ea-trail text-sm">
+                    {tr.icon}
+                  </span>
+                ))}
+            </div>
+            <LeadFigure motion={motionNow.lead} />
+            <span className="text-xs font-extrabold text-indigo-900">
+              {t("echoAvenue.studio.lead", { defaultValue: "Lead" })}
+            </span>
+          </div>
+          <div className="flex flex-col items-center">
+            <div className="h-6 flex gap-1" aria-hidden>
+              {trails
+                .filter((tr) => tr.performer === "partner")
+                .map((tr) => (
+                  <span key={tr.id} className="ea-trail text-sm">
+                    {tr.icon}
+                  </span>
+                ))}
+            </div>
+            <PartnerFigure motion={hasPartner ? motionNow.partner : null} />
+            <span className="text-xs font-extrabold text-indigo-900">
+              {hasPartner
+                ? t("echoAvenue.studio.partner", { defaultValue: "Partner" })
+                : t("echoAvenue.studio.partnerLocked", { defaultValue: "Partner (record a take!)" })}
+            </span>
+          </div>
+        </div>
+        {/* pulse lane (silent-mode duty: beat + sound-color flashes) */}
+        <div className="flex justify-center gap-2 mt-2" aria-hidden>
+          {Array.from({ length: cfg.pulses }, (_, i) => (
+            <div
+              key={i}
+              className={`w-6 h-6 rounded-full ${beat === i && !calm ? "ea-beat-now" : ""}`}
+              style={{
+                background: beat === i ? "#facc15" : "#c7d2fe",
+                ...(lightFlash && beat === i && !calm
+                  ? ({ "--ea-light": lightFlash.color } as React.CSSProperties)
+                  : {}),
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {watching ? (
+        /* Watch the Take — controls hidden; the performance carries itself */
+        <button
+          type="button"
+          onClick={() => setWatching(false)}
+          className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+        >
+          {t("echoAvenue.watch.done", { defaultValue: "Done watching" })}
+        </button>
+      ) : (
+        <>
+          {/* Performer tabs + layer mix */}
+          <div className="flex flex-wrap items-center justify-center gap-2 w-full max-w-xl">
+            {(["lead", "partner"] as Performer[]).map((who) => (
+              <button
+                key={who}
+                type="button"
+                disabled={who === "partner" && !hasPartner}
+                onClick={() => setPerformer(who)}
+                aria-pressed={performer === who}
+                className={`min-h-11 px-5 rounded-full font-extrabold active:scale-95 touch-manipulation disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 ${
+                  performer === who
+                    ? who === "lead"
+                      ? "bg-amber-500 text-white"
+                      : "bg-sky-500 text-white"
+                    : "bg-white border-2 border-slate-200 text-slate-700"
+                }`}
+              >
+                {who === "lead"
+                  ? t("echoAvenue.studio.lead", { defaultValue: "Lead" })
+                  : t("echoAvenue.studio.partner", { defaultValue: "Partner" })}{" "}
+                ({layers[who].length})
+              </button>
+            ))}
+            <label className="flex items-center gap-1 text-xs font-bold text-slate-600">
+              {t("echoAvenue.studio.layerVolume", { defaultValue: "Layer volume" })}
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.1}
+                defaultValue={1}
+                onChange={(e) =>
+                  audioRef.current?.setLayerVolume(performer, Number(e.target.value))
+                }
+                className="w-24 min-h-11"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => setMuted((v) => !v)}
+              aria-pressed={muted}
+              className="min-h-11 px-3 rounded-full bg-white border-2 border-slate-200 font-bold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+              aria-label={t("echoAvenue.sensory.muteAria", { defaultValue: "Toggle sound" })}
+            >
+              {muted ? "🔇" : "🔊"}
+            </button>
+          </div>
+
+          {/* Action pads — ≥64px, one-pointer, motion previews in the label */}
+          <div className="flex flex-wrap justify-center gap-3 w-full max-w-xl">
+            {pads.map((soundId, i) => {
+              const spec = soundSpec(soundId);
+              return (
+                <button
+                  key={soundId}
+                  type="button"
+                  onPointerDown={() => onPad(soundId)}
+                  className="rounded-3xl font-extrabold text-white shadow-md active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-4 focus-visible:outline-white"
+                  style={{ width: 84, height: 84, background: spec.lightColor }}
+                  aria-label={t(`echoAvenue.sound.${soundId}`, { defaultValue: soundId })}
+                >
+                  <span className="text-3xl block" aria-hidden>
+                    {spec.icon}
+                  </span>
+                  <span className="text-[10px] opacity-90">{i + 1}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Transport row */}
+          <div className="flex flex-wrap justify-center gap-2">
+            <button
+              type="button"
+              onClick={() => (recording ? stopTake() : setRecording(true))}
+              aria-pressed={recording}
+              className={`min-h-12 px-6 rounded-full font-extrabold text-white active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white ${
+                recording ? "bg-red-500" : "bg-slate-700"
+              }`}
+            >
+              {recording
+                ? t("echoAvenue.studio.stopTake", { defaultValue: "⏹ Finish the take" })
+                : t("echoAvenue.studio.record", { defaultValue: "● Record a take" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => setWatching(true)}
+              className="min-h-12 px-6 rounded-full bg-indigo-600 text-white font-extrabold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+            >
+              {t("echoAvenue.studio.watch", { defaultValue: "🎬 Watch the Take" })}
+            </button>
+            <button
+              type="button"
+              onClick={clearPerformerLayer}
+              className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+            >
+              {t("echoAvenue.studio.redoLayer", { defaultValue: "Redo this layer" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => void saveDuet()}
+              className="min-h-11 px-4 rounded-full bg-teal-600 text-white font-bold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+            >
+              {name
+                ? t("echoAvenue.studio.save", { defaultValue: "Save" })
+                : t("echoAvenue.studio.name", { defaultValue: "Name it" })}
+            </button>
+            {creationId && !shared && (
+              <button
+                type="button"
+                onClick={() => void shareDuet()}
+                className="min-h-11 px-4 rounded-full bg-violet-600 text-white font-bold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+              >
+                {t("echoAvenue.studio.share", { defaultValue: "Share ✨" })}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={done}
+              className="min-h-11 px-4 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+            >
+              {t("echoAvenue.studio.done", { defaultValue: "Done for now" })}
+            </button>
+          </div>
+          <p className="text-xs text-slate-500 font-semibold" role="status">
+            {name ? `🏷️ ${name}` : t("echoAvenue.studio.untitled", { defaultValue: "Untitled take" })}
+            {saveNote === "saved" && ` · ${t("echoAvenue.studio.saved", { defaultValue: "Saved ✓" })}`}
+            {saveNote === "local" &&
+              ` · ${t("echoAvenue.studio.savedLocal", { defaultValue: "Kept on this device ✓" })}`}
+          </p>
+        </>
+      )}
+
+      {/* Unlock announces (before Reflect — scaffolding announces itself) */}
+      {announceQueue.length > 0 && !wonder && (
+        <Overlay>
+          <div className="text-5xl" aria-hidden>
+            🎉
+          </div>
+          <h3 className="text-xl font-extrabold text-slate-800" role="status">
+            {announceQueue[0] === "partner"
+              ? t("echoAvenue.unlock.partner", {
+                  defaultValue: "Your Partner joins the stage! Overdub a second layer!",
+                })
+              : announceQueue[0] === "spots"
+                ? t("echoAvenue.unlock.spots", {
+                    defaultValue: "Sound spots opened! The tunnel and the puddle color your sounds!",
+                  })
+                : t(`echoAvenue.unlock.${announceQueue[0].replace("sound.", "")}`, {
+                    defaultValue: "You earned a new sound!",
+                  })}
+          </h3>
+          <button
+            type="button"
+            onClick={() => setAnnounceQueue((q) => q.slice(1))}
+            className="min-h-12 px-8 rounded-full bg-green-600 text-white font-extrabold text-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+          >
+            {t("echoAvenue.unlock.tryIt", { defaultValue: "Let's try it!" })}
+          </button>
+        </Overlay>
+      )}
+
+      {/* Reflect — ONE wondering question; a separate moment from naming */}
+      {wonder && (
+        <Overlay>
+          <div className="flex items-start gap-3 text-left w-full">
+            <div className="text-5xl" aria-hidden>
+              🎙️
+            </div>
+            <div className="flex-1 bg-white rounded-2xl p-3 font-bold text-lg text-slate-800 shadow">
+              {t(wonder.key, { defaultValue: "What would you try next?", ...(wonder.params ?? {}) })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setWonder(null)}
+            className="min-h-12 px-8 rounded-full bg-orange-500 text-white font-extrabold text-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+          >
+            {t("echoAvenue.reflect.keepMaking", { defaultValue: "Keep making" })}
+          </button>
+        </Overlay>
+      )}
+
+      {/* Naming — approved token pools only (kid-safety; no free text) */}
+      {showNaming && (
+        <Overlay>
+          <h3 className="text-xl font-extrabold text-slate-800">
+            {t("echoAvenue.name.title", { defaultValue: "Name your duet!" })}
+          </h3>
+          <p className="text-2xl font-black text-sky-700" role="status">
+            {pickLocale(tokenFirst.label, tokenFirst.label.en)}{" "}
+            {pickLocale(tokenSecond.label, tokenSecond.label.en)}
+          </p>
+          {nameTaken && (
+            <p className="text-amber-700 font-bold text-sm" role="status">
+              {t("echoAvenue.name.taken", {
+                defaultValue: "That name's taken — try a different mix!",
+              })}
+            </p>
+          )}
+          <div className="flex flex-wrap justify-center gap-2">
+            {ECHO_TOKENS_FIRST.map((tok) => (
+              <button
+                key={tok.id}
+                type="button"
+                onClick={() => setTokenFirst(tok)}
+                aria-pressed={tokenFirst.id === tok.id}
+                className={`min-h-11 px-4 rounded-full border-2 font-bold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 ${
+                  tokenFirst.id === tok.id
+                    ? "border-sky-500 bg-sky-50 text-sky-800"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
+              >
+                {pickLocale(tok.label, tok.label.en)}
+              </button>
+            ))}
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            {ECHO_TOKENS_SECOND.map((tok) => (
+              <button
+                key={tok.id}
+                type="button"
+                onClick={() => setTokenSecond(tok)}
+                aria-pressed={tokenSecond.id === tok.id}
+                className={`min-h-11 px-4 rounded-full border-2 font-bold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 ${
+                  tokenSecond.id === tok.id
+                    ? "border-green-500 bg-green-50 text-green-800"
+                    : "border-slate-200 bg-white text-slate-700"
+                }`}
+              >
+                {pickLocale(tok.label, tok.label.en)}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={nameTaken}
+              onClick={() => {
+                setName(
+                  tokenName(
+                    pickLocale(tokenFirst.label, tokenFirst.label.en),
+                    pickLocale(tokenSecond.label, tokenSecond.label.en),
+                  ),
+                );
+                setShowNaming(false);
+                setTimeout(() => void saveDuet(), 0);
+              }}
+              className="min-h-12 px-8 rounded-full bg-teal-600 text-white font-extrabold text-lg active:scale-95 touch-manipulation disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+            >
+              {t("echoAvenue.name.keep", { defaultValue: "That's it!" })}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowNaming(false)}
+              className="min-h-11 px-5 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+            >
+              {t("echoAvenue.name.later", { defaultValue: "Later" })}
+            </button>
+          </div>
+        </Overlay>
+      )}
+    </div>
+  );
+}
+
+function Overlay({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 z-40 bg-slate-900/50 flex items-center justify-center p-4 overflow-y-auto">
+      <div className="bg-[#fdf9f0] rounded-3xl p-5 w-full max-w-sm flex flex-col items-center gap-3 text-center shadow-2xl max-h-[90vh] overflow-y-auto">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── Shell wrapper (completion wiring mirrors Boost Track Builder) ───────────
+
+export default function EchoAvenueGame({
+  config,
+  onComplete,
+}: {
+  config?: unknown;
+  onComplete?: (result: GameResult) => void;
+}) {
+  const band: EchoBand =
+    (config as { gradeBand?: string } | undefined)?.gradeBand === "g3_5" ? "g35" : "k2";
+  return (
+    <GameShell
+      gameKey="echo_avenue"
+      title={pickLocale(
+        { en: "Echo Avenue", es: "Avenida del Eco", "zh-CN": "回声大道" },
+        "Echo Avenue",
+      )}
+      onComplete={onComplete ?? (() => {})}
+    >
+      {({ onFinish, reducedEffects }) => (
+        <EchoStudioCore onFinish={onFinish} reducedEffects={reducedEffects} band={band} />
+      )}
+    </GameShell>
+  );
+}

--- a/src/components/games/echoAvenue/EchoAvenueGame.tsx
+++ b/src/components/games/echoAvenue/EchoAvenueGame.tsx
@@ -26,6 +26,8 @@ import { useApi } from "@/services/api";
 import "./echoAvenue.css";
 import {
   BAND_CONFIG,
+  COVER_POSES,
+  COVER_POSE_ICONS,
   ECHO_TOKENS_FIRST,
   ECHO_TOKENS_SECOND,
   EMPTY_LAYERS,
@@ -49,6 +51,7 @@ import {
   summarizeTake,
   tokenName,
   unlockedSounds,
+  type CoverPose,
   type DuetLayers,
   type EchoBand,
   type EchoProgress,
@@ -177,6 +180,7 @@ export function EchoStudioCore({
   const [showNaming, setShowNaming] = useState(false);
   const [tokenFirst, setTokenFirst] = useState(ECHO_TOKENS_FIRST[0]);
   const [tokenSecond, setTokenSecond] = useState(ECHO_TOKENS_SECOND[0]);
+  const [coverPose, setCoverPose] = useState<CoverPose>("sideBySide");
 
   const [motionNow, setMotionNow] = useState<Record<Performer, string | null>>({
     lead: null,
@@ -349,6 +353,8 @@ export function EchoStudioCore({
   // draft autosave (navigate-away safety)
   const latestRef = useRef({ name, band, layers, progress, creationId });
   latestRef.current = { name, band, layers, progress, creationId };
+  const coverPoseRef = useRef(coverPose);
+  coverPoseRef.current = coverPose;
   const persistDraft = useCallback(() => {
     try {
       localStorage.setItem(DRAFT_KEY, JSON.stringify(latestRef.current));
@@ -454,7 +460,13 @@ export function EchoStudioCore({
       setShowNaming(true);
       return;
     }
-    const content = buildDuetContent(duetName, band, latestRef.current.layers, []);
+    const content = buildDuetContent(
+      duetName,
+      band,
+      latestRef.current.layers,
+      [],
+      coverPoseRef.current,
+    );
     if (!courseId) {
       setSaveNote("local");
       return;
@@ -687,14 +699,23 @@ export function EchoStudioCore({
       </div>
 
       {watching ? (
-        /* Watch the Take — controls hidden; the performance carries itself */
-        <button
-          type="button"
-          onClick={() => setWatching(false)}
-          className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
-        >
-          {t("echoAvenue.watch.done", { defaultValue: "Done watching" })}
-        </button>
+        /* Watch the Take — controls hidden; the two source-specified exits */
+        <div className="flex flex-wrap justify-center gap-2">
+          <button
+            type="button"
+            onClick={() => setWatching(false)}
+            className="min-h-12 px-8 rounded-full bg-amber-500 text-white font-extrabold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+          >
+            {t("echoAvenue.watch.joinIn", { defaultValue: "🎤 Join in!" })}
+          </button>
+          <button
+            type="button"
+            onClick={() => setWatching(false)}
+            className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+          >
+            {t("echoAvenue.watch.changeLayer", { defaultValue: "🔁 Change a layer" })}
+          </button>
+        </div>
       ) : (
         <>
           {/* Performer tabs + layer mix */}
@@ -875,7 +896,7 @@ export function EchoStudioCore({
             onClick={() => setWonder(null)}
             className="min-h-12 px-8 rounded-full bg-orange-500 text-white font-extrabold text-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
           >
-            {t("echoAvenue.reflect.keepMaking", { defaultValue: "Keep making" })}
+            {t("echoAvenue.reflect.backToStudio", { defaultValue: "Back to my studio" })}
           </button>
         </Overlay>
       )}
@@ -897,6 +918,28 @@ export function EchoStudioCore({
               })}
             </p>
           )}
+          {/* Cover pose — chosen at share time (source §Share) */}
+          <p className="text-sm font-bold text-slate-600">
+            {t("echoAvenue.name.poseTitle", { defaultValue: "Pick a cover pose" })}
+          </p>
+          <div className="flex justify-center gap-2">
+            {COVER_POSES.map((pose) => (
+              <button
+                key={pose}
+                type="button"
+                onClick={() => setCoverPose(pose)}
+                aria-pressed={coverPose === pose}
+                aria-label={t(`echoAvenue.pose.${pose}`, { defaultValue: pose })}
+                className={`min-w-14 min-h-12 px-3 rounded-2xl border-2 text-2xl active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 ${
+                  coverPose === pose
+                    ? "border-sky-500 bg-sky-50"
+                    : "border-slate-200 bg-white"
+                }`}
+              >
+                {COVER_POSE_ICONS[pose]}
+              </button>
+            ))}
+          </div>
           <div className="flex flex-wrap justify-center gap-2">
             {ECHO_TOKENS_FIRST.map((tok) => (
               <button

--- a/src/components/games/echoAvenue/EchoAvenueGame.tsx
+++ b/src/components/games/echoAvenue/EchoAvenueGame.tsx
@@ -56,6 +56,7 @@ import {
   type EchoBand,
   type EchoProgress,
   type Performer,
+  type SoundDuetContent,
   type SoundId,
 } from "./echoAvenueModel";
 import { getEchoAudio, type EchoAudio } from "./echoAvenueAudio";
@@ -140,6 +141,9 @@ export interface EchoStudioCoreProps {
   onFinish: (result: GameResult) => void;
   reducedEffects: boolean;
   band: EchoBand;
+  /** Peer watch mode: a classmate's saved duet — replay only, no editing,
+   *  no saving, and never touching the maker's own draft. */
+  fixedDuet?: SoundDuetContent | null;
   /** test seam — production uses the real singleton */
   audioFactory?: () => EchoAudio;
 }
@@ -148,20 +152,24 @@ export function EchoStudioCore({
   onFinish,
   reducedEffects,
   band,
+  fixedDuet = null,
   audioFactory = getEchoAudio,
 }: EchoStudioCoreProps) {
+  const watchOnly = !!fixedDuet;
   const { t } = useTranslation();
   const api = useApi();
   const cfg = BAND_CONFIG[band];
 
-  const draft = useMemo(loadDraft, []);
+  const draft = useMemo(() => (watchOnly ? null : loadDraft()), [watchOnly]);
   const [screen, setScreen] = useState<"title" | "studio">("title");
   const [mood, setMood] = useState<Mood>("together");
   const [calmMode, setCalmMode] = useState(false);
   const [muted, setMuted] = useState(false);
   const [masterVol, setMasterVol] = useState(0.9);
 
-  const [layers, setLayers] = useState<DuetLayers>(draft?.layers ?? EMPTY_LAYERS);
+  const [layers, setLayers] = useState<DuetLayers>(
+    fixedDuet?.layers ?? draft?.layers ?? EMPTY_LAYERS,
+  );
   const [progress, setProgress] = useState<EchoProgress>(
     draft?.progress ?? FRESH_ECHO_PROGRESS,
   );
@@ -322,6 +330,7 @@ export function EchoStudioCore({
 
   // ── group context (save mirrors Track Builder; graceful until Phase 5) ──
   useEffect(() => {
+    if (watchOnly) return;
     let cancelled = false;
     (async () => {
       try {
@@ -356,12 +365,13 @@ export function EchoStudioCore({
   const coverPoseRef = useRef(coverPose);
   coverPoseRef.current = coverPose;
   const persistDraft = useCallback(() => {
+    if (watchOnly) return; // a peer's duet must never clobber my own draft
     try {
       localStorage.setItem(DRAFT_KEY, JSON.stringify(latestRef.current));
     } catch {
       /* quota: in-memory state still stands */
     }
-  }, []);
+  }, [watchOnly]);
   useEffect(() => {
     persistDraft();
   }, [layers, name, progress, creationId, persistDraft]);
@@ -376,12 +386,17 @@ export function EchoStudioCore({
   // ── actions ──
   const enterStudio = useCallback(() => {
     titleInteraction(); // Start is itself a title interaction (idempotent)
-    if (layersRef.current.lead.length === 0 && layersRef.current.partner.length === 0) {
+    if (
+      !watchOnly &&
+      layersRef.current.lead.length === 0 &&
+      layersRef.current.partner.length === 0
+    ) {
       setLayers(MOOD_SEEDS[mood]); // starter pulse: the canvas is never blank
     }
+    if (watchOnly) setWatching(true); // a peer visit IS the watch
     setScreen("studio");
     startPump();
-  }, [mood, startPump, titleInteraction]);
+  }, [mood, startPump, titleInteraction, watchOnly]);
 
   const previewMood = useCallback(
     (m: Mood) => {
@@ -556,7 +571,8 @@ export function EchoStudioCore({
     galleryTitles,
   );
 
-  // ── Title / Imagine screen ──
+  // ── Title / Imagine screen (peer watch gets name + Watch — the required
+  //    user gesture that satisfies never-autoplay + wakes the engine) ──
   if (screen === "title") {
     return (
       <div
@@ -568,12 +584,15 @@ export function EchoStudioCore({
           <PartnerFigure motion={null} />
         </div>
         <h2 className="text-2xl font-extrabold text-slate-800">
-          {t("echoAvenue.title.prompt", {
-            defaultValue: "What will your duet sound like?",
-          })}
+          {watchOnly
+            ? fixedDuet!.name
+            : t("echoAvenue.title.prompt", {
+                defaultValue: "What will your duet sound like?",
+              })}
         </h2>
         <div className="flex flex-wrap justify-center gap-2">
-          {(["together", "echo", "space"] as Mood[]).map((m) => (
+          {!watchOnly &&
+            (["together", "echo", "space"] as Mood[]).map((m) => (
             <button
               key={m}
               type="button"
@@ -588,8 +607,8 @@ export function EchoStudioCore({
                 : m === "echo"
                   ? t("echoAvenue.title.moodEcho", { defaultValue: "🔁 Echo" })
                   : t("echoAvenue.title.moodSpace", { defaultValue: "🌙 Space" })}
-            </button>
-          ))}
+              </button>
+            ))}
         </div>
 
         {/* Sensory controls BEFORE Start (held-firm #3) */}
@@ -631,7 +650,9 @@ export function EchoStudioCore({
           onClick={enterStudio}
           className="min-h-14 px-10 rounded-full bg-green-600 text-white text-xl font-extrabold shadow-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-4 focus-visible:outline-green-300"
         >
-          {t("echoAvenue.title.start", { defaultValue: "Open the studio!" })}
+          {watchOnly
+            ? t("echoAvenue.title.watch", { defaultValue: "▶ Watch the duet" })
+            : t("echoAvenue.title.start", { defaultValue: "Open the studio!" })}
         </button>
         {draft && (
           <p className="text-sm text-slate-500 font-semibold">
@@ -699,22 +720,35 @@ export function EchoStudioCore({
       </div>
 
       {watching ? (
-        /* Watch the Take — controls hidden; the two source-specified exits */
+        /* Watch the Take — controls hidden. Makers get the two source-
+           specified exits; peers get a single Done (their visit IS the watch). */
         <div className="flex flex-wrap justify-center gap-2">
-          <button
-            type="button"
-            onClick={() => setWatching(false)}
-            className="min-h-12 px-8 rounded-full bg-amber-500 text-white font-extrabold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
-          >
-            {t("echoAvenue.watch.joinIn", { defaultValue: "🎤 Join in!" })}
-          </button>
-          <button
-            type="button"
-            onClick={() => setWatching(false)}
-            className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
-          >
-            {t("echoAvenue.watch.changeLayer", { defaultValue: "🔁 Change a layer" })}
-          </button>
+          {watchOnly ? (
+            <button
+              type="button"
+              onClick={done}
+              className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+            >
+              {t("echoAvenue.watch.doneWatching", { defaultValue: "Done watching" })}
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => setWatching(false)}
+                className="min-h-12 px-8 rounded-full bg-amber-500 text-white font-extrabold active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+              >
+                {t("echoAvenue.watch.joinIn", { defaultValue: "🎤 Join in!" })}
+              </button>
+              <button
+                type="button"
+                onClick={() => setWatching(false)}
+                className="min-h-12 px-8 rounded-full bg-white border-2 border-slate-300 font-extrabold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
+              >
+                {t("echoAvenue.watch.changeLayer", { defaultValue: "🔁 Change a layer" })}
+              </button>
+            </>
+          )}
         </div>
       ) : (
         <>
@@ -1021,12 +1055,56 @@ function Overlay({ children }: { children: React.ReactNode }) {
 export default function EchoAvenueGame({
   config,
   onComplete,
+  secondaryAction,
 }: {
   config?: unknown;
   onComplete?: (result: GameResult) => void;
+  secondaryAction?: { label: string; icon?: React.ReactNode; onClick: () => void };
 }) {
+  const { t } = useTranslation();
   const band: EchoBand =
     (config as { gradeBand?: string } | undefined)?.gradeBand === "g3_5" ? "g35" : "k2";
+
+  // Peer watch mode (ChallengePlayer passes the saved duet as config.soundDuet).
+  const rawDuet = (config as { soundDuet?: unknown } | undefined)?.soundDuet;
+  const fixedDuet =
+    rawDuet && typeof rawDuet === "object" && Array.isArray((rawDuet as SoundDuetContent).layers?.lead)
+      ? (rawDuet as SoundDuetContent)
+      : null;
+  if (rawDuet !== undefined && rawDuet !== null && !fixedDuet) {
+    // Server validation makes this unreachable; degrade kindly, never crash.
+    return (
+      <div className="p-6 text-center text-slate-600">
+        {t("echoAvenue.watch.notAvailable", {
+          defaultValue: "This duet can't play right now. Try another one!",
+        })}
+      </div>
+    );
+  }
+  if (fixedDuet) {
+    // Watching a classmate is for fun — no GameShell results screen, so a
+    // peer visit never ends on a score/star card (nothing to grade).
+    return (
+      <div className="flex flex-col items-center gap-3 py-4">
+        <EchoStudioCore
+          onFinish={(result) => onComplete?.(result)}
+          reducedEffects={false}
+          band={fixedDuet.band === "g35" ? "g35" : "k2"}
+          fixedDuet={fixedDuet}
+        />
+        {secondaryAction && (
+          <button
+            type="button"
+            onClick={secondaryAction.onClick}
+            className="min-h-11 px-5 rounded-full bg-white border-2 border-slate-300 font-bold text-slate-700 active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500 inline-flex items-center"
+          >
+            {secondaryAction.icon}
+            {secondaryAction.label}
+          </button>
+        )}
+      </div>
+    );
+  }
   return (
     <GameShell
       gameKey="echo_avenue"
@@ -1035,6 +1113,7 @@ export default function EchoAvenueGame({
         "Echo Avenue",
       )}
       onComplete={onComplete ?? (() => {})}
+      secondaryAction={secondaryAction}
     >
       {({ onFinish, reducedEffects }) => (
         <EchoStudioCore onFinish={onFinish} reducedEffects={reducedEffects} band={band} />

--- a/src/components/games/echoAvenue/echoAvenue.css
+++ b/src/components/games/echoAvenue/echoAvenue.css
@@ -1,0 +1,88 @@
+/* Echo Avenue — motion signatures + stage effects.
+   Every sound has a DISTINCT motion (silent-mode duty, design §7).
+   All animation sits behind the prefers-reduced-motion guard at the bottom. */
+
+@keyframes ea-stride {
+  0% { transform: translateX(0); }
+  40% { transform: translateX(14px) translateY(-4px); }
+  100% { transform: translateX(0); }
+}
+@keyframes ea-bounce {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  35% { transform: translateY(-18px) scaleY(1.05); }
+  70% { transform: translateY(0) scaleY(0.92); }
+}
+@keyframes ea-armSnap {
+  0%, 100% { transform: rotate(0deg); }
+  30% { transform: rotate(-10deg) scale(1.06); }
+  60% { transform: rotate(8deg); }
+}
+@keyframes ea-nod {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(6px) rotate(3deg); }
+}
+@keyframes ea-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+@keyframes ea-sparkleTurn {
+  0% { transform: rotate(0deg) scale(1); }
+  50% { transform: rotate(-180deg) scale(1.12); }
+  100% { transform: rotate(-360deg) scale(1); }
+}
+@keyframes ea-glide {
+  0% { transform: translateX(0) skewX(0deg); }
+  50% { transform: translateX(20px) skewX(-8deg); }
+  100% { transform: translateX(0) skewX(0deg); }
+}
+@keyframes ea-sway {
+  0%, 100% { transform: rotate(0deg); }
+  33% { transform: rotate(-6deg); }
+  66% { transform: rotate(6deg); }
+}
+
+.ea-motion-stride { animation: ea-stride 0.4s ease-out; }
+.ea-motion-bounce { animation: ea-bounce 0.45s ease-out; }
+.ea-motion-armSnap { animation: ea-armSnap 0.35s ease-out; }
+.ea-motion-nod { animation: ea-nod 0.3s ease-out; }
+.ea-motion-spin { animation: ea-spin 0.45s ease-out; }
+.ea-motion-sparkleTurn { animation: ea-sparkleTurn 0.5s ease-out; }
+.ea-motion-glide { animation: ea-glide 0.45s ease-out; }
+.ea-motion-sway { animation: ea-sway 0.5s ease-in-out; }
+
+/* pulse-lane light flash (silent-mode duty: color = sound identity) */
+@keyframes ea-lightflash {
+  0% { box-shadow: 0 0 0 0 var(--ea-light, #fff); opacity: 1; }
+  100% { box-shadow: 0 0 26px 10px transparent; opacity: 0.9; }
+}
+.ea-light-flash { animation: ea-lightflash 0.35s ease-out; }
+
+/* trail glyphs drift up and fade */
+@keyframes ea-trail {
+  0% { transform: translateY(0); opacity: 0.95; }
+  100% { transform: translateY(-26px); opacity: 0; }
+}
+.ea-trail { animation: ea-trail 0.9s ease-out forwards; }
+
+/* beat pulse for the lane dots */
+@keyframes ea-beat {
+  0% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+.ea-beat-now { animation: ea-beat 0.25s ease-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ea-motion-stride,
+  .ea-motion-bounce,
+  .ea-motion-armSnap,
+  .ea-motion-nod,
+  .ea-motion-spin,
+  .ea-motion-sparkleTurn,
+  .ea-motion-glide,
+  .ea-motion-sway,
+  .ea-light-flash,
+  .ea-trail,
+  .ea-beat-now {
+    animation: none;
+  }
+}

--- a/src/components/games/echoAvenue/echoAvenueAudio.ts
+++ b/src/components/games/echoAvenue/echoAvenueAudio.ts
@@ -1,0 +1,153 @@
+/**
+ * Echo Avenue — WebAudio synthesis layer. ALL sounds are synthesized from
+ * oscillator/noise primitives: zero audio asset files, zero licensing
+ * surface. Voices are loudness-normalized by per-voice peak gains.
+ *
+ * Latency discipline (proven by /dev/echo-spike, kept as the regression
+ * harness): AudioContext created with latencyHint:'interactive';
+ * `prewarm()` MUST be called on the Start screen's first user interaction so
+ * the ~1s engine wake is never paid by the child's first musical tap
+ * (design doc ruling 10 — tested in the studio).
+ *
+ * This module is deliberately thin and untested in jsdom (no AudioContext
+ * there); everything decision-shaped lives in echoAvenueModel.ts.
+ */
+import type { SoundId } from "./echoAvenueModel";
+
+export interface EchoAudio {
+  ctx: AudioContext;
+  master: GainNode;
+  layerGain: Record<"lead" | "partner", GainNode>;
+  /** resolves once the context is running — call on the FIRST user gesture */
+  prewarm: () => Promise<void>;
+  play: (soundId: SoundId, performer: "lead" | "partner", when?: number) => void;
+  tick: (when: number, downbeat: boolean) => void;
+  setMasterVolume: (v: number) => void;
+  setLayerVolume: (performer: "lead" | "partner", v: number) => void;
+  now: () => number;
+}
+
+let singleton: EchoAudio | null = null;
+
+export function getEchoAudio(): EchoAudio {
+  if (singleton) return singleton;
+
+  const ctx = new AudioContext({ latencyHint: "interactive" });
+  const master = ctx.createGain();
+  master.gain.value = 0.9;
+  master.connect(ctx.destination);
+  const lead = ctx.createGain();
+  const partner = ctx.createGain();
+  lead.connect(master);
+  partner.connect(master);
+
+  // One second of noise, rendered once (claps, whooshes, breezes).
+  const noise = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+  const data = noise.getChannelData(0);
+  for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+
+  const out = (performer: "lead" | "partner") => (performer === "lead" ? lead : partner);
+
+  function osc(
+    dest: GainNode,
+    when: number,
+    type: OscillatorType,
+    f0: number,
+    f1: number | null,
+    peak: number,
+    dur: number,
+  ) {
+    const o = ctx.createOscillator();
+    const g = ctx.createGain();
+    o.type = type;
+    o.frequency.setValueAtTime(f0, when);
+    if (f1 !== null) o.frequency.exponentialRampToValueAtTime(f1, when + dur * 0.9);
+    g.gain.setValueAtTime(peak, when);
+    g.gain.exponentialRampToValueAtTime(0.001, when + dur);
+    o.connect(g);
+    g.connect(dest);
+    o.start(when);
+    o.stop(when + dur + 0.05);
+  }
+
+  function noiseHit(
+    dest: GainNode,
+    when: number,
+    freq0: number,
+    freq1: number | null,
+    q: number,
+    peak: number,
+    dur: number,
+  ) {
+    const src = ctx.createBufferSource();
+    src.buffer = noise;
+    const bp = ctx.createBiquadFilter();
+    bp.type = "bandpass";
+    bp.frequency.setValueAtTime(freq0, when);
+    if (freq1 !== null) bp.frequency.exponentialRampToValueAtTime(freq1, when + dur * 0.9);
+    bp.Q.value = q;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(peak, when);
+    g.gain.exponentialRampToValueAtTime(0.001, when + dur);
+    src.connect(bp);
+    bp.connect(g);
+    g.connect(dest);
+    src.start(when, Math.random() * 0.5, dur + 0.05);
+  }
+
+  const play: EchoAudio["play"] = (soundId, performer, when = ctx.currentTime) => {
+    const dest = out(performer);
+    switch (soundId) {
+      case "step":
+        osc(dest, when, "sine", 130, 48, 0.9, 0.18);
+        break;
+      case "stomp":
+        osc(dest, when, "sine", 90, 36, 1.0, 0.3);
+        break;
+      case "clap":
+        for (let i = 0; i < 3; i++)
+          noiseHit(dest, when + i * 0.012, 2000, null, 1.2, i === 2 ? 0.55 : 0.3, i === 2 ? 0.12 : 0.03);
+        break;
+      case "tap":
+        noiseHit(dest, when, 3200, null, 3, 0.5, 0.05);
+        break;
+      case "chime":
+        osc(dest, when, "triangle", 880, null, 0.5, 0.4);
+        osc(dest, when, "triangle", 1318.5, null, 0.25, 0.35);
+        break;
+      case "twinkle":
+        osc(dest, when, "triangle", 1568, null, 0.35, 0.25);
+        osc(dest, when + 0.07, "triangle", 2093, null, 0.3, 0.3);
+        break;
+      case "whoosh":
+        noiseHit(dest, when, 400, 2400, 2.5, 0.6, 0.3);
+        break;
+      case "breeze":
+        noiseHit(dest, when, 1200, 500, 1.4, 0.4, 0.45);
+        break;
+    }
+  };
+
+  const tick: EchoAudio["tick"] = (when, downbeat) => {
+    osc(master, when, "sine", downbeat ? 1200 : 900, null, downbeat ? 0.14 : 0.08, 0.05);
+  };
+
+  singleton = {
+    ctx,
+    master,
+    layerGain: { lead, partner },
+    prewarm: async () => {
+      if (ctx.state !== "running") await ctx.resume();
+    },
+    play,
+    tick,
+    setMasterVolume: (v) => {
+      master.gain.value = Math.max(0, Math.min(1, v));
+    },
+    setLayerVolume: (performer, v) => {
+      out(performer).gain.value = Math.max(0, Math.min(1, v));
+    },
+    now: () => ctx.currentTime,
+  };
+  return singleton;
+}

--- a/src/components/games/echoAvenue/echoAvenueModel.ts
+++ b/src/components/games/echoAvenue/echoAvenueModel.ts
@@ -185,8 +185,11 @@ export const FRESH_ECHO_PROGRESS: EchoProgress = {
   soundsUsed: [],
 };
 
-export const K2_START_SOUNDS: SoundId[] = ["step", "chime"];
-const K2_UNLOCK_1: SoundId[] = ["clap", "whoosh"]; // first phrase
+// Source-reconciled K-2 opening: Step + Clap pads first; the first phrase
+// brings the Partner plus Chime/Whoosh; the first layered phrase reveals the
+// sound spot plus Stomp/Twinkle (design doc §7).
+export const K2_START_SOUNDS: SoundId[] = ["step", "clap"];
+const K2_UNLOCK_1: SoundId[] = ["chime", "whoosh"]; // first phrase
 const K2_UNLOCK_2: SoundId[] = ["stomp", "twinkle"]; // first layered phrase
 
 export function unlockedSounds(band: EchoBand, p: EchoProgress): SoundId[] {
@@ -357,6 +360,16 @@ export function buildEchoAvenueResult(s: EchoSessionSummary): GameResult {
 
 // ── Persisted content shape (validated server-side in soundDuet.ts) ─────────
 
+/** The gallery card's cover pose — chosen at share time (design doc §6). */
+export const COVER_POSES = ["sideBySide", "highFive", "backToBack"] as const;
+export type CoverPose = (typeof COVER_POSES)[number];
+
+export const COVER_POSE_ICONS: Record<CoverPose, string> = {
+  sideBySide: "🧍🧍",
+  highFive: "🙌",
+  backToBack: "🔄",
+};
+
 export interface SoundDuetContent {
   v: 1;
   name: string;
@@ -364,6 +377,7 @@ export interface SoundDuetContent {
   pulses: number;
   layers: DuetLayers;
   spots: ("tunnel" | "puddle")[];
+  coverPose: CoverPose;
 }
 
 export function buildDuetContent(
@@ -371,6 +385,7 @@ export function buildDuetContent(
   band: EchoBand,
   layers: DuetLayers,
   spots: ("tunnel" | "puddle")[],
+  coverPose: CoverPose = "sideBySide",
 ): SoundDuetContent {
-  return { v: 1, name, band, pulses: BAND_CONFIG[band].pulses, layers, spots };
+  return { v: 1, name, band, pulses: BAND_CONFIG[band].pulses, layers, spots, coverPose };
 }

--- a/src/components/games/echoAvenue/echoAvenueModel.ts
+++ b/src/components/games/echoAvenue/echoAvenueModel.ts
@@ -1,0 +1,376 @@
+/**
+ * Echo Avenue — pure engine model (Set 3 · slot 3 · "mastery through making").
+ *
+ * Everything timing-critical is integer subdivision math on the cycle grid —
+ * events persist as grid indices, never float seconds, so replay is exact and
+ * drift-impossible by construction. All functions here are pure and
+ * mock-clock testable; the WebAudio layer lives in ./echoAvenueAudio.ts.
+ *
+ * Non-negotiables from docs/games/echo-avenue-design.md:
+ * - NO scores/stars/timers/verdicts/win-lose/correct-rhythms anywhere.
+ * - Quantization is a scaffold (every tap lands musically) AND the
+ *   hardware-latency shock absorber (§3 of the design doc).
+ * - Unlocks respond to MAKING (phrases, layers) — never accuracy; ignoring
+ *   every prompt still unlocks everything by making.
+ */
+import type { GameResult } from "../shared/GameShell";
+
+// ── Sounds (all synthesized; each pairs with a silent-mode signature) ───────
+
+export type Performer = "lead" | "partner";
+export type SoundFamily = "steps" | "hands" | "bells" | "air";
+export const SOUND_IDS = [
+  "step",
+  "stomp",
+  "clap",
+  "tap",
+  "chime",
+  "twinkle",
+  "whoosh",
+  "breeze",
+] as const;
+export type SoundId = (typeof SOUND_IDS)[number];
+
+export interface SoundSpec {
+  id: SoundId;
+  family: SoundFamily;
+  icon: string;
+  /** motion signature id — the animation the performer plays (silent-mode duty) */
+  motion: "stride" | "bounce" | "armSnap" | "nod" | "spin" | "sparkleTurn" | "glide" | "sway";
+  /** pulse-light color flashed on the beat lane (silent-mode duty) */
+  lightColor: string;
+  /** trail glyph left on the stage strip (silent-mode duty) */
+  trail: "ripple" | "flash" | "sparkle" | "streak";
+}
+
+export const SOUND_SET: SoundSpec[] = [
+  { id: "step", family: "steps", icon: "🦶", motion: "stride", lightColor: "#8b5cf6", trail: "ripple" },
+  { id: "stomp", family: "steps", icon: "🐘", motion: "bounce", lightColor: "#6d28d9", trail: "ripple" },
+  { id: "clap", family: "hands", icon: "👏", motion: "armSnap", lightColor: "#f59e0b", trail: "flash" },
+  { id: "tap", family: "hands", icon: "👆", motion: "nod", lightColor: "#fbbf24", trail: "flash" },
+  { id: "chime", family: "bells", icon: "🔔", motion: "spin", lightColor: "#0ea5e9", trail: "sparkle" },
+  { id: "twinkle", family: "bells", icon: "✨", motion: "sparkleTurn", lightColor: "#38bdf8", trail: "sparkle" },
+  { id: "whoosh", family: "air", icon: "💨", motion: "glide", lightColor: "#10b981", trail: "streak" },
+  { id: "breeze", family: "air", icon: "🍃", motion: "sway", lightColor: "#34d399", trail: "streak" },
+];
+
+export function soundSpec(id: SoundId): SoundSpec {
+  return SOUND_SET.find((s) => s.id === id)!;
+}
+
+// ── Cycle model ─────────────────────────────────────────────────────────────
+
+export type EchoBand = "k2" | "g35"; // 6-8 is documented future intent, not built
+
+export interface BandConfig {
+  pulses: number;
+  pulseSec: number;
+  /** snap subdivisions per pulse (the quantization scaffold) */
+  snapPerPulse: number;
+}
+
+export const BAND_CONFIG: Record<EchoBand, BandConfig> = {
+  k2: { pulses: 4, pulseSec: 0.6, snapPerPulse: 2 }, // 100 BPM, 8 slots
+  g35: { pulses: 8, pulseSec: 0.6, snapPerPulse: 2 }, // 16 slots
+};
+
+export function subdivisions(cfg: BandConfig): number {
+  return cfg.pulses * cfg.snapPerPulse;
+}
+export function cycleSec(cfg: BandConfig): number {
+  return cfg.pulses * cfg.pulseSec;
+}
+
+/**
+ * Quantize a raw offset (seconds into the cycle) to the nearest subdivision,
+ * WRAPPING at the cycle boundary: a tap a hair before the loop point lands on
+ * slot 0 of the next pass, never on a phantom slot past the end.
+ */
+export function quantizeToSubdivision(rawOffsetSec: number, cfg: BandConfig): number {
+  const subSec = cfg.pulseSec / cfg.snapPerPulse;
+  const total = subdivisions(cfg);
+  const idx = Math.round(rawOffsetSec / subSec);
+  return ((idx % total) + total) % total;
+}
+
+export function subdivisionTime(t: number, cfg: BandConfig): number {
+  return t * (cfg.pulseSec / cfg.snapPerPulse);
+}
+
+// ── Scheduler math (the lookahead pump's brain; mock-clock testable) ────────
+
+/** Pulse indices whose start times fall inside the lookahead horizon. */
+export function pulsesToSchedule(
+  nextPulse: number,
+  loopStart: number,
+  now: number,
+  horizonSec: number,
+  pulseSec: number,
+): number[] {
+  const out: number[] = [];
+  let p = nextPulse;
+  while (loopStart + p * pulseSec < now + horizonSec) {
+    out.push(p);
+    p += 1;
+  }
+  return out;
+}
+
+/** Absolute AudioContext time of an event in a given cycle pass. */
+export function eventTime(
+  loopStart: number,
+  cycleIdx: number,
+  t: number,
+  cfg: BandConfig,
+): number {
+  return loopStart + cycleIdx * cycleSec(cfg) + subdivisionTime(t, cfg);
+}
+
+// ── Layers ──────────────────────────────────────────────────────────────────
+
+export interface DuetEvent {
+  t: number; // subdivision index
+  soundId: SoundId;
+}
+
+export interface DuetLayers {
+  lead: DuetEvent[];
+  partner: DuetEvent[];
+}
+
+export const EMPTY_LAYERS: DuetLayers = { lead: [], partner: [] };
+
+export function recordEvent(
+  layers: DuetLayers,
+  performer: Performer,
+  ev: DuetEvent,
+): DuetLayers {
+  return { ...layers, [performer]: [...layers[performer], ev] };
+}
+
+/** Re-recording replaces ONE layer; the other is untouched (tested invariant). */
+export function replaceLayer(
+  layers: DuetLayers,
+  performer: Performer,
+  events: DuetEvent[],
+): DuetLayers {
+  return { ...layers, [performer]: events };
+}
+
+export function clearLayer(layers: DuetLayers, performer: Performer): DuetLayers {
+  return replaceLayer(layers, performer, []);
+}
+
+export function totalEvents(layers: DuetLayers): number {
+  return layers.lead.length + layers.partner.length;
+}
+
+// ── Unlock ladder (fast pacing — founder-review flag; making, never accuracy) ─
+
+export interface EchoProgress {
+  /** completed recorded takes with ≥1 event */
+  phrasesRecorded: number;
+  /** takes where BOTH performers had events */
+  layeredPhrases: number;
+  layersReplaced: number;
+  shared: boolean;
+  soundsUsed: SoundId[];
+}
+
+export const FRESH_ECHO_PROGRESS: EchoProgress = {
+  phrasesRecorded: 0,
+  layeredPhrases: 0,
+  layersReplaced: 0,
+  shared: false,
+  soundsUsed: [],
+};
+
+export const K2_START_SOUNDS: SoundId[] = ["step", "chime"];
+const K2_UNLOCK_1: SoundId[] = ["clap", "whoosh"]; // first phrase
+const K2_UNLOCK_2: SoundId[] = ["stomp", "twinkle"]; // first layered phrase
+
+export function unlockedSounds(band: EchoBand, p: EchoProgress): SoundId[] {
+  if (band !== "k2") return [...SOUND_IDS];
+  const out: SoundId[] = [...K2_START_SOUNDS];
+  if (p.phrasesRecorded >= 1) out.push(...K2_UNLOCK_1);
+  if (p.layeredPhrases >= 1) out.push(...K2_UNLOCK_2);
+  return out;
+}
+
+/** The Partner joins after the child's first recorded phrase (K-2). */
+export function partnerUnlocked(band: EchoBand, p: EchoProgress): boolean {
+  return band !== "k2" || p.phrasesRecorded >= 1;
+}
+
+/** The two curated sound spots open with the first layered phrase (K-2). */
+export function spotsUnlocked(band: EchoBand, p: EchoProgress): boolean {
+  return band !== "k2" || p.layeredPhrases >= 1;
+}
+
+export function newlyUnlockedSounds(
+  band: EchoBand,
+  before: EchoProgress,
+  after: EchoProgress,
+): SoundId[] {
+  const prev = new Set(unlockedSounds(band, before));
+  return unlockedSounds(band, after).filter((id) => !prev.has(id));
+}
+
+export interface TakeSummary {
+  hadEvents: boolean;
+  bothPerformers: boolean;
+  soundsInTake: SoundId[];
+}
+
+export function summarizeTake(layers: DuetLayers): TakeSummary {
+  return {
+    hadEvents: totalEvents(layers) > 0,
+    bothPerformers: layers.lead.length > 0 && layers.partner.length > 0,
+    soundsInTake: [
+      ...new Set([...layers.lead, ...layers.partner].map((ev) => ev.soundId)),
+    ],
+  };
+}
+
+export function advanceEchoProgress(p: EchoProgress, take: TakeSummary): EchoProgress {
+  if (!take.hadEvents) return p; // an empty take advances nothing (and costs nothing)
+  return {
+    ...p,
+    phrasesRecorded: p.phrasesRecorded + 1,
+    layeredPhrases: p.layeredPhrases + (take.bothPerformers ? 1 : 0),
+    soundsUsed: [...new Set([...p.soundsUsed, ...take.soundsInTake])],
+  };
+}
+
+// ── Reflect: the mascot's ONE wondering question (separate from naming) ─────
+
+export interface EchoWonderContext {
+  callAndResponse: boolean;
+  restsUsed: boolean;
+  newSoundUsed?: SoundId;
+}
+
+/** Call-and-response: both performers played, and the Partner's hits all sit
+ *  in the Lead's gaps (no shared slots) — the simplest honest detector. */
+export function detectCallAndResponse(layers: DuetLayers): boolean {
+  if (layers.lead.length === 0 || layers.partner.length === 0) return false;
+  const leadSlots = new Set(layers.lead.map((ev) => ev.t));
+  return layers.partner.every((ev) => !leadSlots.has(ev.t));
+}
+
+/** Rests: at least two grid slots left intentionally empty (and something played). */
+export function detectRests(layers: DuetLayers, cfg: BandConfig): boolean {
+  if (totalEvents(layers) === 0) return false;
+  const occupied = new Set([...layers.lead, ...layers.partner].map((ev) => ev.t));
+  return subdivisions(cfg) - occupied.size >= 2;
+}
+
+export function pickEchoWonder(
+  ctx: EchoWonderContext,
+  rand: () => number = Math.random,
+): { key: string; params?: Record<string, unknown> } {
+  if (ctx.newSoundUsed) return { key: `echoAvenue.wonder.newSound.${ctx.newSoundUsed}` };
+  if (ctx.callAndResponse) return { key: "echoAvenue.wonder.callResponse" };
+  if (ctx.restsUsed) return { key: "echoAvenue.wonder.rests" };
+  return rand() < 0.5
+    ? { key: "echoAvenue.wonder.favorite" }
+    : { key: "echoAvenue.wonder.next" };
+}
+
+// ── Naming: approved localized token pools only (no free text — kid-safety) ─
+
+type LocalizedLabel = Record<string, string>;
+
+export interface NameToken {
+  id: string;
+  label: LocalizedLabel; // per-locale curated pools, not word-by-word translation
+}
+
+export const ECHO_TOKENS_FIRST: NameToken[] = [
+  { id: "midnight", label: { en: "Midnight", es: "Medianoche", "zh-CN": "午夜" } },
+  { id: "sunny", label: { en: "Sunny", es: "Soleado", "zh-CN": "阳光" } },
+  { id: "bouncy", label: { en: "Bouncy", es: "Saltarín", "zh-CN": "蹦蹦" } },
+  { id: "quiet", label: { en: "Quiet", es: "Tranquilo", "zh-CN": "安静" } },
+  { id: "double", label: { en: "Double", es: "Doble", "zh-CN": "双重" } },
+  { id: "electric", label: { en: "Electric", es: "Eléctrico", "zh-CN": "闪电" } },
+];
+
+export const ECHO_TOKENS_SECOND: NameToken[] = [
+  { id: "echo", label: { en: "Echo", es: "Eco", "zh-CN": "回声" } },
+  { id: "parade", label: { en: "Parade", es: "Desfile", "zh-CN": "巡游" } },
+  { id: "groove", label: { en: "Groove", es: "Ritmo", "zh-CN": "节奏" } },
+  { id: "shuffle", label: { en: "Shuffle", es: "Pasitos", "zh-CN": "小步舞" } },
+  { id: "duet", label: { en: "Duet", es: "Dúo", "zh-CN": "二重奏" } },
+  { id: "avenue", label: { en: "Avenue", es: "Avenida", "zh-CN": "大道" } },
+];
+
+export function tokenName(first: string, second: string): string {
+  return `${first} ${second}`.trim().slice(0, 24);
+}
+
+/** Duplicate titles are handled by a recombination hint, never an error. */
+export function isNameTaken(
+  name: string,
+  existingTitles: (string | null | undefined)[],
+): boolean {
+  const target = name.trim().toLowerCase();
+  return existingTitles.some((t) => !!t && t.trim().toLowerCase() === target);
+}
+
+// ── Completion payload — mirrors Boost Track Builder EXACTLY (no verdicts) ──
+
+export interface EchoSessionSummary {
+  phraseRecorded: boolean;
+  overdubbed: boolean;
+  layerReplaced: boolean;
+  shared: boolean;
+  takesRecorded: number;
+  familiesExplored: number;
+}
+
+export const ECHO_AVENUE_TOTAL = 6;
+
+/**
+ * Flat participation-shaped score (integer, platform byte-compatible):
+ * recorded a phrase (+2), overdubbed the Partner (+2), revised a layer (+1),
+ * shared (+1). Nothing in-game ever displays this — zero verdict UI.
+ */
+export function buildEchoAvenueResult(s: EchoSessionSummary): GameResult {
+  const score =
+    (s.phraseRecorded ? 2 : 0) +
+    (s.overdubbed ? 2 : 0) +
+    (s.layerReplaced ? 1 : 0) +
+    (s.shared ? 1 : 0);
+  return {
+    gameKey: "echo_avenue",
+    score,
+    total: ECHO_AVENUE_TOTAL,
+    streakMax: 0, // no streak concept exists in this game — flat by design
+    roundsCompleted: s.takesRecorded,
+    gameSpecific: {
+      takesRecorded: s.takesRecorded,
+      familiesExplored: s.familiesExplored,
+      shared: s.shared,
+    },
+  };
+}
+
+// ── Persisted content shape (validated server-side in soundDuet.ts) ─────────
+
+export interface SoundDuetContent {
+  v: 1;
+  name: string;
+  band: EchoBand;
+  pulses: number;
+  layers: DuetLayers;
+  spots: ("tunnel" | "puddle")[];
+}
+
+export function buildDuetContent(
+  name: string,
+  band: EchoBand,
+  layers: DuetLayers,
+  spots: ("tunnel" | "puddle")[],
+): SoundDuetContent {
+  return { v: 1, name, band, pulses: BAND_CONFIG[band].pulses, layers, spots };
+}

--- a/src/components/games/echoAvenue/echoAvenueWarmup.ts
+++ b/src/components/games/echoAvenue/echoAvenueWarmup.ts
@@ -1,0 +1,43 @@
+/**
+ * Echo Avenue — AudioContext warm-up gate (design ruling 10).
+ *
+ * The ~1s engine wake must be paid on the Start screen's FIRST interaction
+ * (a mood-preview tap, a volume nudge, the Start button — anything), never
+ * by the child's first musical tap in the studio. This gate makes that
+ * sequencing a testable contract:
+ *   - warmOnFirstInteraction() starts the wake exactly once (idempotent);
+ *   - isWarm() lets the tap path stay fully synchronous once running —
+ *     a warm pad tap never awaits anything.
+ */
+export interface WarmableAudio {
+  prewarm: () => Promise<void>;
+}
+
+export interface WarmupGate {
+  /** Call on ANY Start-screen interaction. Idempotent; returns the single
+   *  in-flight wake promise. */
+  warmOnFirstInteraction: () => Promise<void>;
+  isWarm: () => boolean;
+  /** How many times the underlying prewarm actually ran (test hook). */
+  wakeCount: () => number;
+}
+
+export function createWarmupGate(audio: WarmableAudio): WarmupGate {
+  let warm = false;
+  let pending: Promise<void> | null = null;
+  let wakes = 0;
+  return {
+    warmOnFirstInteraction: () => {
+      if (warm) return Promise.resolve();
+      if (!pending) {
+        wakes += 1;
+        pending = audio.prewarm().then(() => {
+          warm = true;
+        });
+      }
+      return pending;
+    },
+    isWarm: () => warm,
+    wakeCount: () => wakes,
+  };
+}

--- a/src/components/games/gameRegistry.ts
+++ b/src/components/games/gameRegistry.ts
@@ -14,6 +14,7 @@ import QualifyTuneRaceGame from "./QualifyTuneRaceGame";
 import TankTrekGame from "./TankTrekGame";
 import QuantumQuestGame from "./QuantumQuestGame";
 import DataDashSortDiscoverGame from "./DataDashSortDiscoverGame";
+import EchoAvenueGame from "./echoAvenue/EchoAvenueGame";
 
 type GameProps = {
   config?: any;
@@ -41,6 +42,9 @@ export const GAME_COMPONENTS: Record<string, ComponentType<GameProps>> = {
   sky_shield: SkyShieldGame,                    // "Sky Shield Patterns" (Set 2)
   fast_lane: FastLaneGame,                      // "Fast Lane Signals" (Set 2)
   qualify_tune_race: QualifyTuneRaceGame,       // "Qualify, Tune, Race" (Set 2)
+
+  // ── Set 3 keys ──
+  echo_avenue: EchoAvenueGame,                  // "Echo Avenue" (Set 3 slot 3, gated)
 
   // ── Legacy / alias keys → same implementations ──
   sequence_drag_drop: BoostPathPlannerGame,

--- a/src/constants/stemSets.ts
+++ b/src/constants/stemSets.ts
@@ -42,6 +42,10 @@ export const STEM_SET_1_STRANDS: Record<StemSet1GameId, string> = {
 export const HIDDEN_MODULE_SLUGS = new Set([
   "stem-1-intro",      // Legacy "Quantum Explorers" — archived
   "k2-stem-sequencing", // "Fix the Order" / "Lost Steps" — removed from canon
+  // GATED (not removed): Set 3 slot-3 game is fully wired (registry, seed,
+  // sound_duet creation type) but held back until Set 3 launches / leads
+  // sign off. Ungating = delete the next line. See #676.
+  "k2-stem-echo-avenue",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -85,9 +89,9 @@ export const STEM_SET_2_PERKS: Record<StemSet2GameId, string> = {
 // Set 3 — Mastery (placeholder, gates specialization)
 // ---------------------------------------------------------------------------
 export const STEM_SET_3_IDS = [
-  "set3-game-1",
-  "set3-game-2",
-  "set3-game-3",
+  "set3-game-1", // Boost Track Builder claims this slot in PR #691
+  "set3-game-2", // reserved: machine game (in design)
+  "echo-avenue", // Echo Avenue (implemented, GATED via HIDDEN_MODULE_SLUGS)
   "set3-game-4",
   "set3-game-5",
 ] as const;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1879,6 +1879,93 @@
     "saving": "Sharing...",
     "saveError": "Could not share. Try again."
   },
+  "echoAvenue": {
+    "title": {
+      "prompt": "What will your duet sound like?",
+      "moodTogether": "🤝 Together",
+      "moodEcho": "🔁 Echo",
+      "moodSpace": "🌙 Space",
+      "start": "Open the studio!",
+      "watch": "▶ Watch the duet",
+      "resume": "Your last take is waiting inside."
+    },
+    "sensory": {
+      "mute": "🔊 Sound on",
+      "unmute": "🔇 Sound off",
+      "volume": "Volume",
+      "calm": "🕊️ Calm lights",
+      "muteAria": "Toggle sound"
+    },
+    "studio": {
+      "lead": "Lead",
+      "partner": "Partner",
+      "partnerLocked": "Partner (record a take!)",
+      "layerVolume": "Layer volume",
+      "record": "● Record a take",
+      "stopTake": "⏹ Finish the take",
+      "watch": "🎬 Watch the Take",
+      "redoLayer": "Redo this layer",
+      "save": "Save",
+      "name": "Name it",
+      "share": "Share ✨",
+      "done": "Done for now",
+      "untitled": "Untitled take",
+      "saved": "Saved ✓",
+      "savedLocal": "Kept on this device ✓"
+    },
+    "watch": {
+      "joinIn": "🎤 Join in!",
+      "changeLayer": "🔁 Change a layer",
+      "doneWatching": "Done watching",
+      "notAvailable": "This duet can't play right now. Try another one!"
+    },
+    "sound": {
+      "step": "Step",
+      "stomp": "Stomp",
+      "clap": "Clap",
+      "tap": "Tap",
+      "chime": "Chime",
+      "twinkle": "Twinkle",
+      "whoosh": "Whoosh",
+      "breeze": "Breeze"
+    },
+    "unlock": {
+      "partner": "Your Partner joins the stage! Overdub a second layer!",
+      "spots": "Sound spots opened! The tunnel and the puddle color your sounds!",
+      "chime": "You earned the Chime! 🔔",
+      "whoosh": "You earned the Whoosh! 💨",
+      "stomp": "You earned the Stomp! 🐘",
+      "twinkle": "You earned the Twinkle! ✨",
+      "tryIt": "Let's try it!"
+    },
+    "wonder": {
+      "callResponse": "Where did your performers answer each other?",
+      "rests": "Where did quiet make the next sound stand out?",
+      "favorite": "What's your favorite moment in your duet?",
+      "next": "What would you try next?",
+      "newSound": {
+        "chime": "Your new Chime rang out! Where else could it sing?",
+        "whoosh": "Your new Whoosh swept through! What did it change?",
+        "stomp": "Your new Stomp shook the street! Who should answer it?",
+        "twinkle": "Your new Twinkle sparkled! What happens if it comes back quieter?"
+      }
+    },
+    "reflect": {
+      "backToStudio": "Back to my studio"
+    },
+    "name": {
+      "title": "Name your duet!",
+      "taken": "That name's taken — try a different mix!",
+      "poseTitle": "Pick a cover pose",
+      "keep": "That's it!",
+      "later": "Later"
+    },
+    "pose": {
+      "sideBySide": "Side by side",
+      "highFive": "High five",
+      "backToBack": "Back to back"
+    }
+  },
   "challengePlayer": {
     "loading": "Loading challenge...",
     "notFound": "This challenge isn't available.",
@@ -1897,6 +1984,7 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "watchListen": "Watch / Listen"
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1617,6 +1617,93 @@
     "saving": "Compartiendo...",
     "saveError": "No se pudo compartir. Inténtalo de nuevo."
   },
+  "echoAvenue": {
+    "title": {
+      "prompt": "¿Cómo sonará tu dúo?",
+      "moodTogether": "🤝 Juntos",
+      "moodEcho": "🔁 Eco",
+      "moodSpace": "🌙 Espacio",
+      "start": "¡Abre el estudio!",
+      "watch": "▶ Ver el dúo",
+      "resume": "Tu última toma te espera adentro."
+    },
+    "sensory": {
+      "mute": "🔊 Sonido activado",
+      "unmute": "🔇 Sonido apagado",
+      "volume": "Volumen",
+      "calm": "🕊️ Luces tranquilas",
+      "muteAria": "Activar o silenciar el sonido"
+    },
+    "studio": {
+      "lead": "Solista",
+      "partner": "Compañero",
+      "partnerLocked": "Compañero (¡graba una toma!)",
+      "layerVolume": "Volumen de la capa",
+      "record": "● Grabar una toma",
+      "stopTake": "⏹ Terminar la toma",
+      "watch": "🎬 Ver la toma",
+      "redoLayer": "Rehacer esta capa",
+      "save": "Guardar",
+      "name": "Ponle nombre",
+      "share": "Compartir ✨",
+      "done": "Por ahora, listo",
+      "untitled": "Toma sin título",
+      "saved": "Guardado ✓",
+      "savedLocal": "Guardado en este dispositivo ✓"
+    },
+    "watch": {
+      "joinIn": "🎤 ¡Únete!",
+      "changeLayer": "🔁 Cambiar una capa",
+      "doneWatching": "Terminé de ver",
+      "notAvailable": "Este dúo no se puede reproducir ahora. ¡Prueba otro!"
+    },
+    "sound": {
+      "step": "Paso",
+      "stomp": "Pisotón",
+      "clap": "Palmada",
+      "tap": "Toque",
+      "chime": "Campanada",
+      "twinkle": "Destello",
+      "whoosh": "Zumbido",
+      "breeze": "Brisa"
+    },
+    "unlock": {
+      "partner": "¡Tu Compañero sube al escenario! ¡Graba una segunda capa!",
+      "spots": "¡Se abrieron los rincones sonoros! ¡El túnel y el charco colorean tus sonidos!",
+      "chime": "¡Ganaste la Campanada! 🔔",
+      "whoosh": "¡Ganaste el Zumbido! 💨",
+      "stomp": "¡Ganaste el Pisotón! 🐘",
+      "twinkle": "¡Ganaste el Destello! ✨",
+      "tryIt": "¡A probarlo!"
+    },
+    "wonder": {
+      "callResponse": "¿Dónde se respondieron tus artistas?",
+      "rests": "¿Dónde hizo el silencio que el siguiente sonido brillara?",
+      "favorite": "¿Cuál es tu momento favorito de tu dúo?",
+      "next": "¿Qué te gustaría probar ahora?",
+      "newSound": {
+        "chime": "¡Tu nueva Campanada sonó! ¿Dónde más podría cantar?",
+        "whoosh": "¡Tu nuevo Zumbido pasó volando! ¿Qué cambió?",
+        "stomp": "¡Tu nuevo Pisotón sacudió la calle! ¿Quién debería responderle?",
+        "twinkle": "¡Tu nuevo Destello brilló! ¿Qué pasa si vuelve más despacito?"
+      }
+    },
+    "reflect": {
+      "backToStudio": "Volver a mi estudio"
+    },
+    "name": {
+      "title": "¡Ponle nombre a tu dúo!",
+      "taken": "Ese nombre ya existe — ¡prueba otra combinación!",
+      "poseTitle": "Elige una pose de portada",
+      "keep": "¡Ese es!",
+      "later": "Después"
+    },
+    "pose": {
+      "sideBySide": "Lado a lado",
+      "highFive": "Chócala",
+      "backToBack": "Espalda con espalda"
+    }
+  },
   "challengePlayer": {
     "loading": "Cargando desafío...",
     "notFound": "Este desafío no está disponible.",
@@ -1635,6 +1722,7 @@
     "by": "por {{name}}",
     "boosts": "Ánimos",
     "giveBoost": "Dar ánimo ⭐",
-    "play": "Jugar"
+    "play": "Jugar",
+    "watchListen": "Ver / Escuchar"
   }
 }

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -1516,6 +1516,93 @@
     "saving": "Sharing...",
     "saveError": "Could not share. Try again."
   },
+  "echoAvenue": {
+    "title": {
+      "prompt": "What will your duet sound like?",
+      "moodTogether": "🤝 Together",
+      "moodEcho": "🔁 Echo",
+      "moodSpace": "🌙 Space",
+      "start": "Open the studio!",
+      "watch": "▶ Watch the duet",
+      "resume": "Your last take is waiting inside."
+    },
+    "sensory": {
+      "mute": "🔊 Sound on",
+      "unmute": "🔇 Sound off",
+      "volume": "Volume",
+      "calm": "🕊️ Calm lights",
+      "muteAria": "Toggle sound"
+    },
+    "studio": {
+      "lead": "Lead",
+      "partner": "Partner",
+      "partnerLocked": "Partner (record a take!)",
+      "layerVolume": "Layer volume",
+      "record": "● Record a take",
+      "stopTake": "⏹ Finish the take",
+      "watch": "🎬 Watch the Take",
+      "redoLayer": "Redo this layer",
+      "save": "Save",
+      "name": "Name it",
+      "share": "Share ✨",
+      "done": "Done for now",
+      "untitled": "Untitled take",
+      "saved": "Saved ✓",
+      "savedLocal": "Kept on this device ✓"
+    },
+    "watch": {
+      "joinIn": "🎤 Join in!",
+      "changeLayer": "🔁 Change a layer",
+      "doneWatching": "Done watching",
+      "notAvailable": "This duet can't play right now. Try another one!"
+    },
+    "sound": {
+      "step": "Step",
+      "stomp": "Stomp",
+      "clap": "Clap",
+      "tap": "Tap",
+      "chime": "Chime",
+      "twinkle": "Twinkle",
+      "whoosh": "Whoosh",
+      "breeze": "Breeze"
+    },
+    "unlock": {
+      "partner": "Your Partner joins the stage! Overdub a second layer!",
+      "spots": "Sound spots opened! The tunnel and the puddle color your sounds!",
+      "chime": "You earned the Chime! 🔔",
+      "whoosh": "You earned the Whoosh! 💨",
+      "stomp": "You earned the Stomp! 🐘",
+      "twinkle": "You earned the Twinkle! ✨",
+      "tryIt": "Let's try it!"
+    },
+    "wonder": {
+      "callResponse": "Where did your performers answer each other?",
+      "rests": "Where did quiet make the next sound stand out?",
+      "favorite": "What's your favorite moment in your duet?",
+      "next": "What would you try next?",
+      "newSound": {
+        "chime": "Your new Chime rang out! Where else could it sing?",
+        "whoosh": "Your new Whoosh swept through! What did it change?",
+        "stomp": "Your new Stomp shook the street! Who should answer it?",
+        "twinkle": "Your new Twinkle sparkled! What happens if it comes back quieter?"
+      }
+    },
+    "reflect": {
+      "backToStudio": "Back to my studio"
+    },
+    "name": {
+      "title": "Name your duet!",
+      "taken": "That name's taken — try a different mix!",
+      "poseTitle": "Pick a cover pose",
+      "keep": "That's it!",
+      "later": "Later"
+    },
+    "pose": {
+      "sideBySide": "Side by side",
+      "highFive": "High five",
+      "backToBack": "Back to back"
+    }
+  },
   "challengePlayer": {
     "loading": "Loading challenge...",
     "notFound": "This challenge isn't available."
@@ -1533,6 +1620,7 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "watchListen": "Watch / Listen"
   }
 }

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -1515,6 +1515,50 @@
     "saving": "Sharing...",
     "saveError": "Could not share. Try again."
   },
+  "echoAvenue": {
+    "title": {
+      "prompt": "你的二重奏会是什么声音？",
+      "moodTogether": "🤝 一起",
+      "moodEcho": "🔁 回声",
+      "moodSpace": "🌙 留白",
+      "start": "打开录音棚！",
+      "watch": "▶ 看这段二重奏"
+    },
+    "unlock": {
+      "partner": "你的搭档登台啦！再录一层吧！",
+      "spots": "声音角落打开了！隧道和水洼会给你的声音上色！",
+      "chime": "你赢得了风铃声！🔔",
+      "whoosh": "你赢得了呼呼声！💨",
+      "stomp": "你赢得了跺脚声！🐘",
+      "twinkle": "你赢得了闪烁声！✨",
+      "tryIt": "来试试！"
+    },
+    "wonder": {
+      "callResponse": "你的两位演员在哪里互相回应了？",
+      "rests": "哪里的安静让下一个声音更亮了？",
+      "favorite": "你的二重奏里你最喜欢哪一刻？",
+      "next": "接下来你想试试什么？",
+      "newSound": {
+        "chime": "你的新风铃声响啦！它还能在哪里唱歌？",
+        "whoosh": "你的新呼呼声吹过去了！它改变了什么？",
+        "stomp": "你的新跺脚声震动了街道！谁来回应它？",
+        "twinkle": "你的新闪烁声亮了一下！如果它轻轻地回来会怎样？"
+      }
+    },
+    "reflect": {
+      "backToStudio": "回到我的录音棚"
+    },
+    "name": {
+      "title": "给你的二重奏起个名字！",
+      "keep": "就是它！",
+      "later": "以后再说"
+    },
+    "pose": {
+      "sideBySide": "并肩站",
+      "highFive": "击掌",
+      "backToBack": "背靠背"
+    }
+  },
   "challengePlayer": {
     "loading": "Loading challenge...",
     "notFound": "This challenge isn't available."
@@ -1532,6 +1576,7 @@
     "by": "by {{name}}",
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
-    "play": "Play"
+    "play": "Play",
+    "watchListen": "看 / 听"
   }
 }

--- a/src/pages/ChallengePlayer.tsx
+++ b/src/pages/ChallengePlayer.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Sparkles } from "lucide-react";
 import { useApi } from "../services/api";
 import DataDashSortDiscoverGame from "../components/games/DataDashSortDiscoverGame";
+import EchoAvenueGame from "../components/games/echoAvenue/EchoAvenueGame";
 
 // Phase 0 — play a saved (group-shared) Data Dash challenge. Fetches the single
 // creation (group-scoped + visibility enforced server-side) and renders the
@@ -16,15 +17,19 @@ export default function ChallengePlayer() {
   const api = useApi();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [content, setContent] = useState<unknown | null>(null);
+  const [creation, setCreation] = useState<{ type: string; content: unknown } | null>(null);
   const [state, setState] = useState<"loading" | "error" | "ready">("loading");
 
   useEffect(() => {
     if (!id) return;
     api
       .get(`/creations/${id}`)
-      .then((res: { content?: unknown } | null) => {
-        setContent(res?.content ?? null);
+      .then((res: { type?: string; content?: unknown } | null) => {
+        setCreation(
+          res?.content !== undefined && res?.content !== null
+            ? { type: res.type ?? "", content: res.content }
+            : null,
+        );
         setState("ready");
       })
       .catch(() => setState("error"));
@@ -35,22 +40,32 @@ export default function ChallengePlayer() {
   if (state === "loading") {
     return <div className="p-6 text-center text-gray-500">{t("challengePlayer.loading")}</div>;
   }
-  if (state === "error" || !content) {
+  if (state === "error" || !creation) {
     return (
       <div className="p-6 text-center text-gray-600">
         {t("challengePlayer.notFound")}
       </div>
     );
   }
+  const secondaryAction = {
+    label: t("challengePlayer.viewMyGallery", { defaultValue: "View My Gallery" }),
+    icon: <Sparkles className="w-4 h-4 mr-1" />,
+    onClick: goToGallery,
+  };
+  if (creation.type === "sound_duet") {
+    return (
+      <EchoAvenueGame
+        config={{ soundDuet: creation.content }}
+        onComplete={goToGallery}
+        secondaryAction={secondaryAction}
+      />
+    );
+  }
   return (
     <DataDashSortDiscoverGame
-      config={{ challenge: content }}
+      config={{ challenge: creation.content }}
       onComplete={goToGallery}
-      secondaryAction={{
-        label: t("challengePlayer.viewMyGallery", { defaultValue: "View My Gallery" }),
-        icon: <Sparkles className="w-4 h-4 mr-1" />,
-        onClick: goToGallery,
-      }}
+      secondaryAction={secondaryAction}
     />
   );
 }

--- a/src/pages/dev/EchoSpike.tsx
+++ b/src/pages/dev/EchoSpike.tsx
@@ -1,0 +1,434 @@
+/**
+ * /dev/echo-spike — Echo Avenue LATENCY SPIKE (dev-only harness, NOT the game).
+ *
+ * The whole Echo Avenue concept lives or dies on tap→sound→motion latency.
+ * This page proves (or kills) the live-instrument feel before any game code
+ * is written:
+ *   1. Four pads: pointerdown → synthesized sound scheduled immediately
+ *      (AudioContext latencyHint:'interactive', pre-resumed, pre-built
+ *      buffers) → simultaneous motion flash.
+ *   2. Honest instrumentation on screen: baseLatency / outputLatency where
+ *      the browser exposes them, per-tap pointerdown→scheduled-start delta.
+ *      NOTE: touch-digitizer→event input latency is NOT measurable from JS
+ *      (typically ~15–30 ms) — the human feel test is the real gate.
+ *   3. The loop-engine primitive: a repeating 4-pulse cycle with lookahead
+ *      scheduling (25 ms pump, ~120 ms horizon against ctx.currentTime);
+ *      recorded taps replay on-grid. Underruns + pump health are counted to
+ *      prove drift-free replay over 60+ seconds.
+ *
+ * Dev-only: registered behind import.meta.env.DEV — never in a prod build.
+ * Strings are intentionally unlocalized (developer harness, not kid UI).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ── Synth voices (all synthesized — zero audio assets) ──────────────────────
+
+type VoiceId = "chime" | "thump" | "clap" | "whoosh";
+
+const VOICES: { id: VoiceId; label: string; emoji: string; color: string }[] = [
+  { id: "chime", label: "Chime", emoji: "🔔", color: "#0ea5e9" },
+  { id: "thump", label: "Step", emoji: "🦶", color: "#8b5cf6" },
+  { id: "clap", label: "Clap", emoji: "👏", color: "#f59e0b" },
+  { id: "whoosh", label: "Whoosh", emoji: "💨", color: "#10b981" },
+];
+
+let sharedCtx: AudioContext | null = null;
+let noiseBuffer: AudioBuffer | null = null;
+let masterGain: GainNode | null = null;
+
+function getCtx(): AudioContext {
+  if (!sharedCtx) {
+    sharedCtx = new AudioContext({ latencyHint: "interactive" });
+    masterGain = sharedCtx.createGain();
+    masterGain.gain.value = 0.9;
+    masterGain.connect(sharedCtx.destination);
+    // Pre-render one second of noise ONCE (clap + whoosh source material).
+    noiseBuffer = sharedCtx.createBuffer(1, sharedCtx.sampleRate, sharedCtx.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+  }
+  return sharedCtx;
+}
+
+/** Schedule one voice at `when` (AudioContext time). Loudness-normalized
+ *  by ear via per-voice peak gains. */
+function playVoice(id: VoiceId, when: number) {
+  const ctx = getCtx();
+  const out = masterGain!;
+  if (id === "chime") {
+    const osc = ctx.createOscillator();
+    const osc2 = ctx.createOscillator();
+    const g = ctx.createGain();
+    osc.type = "triangle";
+    osc.frequency.value = 880;
+    osc2.type = "triangle";
+    osc2.frequency.value = 1318.5; // a fifth above — small sparkle
+    g.gain.setValueAtTime(0.5, when);
+    g.gain.exponentialRampToValueAtTime(0.001, when + 0.4);
+    osc.connect(g);
+    osc2.connect(g);
+    g.connect(out);
+    osc.start(when);
+    osc2.start(when);
+    osc.stop(when + 0.45);
+    osc2.stop(when + 0.45);
+  } else if (id === "thump") {
+    const osc = ctx.createOscillator();
+    const g = ctx.createGain();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(130, when);
+    osc.frequency.exponentialRampToValueAtTime(48, when + 0.16);
+    g.gain.setValueAtTime(0.9, when);
+    g.gain.exponentialRampToValueAtTime(0.001, when + 0.18);
+    osc.connect(g);
+    g.connect(out);
+    osc.start(when);
+    osc.stop(when + 0.2);
+  } else if (id === "clap") {
+    // click-burst: three micro noise hits
+    for (let i = 0; i < 3; i++) {
+      const src = ctx.createBufferSource();
+      src.buffer = noiseBuffer;
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = 2000;
+      bp.Q.value = 1.2;
+      const g = ctx.createGain();
+      const t = when + i * 0.012;
+      g.gain.setValueAtTime(i === 2 ? 0.55 : 0.3, t);
+      g.gain.exponentialRampToValueAtTime(0.001, t + (i === 2 ? 0.12 : 0.03));
+      src.connect(bp);
+      bp.connect(g);
+      g.connect(out);
+      src.start(t, Math.random() * 0.5, 0.15);
+    }
+  } else {
+    // whoosh: filtered noise with a rising sweep
+    const src = ctx.createBufferSource();
+    src.buffer = noiseBuffer;
+    const bp = ctx.createBiquadFilter();
+    bp.type = "bandpass";
+    bp.frequency.setValueAtTime(400, when);
+    bp.frequency.exponentialRampToValueAtTime(2400, when + 0.28);
+    bp.Q.value = 2.5;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(0.0001, when);
+    g.gain.exponentialRampToValueAtTime(0.6, when + 0.06);
+    g.gain.exponentialRampToValueAtTime(0.001, when + 0.3);
+    src.connect(bp);
+    bp.connect(g);
+    g.connect(out);
+    src.start(when, Math.random() * 0.4, 0.35);
+  }
+}
+
+// ── Loop primitive constants ────────────────────────────────────────────────
+
+const PULSES = 4;
+const PULSE_SEC = 0.6; // 100 BPM — a comfortable K-2 walking pulse
+const CYCLE_SEC = PULSES * PULSE_SEC;
+const SNAP_SEC = PULSE_SEC / 2; // half-pulse quantization grid (the K-2 scaffold)
+const PUMP_MS = 25;
+const HORIZON_SEC = 0.12;
+
+interface LoopEvent {
+  offset: number; // seconds into the cycle, quantized
+  voice: VoiceId;
+}
+
+export default function EchoSpike() {
+  const [ready, setReady] = useState(false);
+  const [stats, setStats] = useState<{
+    base: number | null;
+    output: number | null;
+    deltas: number[];
+    firstTapMs: number | null;
+  }>({ base: null, output: null, deltas: [], firstTapMs: null });
+  const [flash, setFlash] = useState<VoiceId | null>(null);
+
+  // loop state
+  const [looping, setLooping] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [events, setEvents] = useState<LoopEvent[]>([]);
+  const [cycles, setCycles] = useState(0);
+  const [underruns, setUnderruns] = useState(0);
+  const [worstPumpGap, setWorstPumpGap] = useState(0);
+  const [beat, setBeat] = useState(-1);
+
+  const loopStartRef = useRef(0);
+  const nextPulseRef = useRef(0); // absolute pulse index scheduled next
+  const scheduledCycleEventsRef = useRef(0); // cycle index whose events are scheduled
+  const eventsRef = useRef<LoopEvent[]>([]);
+  eventsRef.current = events;
+  const recordingRef = useRef(false);
+  recordingRef.current = recording;
+  const loopingRef = useRef(false);
+  const pumpRef = useRef<number | null>(null);
+  const lastPumpAtRef = useRef(0);
+
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const ensureAudio = useCallback(async (): Promise<AudioContext> => {
+    const ctx = getCtx();
+    if (ctx.state !== "running") await ctx.resume();
+    if (!ready) {
+      setReady(true);
+      const withOutput = ctx as AudioContext & { outputLatency?: number };
+      setStats((s) => ({
+        ...s,
+        base: ctx.baseLatency ?? null,
+        output: typeof withOutput.outputLatency === "number" ? withOutput.outputLatency : null,
+      }));
+    }
+    return ctx;
+  }, [ready]);
+
+  // ── Pad tap: the latency-critical path ──
+  const onPad = useCallback(
+    async (voice: VoiceId) => {
+      const tDown = performance.now();
+      const ctx = await ensureAudio();
+      playVoice(voice, ctx.currentTime); // schedule ASAP — "now"
+      const jsDelta = performance.now() - tDown;
+      setStats((s) =>
+        s.firstTapMs === null
+          ? { ...s, firstTapMs: jsDelta } // first tap pays the resume cost — shown separately
+          : { ...s, deltas: [...s.deltas.slice(-19), jsDelta] },
+      );
+      // simultaneous motion cue
+      setFlash(voice);
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+      flashTimerRef.current = setTimeout(() => setFlash(null), 160);
+      // record into the loop, snapped to the half-pulse grid
+      if (recordingRef.current && loopingRef.current) {
+        const raw = (ctx.currentTime - loopStartRef.current) % CYCLE_SEC;
+        const snapped = (Math.round(raw / SNAP_SEC) * SNAP_SEC) % CYCLE_SEC;
+        setEvents((prev) => [...prev, { offset: snapped, voice }]);
+      }
+    },
+    [ensureAudio],
+  );
+
+  // keyboard operability (laptop test): 1-4 trigger pads
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      const idx = ["1", "2", "3", "4"].indexOf(e.key);
+      if (idx >= 0) void onPad(VOICES[idx].id);
+    };
+    window.addEventListener("keydown", down);
+    return () => window.removeEventListener("keydown", down);
+  }, [onPad]);
+
+  // ── The lookahead pump (the standard WebAudio scheduler pattern) ──
+  const startLoop = useCallback(async () => {
+    const ctx = await ensureAudio();
+    loopingRef.current = true;
+    setLooping(true);
+    setCycles(0);
+    setUnderruns(0);
+    setWorstPumpGap(0);
+    loopStartRef.current = ctx.currentTime + 0.1;
+    nextPulseRef.current = 0;
+    scheduledCycleEventsRef.current = -1;
+    lastPumpAtRef.current = performance.now();
+
+    const pump = () => {
+      if (!loopingRef.current) return;
+      const nowMs = performance.now();
+      const gap = nowMs - lastPumpAtRef.current;
+      lastPumpAtRef.current = nowMs;
+      if (gap > worstGapLocal) {
+        worstGapLocal = gap;
+        setWorstPumpGap(Math.round(gap));
+      }
+      const now = ctx.currentTime;
+      // schedule pulses (metronome ticks) into the horizon
+      while (loopStartRef.current + nextPulseRef.current * PULSE_SEC < now + HORIZON_SEC) {
+        const pulseIdx = nextPulseRef.current;
+        const when = loopStartRef.current + pulseIdx * PULSE_SEC;
+        if (when < now) setUnderruns((u) => u + 1); // fell behind — count honestly
+        tick(ctx, when, pulseIdx % PULSES === 0);
+        nextPulseRef.current += 1;
+        if (pulseIdx % PULSES === 0) {
+          const cycleIdx = pulseIdx / PULSES;
+          setCycles(cycleIdx);
+          // schedule this cycle's recorded events, on-grid
+          if (scheduledCycleEventsRef.current < cycleIdx) {
+            scheduledCycleEventsRef.current = cycleIdx;
+            const cycleStart = loopStartRef.current + cycleIdx * PULSES * PULSE_SEC;
+            for (const ev of eventsRef.current) playVoice(ev.voice, cycleStart + ev.offset);
+          }
+        }
+      }
+    };
+    let worstGapLocal = 0;
+    pump();
+    pumpRef.current = window.setInterval(pump, PUMP_MS);
+  }, [ensureAudio]);
+
+  const stopLoop = useCallback(() => {
+    loopingRef.current = false;
+    setLooping(false);
+    setRecording(false);
+    setBeat(-1);
+    if (pumpRef.current !== null) {
+      clearInterval(pumpRef.current);
+      pumpRef.current = null;
+    }
+  }, []);
+  useEffect(() => stopLoop, [stopLoop]);
+
+  // visual beat indicator (rAF against the audio clock — display only)
+  useEffect(() => {
+    if (!looping) return;
+    let raf = 0;
+    const ctx = getCtx();
+    const frame = () => {
+      const t = ctx.currentTime - loopStartRef.current;
+      if (t >= 0) setBeat(Math.floor(t / PULSE_SEC) % PULSES);
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+    return () => cancelAnimationFrame(raf);
+  }, [looping]);
+
+  const avg =
+    stats.deltas.length > 0
+      ? stats.deltas.reduce((a, b) => a + b, 0) / stats.deltas.length
+      : null;
+  const max = stats.deltas.length > 0 ? Math.max(...stats.deltas) : null;
+  const outputMs =
+    stats.output !== null ? stats.output * 1000 : stats.base !== null ? stats.base * 1000 : null;
+
+  return (
+    <div className="min-h-screen bg-slate-900 text-slate-100 p-4 flex flex-col items-center gap-4 touch-manipulation select-none">
+      <h1 className="text-xl font-bold">Echo Avenue — latency spike (dev harness)</h1>
+
+      {/* Pads */}
+      <div className="grid grid-cols-2 gap-4">
+        {VOICES.map((v) => (
+          <button
+            key={v.id}
+            type="button"
+            onPointerDown={() => void onPad(v.id)}
+            className="rounded-3xl font-extrabold text-2xl text-white shadow-lg active:scale-95 touch-manipulation focus-visible:outline focus-visible:outline-4 focus-visible:outline-white"
+            style={{
+              width: 140,
+              height: 140,
+              background: v.color,
+              transform: flash === v.id ? "scale(1.12)" : undefined,
+              boxShadow: flash === v.id ? `0 0 40px ${v.color}` : undefined,
+              transition: "transform 60ms linear, box-shadow 60ms linear",
+            }}
+          >
+            <span className="text-4xl block" aria-hidden>
+              {v.emoji}
+            </span>
+            {v.label}
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-slate-400">keys 1–4 work too · first tap wakes the audio engine</p>
+
+      {/* Latency readout */}
+      <div className="bg-slate-800 rounded-2xl p-4 w-full max-w-md font-mono text-sm flex flex-col gap-1">
+        <div>audio state: {ready ? "running" : "tap any pad to start"}</div>
+        <div>baseLatency: {stats.base !== null ? `${(stats.base * 1000).toFixed(1)} ms` : "n/a"}</div>
+        <div>
+          outputLatency: {stats.output !== null ? `${(stats.output * 1000).toFixed(1)} ms` : "n/a (browser doesn't expose it)"}
+        </div>
+        <div>
+          first tap (incl. engine wake): {stats.firstTapMs !== null ? `${stats.firstTapMs.toFixed(1)} ms` : "—"}
+        </div>
+        <div>
+          tap→schedule delta (last {stats.deltas.length}): avg {avg !== null ? avg.toFixed(1) : "—"} ms · max {max !== null ? max.toFixed(1) : "—"} ms
+        </div>
+        <div className="text-emerald-300">
+          est. audible latency ≈ tap-delta + output ≈ {avg !== null && outputMs !== null ? (avg + outputMs).toFixed(0) : "—"} ms
+          <span className="text-slate-400"> (+ ~15–30 ms touch input, unmeasurable from JS)</span>
+        </div>
+      </div>
+
+      {/* Loop primitive */}
+      <div className="bg-slate-800 rounded-2xl p-4 w-full max-w-md flex flex-col gap-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          {!looping ? (
+            <button
+              type="button"
+              onClick={() => void startLoop()}
+              className="min-h-11 px-5 rounded-full bg-emerald-600 font-bold touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+            >
+              ▶ Start loop
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={stopLoop}
+              className="min-h-11 px-5 rounded-full bg-rose-600 font-bold touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+            >
+              ⏹ Stop
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setRecording((r) => !r)}
+            disabled={!looping}
+            aria-pressed={recording}
+            className={`min-h-11 px-5 rounded-full font-bold touch-manipulation disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white ${
+              recording ? "bg-red-500" : "bg-slate-600"
+            }`}
+          >
+            {recording ? "● Recording taps" : "○ Record"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setEvents([])}
+            className="min-h-11 px-5 rounded-full bg-slate-600 font-bold touch-manipulation focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+          >
+            Clear ({events.length})
+          </button>
+        </div>
+        {/* beat lights */}
+        <div className="flex gap-2 justify-center" aria-hidden>
+          {Array.from({ length: PULSES }, (_, i) => (
+            <div
+              key={i}
+              className="w-8 h-8 rounded-full transition-colors duration-75"
+              style={{ background: beat === i ? "#facc15" : "#334155" }}
+            />
+          ))}
+        </div>
+        <div className="font-mono text-sm flex flex-col gap-1">
+          <div>
+            cycle: {cycles} ({(cycles * CYCLE_SEC).toFixed(0)}s) · 4 pulses @ 100 BPM · snap grid ½ pulse
+          </div>
+          <div>
+            scheduler underruns: <span className={underruns > 0 ? "text-rose-400" : "text-emerald-300"}>{underruns}</span> · worst pump gap: {worstPumpGap} ms (pump {PUMP_MS} ms, horizon {HORIZON_SEC * 1000} ms)
+          </div>
+          <div className="text-slate-400">
+            drift check: events are scheduled on the AudioContext clock, so replay is drift-free
+            unless underruns rise — run 60s+ and watch that counter.
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs text-slate-500 max-w-md text-center">
+        Feel test: tap pads freely, then record a phrase and let it loop for a minute. Live = go.
+        Rubbery = numbers below tell us which stage is eating the time.
+      </p>
+    </div>
+  );
+}
+
+function tick(ctx: AudioContext, when: number, downbeat: boolean) {
+  const osc = ctx.createOscillator();
+  const g = ctx.createGain();
+  osc.type = "sine";
+  osc.frequency.value = downbeat ? 1200 : 900;
+  g.gain.setValueAtTime(downbeat ? 0.18 : 0.1, when);
+  g.gain.exponentialRampToValueAtTime(0.001, when + 0.05);
+  osc.connect(g);
+  g.connect(masterGain!);
+  osc.start(when);
+  osc.stop(when + 0.06);
+}


### PR DESCRIPTION
**Lands against #676 — Set 3 game, slot 3.** Design doc: `docs/games/echo-avenue-design.md`.

> **For reviewers:** no urgency — take it when the queue clears. The design was **externally authored, founder-reviewed, and source-reconciled** (`8b5ab67`); your review is the standard gate it hasn't had yet. Playing it is most of the review: ungate locally (one line, see below) and make a duet.

## What this is

**Echo Avenue** — a live two-performer sound-and-motion studio. The child taps large action pads; each tap makes one of two original performers **move and sound at the same instant**. Taps record into a repeating pulse loop: the Lead's take loops while the child overdubs the Partner — call-and-response, overlaps, rests. Watch the Take, revise a layer, name it from structured tokens, share the audiovisual duet to the group gallery. **No scores, stars, timers, verdicts, win/lose, or correct rhythms anywhere** — creation and feedback are simultaneous; it's a live instrument, not a batch simulation.

## Provenance (honest)

Externally authored design → founder-reviewed (rulings are the doc's §11 delta layer) → **source-reconciled at `8b5ab67`**, where the repo transcription was diffed against the original commission doc and **source won on real drift** — including **one dropped feature** (the share-time **cover pose**, now implemented end-to-end: picker → strict-validated content field → gallery card) plus the K–2 opening pads (Step + Clap), the Watch-the-Take exits (Join in! / Change a layer), and Reflect's "Back to my studio." Provenance in-repo is deliberately trimmed to "classic side-scrolling two-player cooperation patterns" + the transformation table; no third-party franchise is named anywhere in doc, code, comments, or commits.

## The latency gate (Phase 1 spike — hardware-verified before any game code)

Founder hardware report: **iPhone est. audible ≈13 ms** (+ ~30–45 ms touch input) — **feels live**; loop **0 underruns over 158 s**, worst pump gap 34 ms; **desktop sub-ms tap deltas**. Final QA confirmed the feel holds **in the real studio**, not just the spike. The spike (`/dev/echo-spike`, dev-only, zero prod bundle weight) **stays in-tree as the audio regression harness**. Hedge: feel is device-dependent — quantization is the shock absorber, the AudioContext **pre-warms on the Start screen's first interaction** (tested: the child's first musical tap never pays the engine wake), and a **budget-device spike gates any classroom pilot**.

## Differentiation (why a fifth maker game isn't redundant)

| Activity | Creative medium | Core verb | STEM lens | Feedback relationship |
| --- | --- | --- | --- | --- |
| Boost Track Builder | Spatial piece construction | Build → ride | Speed, curves, cause/effect | Build, then test |
| Machine game (in design) | Logical instruction construction | Program → watch | Sequencing, loops, debugging | Program, then execute |
| Waterworks | Systems construction | Route → storm-test | Flow, protection, tradeoffs | Build, then simulate |
| Data Dash authoring | Structured challenge authoring | Author → challenge | Categories and sorting | Compose, then peer-play |
| **Echo Avenue** | **Live audiovisual performance** | **Improvise → layer → listen** | **Rhythm fractions, ratios, repetition, acoustics** | **Creation and feedback happen simultaneously** |

## Spiral

| Stage | Moment |
|---|---|
| **Imagine** | Mood previews (Together / Echo / Space); mute/volume/calm-lights **before Start**; starter pulse — the canvas is never blank |
| **Create** | Tap pads — the performer moves + sounds NOW; quantization keeps every tap musical (no "miss" can exist); Partner overdub; per-layer redo |
| **Play** | The loop IS playback; Watch the Take hides controls — Join in! / Change a layer |
| **Share** | Token name + cover pose → save-in-place → group gallery (Watch / Listen, **never autoplay**) |
| **Reflect** | ONE wondering question (call-and-response / rests / new-sound variants) → "Back to my studio" — separate moment from naming |

## Principles checklist (self-audit)

- ✅ Spiral is the spine (table above) · ✅ Creators, not consumers (the duet is theirs, named, shared)
- ✅ Low floor/high ceiling: 2-pad start → **fast unlock pacing** (~6 sounds in session one; unlocks respond to *making*, never accuracy — "ignoring prompts still unlocks" is a named test) → 3–5 full palette; 6–8 documented future mode
- ✅ Playground, not playpen: no wrong beat exists; rests are natural; empty takes cost nothing
- ✅ **Measure creation, not completion**: takes/layers/families/shares only; the completion payload is scanned by test for verdict words (`accuracy`, `correct`, `miss`, `combo`, `grade` appear nowhere; `streakMax` hard-zero)
- ✅ Adult is a guide (existing gallery pattern, no fork) · ✅ Localizable: EN + real ES; zh-CN on title tokens + mascot voice; vi placeholder; token pools localized per language, not word-by-word
- ✅ Kid-safety: approved-token titles only (no free text), group-scoped read-only gallery, first-name-only, **no mic/camera/recording of the child** — taps move the character
- ✅ Accessibility floor: one-pointer; keyboard (digits/R/W) with visible focus; 84px pads; `touch-action: manipulation`; no multitouch/drag/hold; `prefers-reduced-motion` on every animation; master + per-layer volume; loudness-normalized synthesis; **all sounds synthesized — zero audio assets, zero licensing surface**

## Silent-mode verdict (updated with the founder's muted run)

**PASS.** Every sound has a tested-distinct motion + pulse-light + trail signature; the founder's muted-tablet run confirmed the replay is **readable and expressive with audio off** — call-and-response and rests legible. The designed fallback (a subdivision tick-strip) was **not needed** and stays on the shelf, documented in the Phase 6 report.

## Gating + completion wiring

**Not student-visible**: gated via `HIDDEN_MODULE_SLUGS` — **ungate is one line** in `src/constants/stemSets.ts`. Completion mirrors Boost Track Builder exactly (standard `GameShell`/`completeActivity`, flat participation score/total, zero verdict UI in-studio); peers watching from the gallery **never see a results screen at all**. The set-wide "creation-shaped finish" question is tracked as **#693**.

## Verification

| Check | Result |
|---|---|
| FE / BE typecheck | 0 errors / clean |
| Repo lint (zero-warnings) | pass |
| Full unit suite | **528 passed / 0 failed** (19 pre-existing skips) — 75 Echo tests incl. quantization wrap, layer independence, unlock ladder, pre-warm contract, strict-validator levels, gallery never-crash mounts |
| Production build | ✓ 17.66s |
| **Schema proof** | `git diff origin/main -- prisma/ backend/prisma/` → seed files only |
| **Live round-trip** (real backend + Postgres) | **17/17 PASS**: author 201 + token title → gallery ships cover pose (other types stay lean) → reopen intact → rename-in-place (no fork) → share COMPLETE → live 422s (unknown key / zero events / off-grid slot) |
| Manual QA | founder-verified: live feel in the real studio, muted replay readable, keyboard pass, ES/中文 sweep |

## Coordination note (three branches, same seams)

This PR, **#691** (Track Builder), and **#692** (Waterworks) touch the same integration seams (`stemSets.ts`, `gameRegistry.ts`, seeds, `creationContent.ts`, `ChallengePlayer`, `GroupGallery`, locale files). Whichever PRs land later rebase; the conflicts are **mechanical unions** (allowlist entries, registry keys, seed blocks, type-switch arms) — each branch's edits were shaped for clean merging.

## Follow-ups (named, not here)

- Budget-device latency spike **before any classroom pilot** (required gate, design §4)
- #693 — set-wide creation-shaped finish decision (leads)
- Peer remix ("Invite a Partner") deferred past first release per ruling; sound-spot stage placement UI is v1-minimal
- zh-CN full pass beyond the selected surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
