### PR TITLE
docs: tidy contributor references and add a contribution note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ class) — on a fresh DB there is no K-2 class code. Works on long-lived demo DB
   approve their own PR; cross-pod PRs get both leads), **linear history** — squash merge preferred.
 - Branches: `your-name/short-description`. Conventional commits (`feat:`/`fix:`/`docs:`/...).
 - Log significant Claude Code prompts in `prompts/`. Intern guide: `docs/prompting-guide.md`.
-- Full workflow: `CONTRIBUTING.md` (pod leads: Alice Lin — Build, Catarina Lucas Herrera — Experience).
+- Full workflow: `CONTRIBUTING.md` (pod leads: Alice @alitlin — Build, Catarina @Cat-a-rina — Experience).
 - Labels, priority (`P0`/`P1`/`P2`) & delegation: canonical in `docs/team-workflow.md`.
 
 ### Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,13 @@ Before approving a PR, reviewers check:
 
 ## Pod Leads
 
-- **Build Pod Lead:** Alice Lin — reviews all Build Pod PRs
-- **Experience Pod Lead:** Catarina Lucas Herrera — reviews all Experience Pod PRs
+- **Build Pod Lead:** Alice (@alitlin) — reviews all Build Pod PRs
+- **Experience Pod Lead:** Catarina (@Cat-a-rina) — reviews all Experience Pod PRs
 - **Cross-pod PRs:** Both leads review
+
+> **Contribution note:** repo surfaces are for code — schedules, travel,
+> availability, and contact channels live in Slack, never in docs, issues,
+> or PRs.
 
 ## Labels, Priority & Delegation
 


### PR DESCRIPTION
Follow-up from this week's impersonation incident — two small hygiene items:

1. **Pod-lead references** in CONTRIBUTING.md and CLAUDE.md now use first name + GitHub handle (handles are inherently public; full names remain on commits, which is normal open source).
2. **One new convention line** in CONTRIBUTING.md: *repo surfaces are for code — schedules, travel, availability, and contact channels live in Slack, never in docs, issues, or PRs.*

No other content changes. Doc-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)