### PR TITLE
fix: rejects unexpected keys

### DIFF
--- a/backend/src/routes/creations.test.ts
+++ b/backend/src/routes/creations.test.ts
@@ -167,6 +167,22 @@ describe("Creations routes", () => {
           })
         )
     })
+
+    it("rejects a challenge with unexpected extra keys (422)", async () => {
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+
+      const res = await request(app)
+        .post("/api/creations")
+        .set(asStudent(KID))
+        .send({
+          courseId: COURSE,
+          type: "data_dash_challenge",
+          content: { ...validChallenge, surprise: "not allowed" },
+        });
+
+        expect(res.status).toBe(422);
+        expect(prismaMock.creation.create).not.toHaveBeenCalled();
+    })
   });
 
   describe("PATCH /api/creations/:id", () => {
@@ -245,6 +261,25 @@ describe("Creations routes", () => {
             })
           })
         )
+    })
+
+    it("rejects unexpected extra keys on update (422)", async () => {
+      prismaMock.creation.findUnique.mockResolvedValue({
+        id: "creation-1",
+        authorId: KID,
+        type: "data_dash_challenge",
+        content: validChallenge,
+      });
+
+      const res = await request(app)
+        .patch("/api/creations/creation-1")
+        .set(asStudent(KID))
+        .send({
+          content: { ...validChallenge, surprise: "not allowed" },
+        })
+
+      expect(res.status).toBe(422);
+      expect(prismaMock.creation.update).not.toHaveBeenCalled();
     })
   });
 
@@ -356,6 +391,23 @@ describe("Creations routes", () => {
 
       expect(res.status).toBe(404);
     });
+
+    it("does not return unexpected content keys", async () => {
+      prismaMock.creation.findUnique.mockResolvedValue({
+        ...dbCreation,
+        status: "SHARED",
+        content: { ...validChallenge, surprise: "not shared" }
+      });
+      prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+      
+      const res = await request(app)
+        .get("/api/creations/creation-1")
+        .set(asStudent(OTHER_KID));
+
+      expect(res.status).toBe(200);
+      expect(res.body.content).toEqual(validChallenge);
+      expect(res.body.content).not.toHaveProperty("surprise");
+    })
   });
 
   describe("POST /api/creations/:id/encourage", () => {

--- a/backend/src/routes/creations.ts
+++ b/backend/src/routes/creations.ts
@@ -316,8 +316,20 @@ router.get(
       return res.status(403).json({ error: "creation is not shared" });
     }
 
+    const safeContent =
+      typeof creation.content === "object" &&
+      creation.content !== null &&
+      !Array.isArray(creation.content)
+        ? {
+          v: creation.content.v,
+          cardIds: creation.content.cardIds,
+          sortRule: creation.content.sortRule,
+          inferRule: creation.content.inferRule,
+        }
+        : creation.content;
+
     // Single-get includes content so the creation can actually be played.
-    return res.json({ ...toDTO(creation), content: creation.content });
+    return res.json({ ...toDTO(creation), content: safeContent });
   },
 );
 

--- a/backend/src/services/dataDashChallenge.test.ts
+++ b/backend/src/services/dataDashChallenge.test.ts
@@ -88,4 +88,9 @@ describe("validateDataDashChallenge", () => {
     });
     expect(r.ok).toBe(false);
   });
+
+  it("rejects unexpected extra keys", () => {
+    const r = validateDataDashChallenge({ ...valid, surprise: "not allowed" });
+    expect(r.ok).toBe(false);
+  })
 });

--- a/backend/src/services/dataDashChallenge.ts
+++ b/backend/src/services/dataDashChallenge.ts
@@ -100,6 +100,13 @@ export function validateDataDashChallenge(content: unknown): ContentValidation {
   if (!c || typeof c !== "object") {
     return { ok: false, error: "challenge must be an object" };
   }
+
+  const allowedKeys = new Set(["v", "cardIds", "sortRule", "inferRule"]);
+  const extraKeys = Object.keys(c).filter((key) => !allowedKeys.has(key));
+  if(extraKeys.length > 0) {
+    return { ok: false, error: "unexpected field(s)" };
+  }
+
   if (c.v !== 1) {
     return { ok: false, error: "unsupported challenge version" };
   }


### PR DESCRIPTION
Closes #668:

- adds a check to validateDataDashChallenge to reject any unknown keys (gets called in both POST and PATCH)
- adds tests to validate that the check is working
- updates GET to only return expected keys (as an extra safety check)