### PR TITLE
fix: seed the K-2 STARS1 emoji-login class (closes #698)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,10 @@ Seed is find-or-create and **always refreshes password hashes**, so these plaint
 | marcus@test.com | marcus123 | Pathways Student (Launch) | 3/7 Cyber Launch done |
 | aisha@test.com | aisha123 | Pathways Student (Explorer) | Fresh, 0 completions |
 
-Class join codes seeded: `GRADE35` and `UPPER35` (both grade 3-5). Pathways cohort code: `ETO2026`
-("ETO Spring 2026 — Cyber Cohort", partner "Escape The Odds — South Side"; ended pilot: `ETO2025F`).
-⚠️ **Conflict, flagged:** `SETUP.md`/`docs/intern-credentials.md` say K-2 emoji login uses class code
-`STARS1`, but the current seed does **not** create it (it only reuses the teacher's pre-existing first
-class) — on a fresh DB there is no K-2 class code. Works on long-lived demo DBs where STARS1 already exists.
+Class join codes seeded: `STARS1` (K-2 emoji-login demo class "Ms. Frizzle's Star Class", band k2,
+with 3 emoji students: Nova ⭐ / Comet 🚀 / Luna 🌙, no PIN), `GRADE35` and `UPPER35` (both grade
+3-5). Pathways cohort code: `ETO2026` ("ETO Spring 2026 — Cyber Cohort", partner "Escape The Odds
+— South Side"; ended pilot: `ETO2025F`).
 
 ### Misc
 - Slack notifications are optional — without `SLACK_WEBHOOK_URL` they silently no-op (`backend/src/utils/slack.ts`).
@@ -166,7 +165,6 @@ Known conflicts (flag new ones explicitly — never silently pick a side):
 - `frontend/CONTRIBUTING.md` says Node 18; truth is Node 20 (engines + `.nvmrc`).
 - `backend/README.md` describes retired AWS Lambda/Aurora and self-flags as stale; production is
   **Railway + Supabase (PostgreSQL)**.
-- `STARS1` class code: in docs, not in seed (see Test accounts above).
 
 ---
 

--- a/backend/prisma/seed.cjs
+++ b/backend/prisma/seed.cjs
@@ -249,6 +249,55 @@ async function main() {
     update: {},
   });
 
+  // ---------------------------------------------------------------------
+  // K-2 emoji-login demo class — join code STARS1  (fixes #698)
+  //
+  // STARS1 was documented (intern-credentials.md, SETUP.md) as the K-2
+  // emoji-login class code but was NEVER seeded, so "Join with a Code" →
+  // STARS1 returned 404 and the K-2 section never unlocked. This seeds the
+  // class (Course.gradeBand defaults "k2") plus a few dedicated emoji-login
+  // students so the emoji-picker roster is non-empty. Effectively resolves
+  // #665. Idempotent (upsert by joinCode / stable student ids).
+  // ---------------------------------------------------------------------
+  const starsClass = await prisma.course.upsert({
+    where: { joinCode: "STARS1" },
+    // gradeBand intentionally omitted on create — schema default is "k2".
+    create: { name: "Ms. Frizzle's Star Class", joinCode: "STARS1", teacherId: teacher.id },
+    update: { gradeBand: "k2", teacherId: teacher.id },
+  });
+
+  // Dedicated emoji-login K-2 students: loginIcon set, NO PIN, NO email —
+  // fresh accounts so student@/explorer@ keep their existing semantics.
+  const starStudents = [
+    { id: "star-nova", name: "Nova", loginIcon: "⭐" },
+    { id: "star-comet", name: "Comet", loginIcon: "🚀" },
+    { id: "star-luna", name: "Luna", loginIcon: "🌙" },
+  ];
+  for (const s of starStudents) {
+    const kid = await prisma.user.upsert({
+      where: { id: s.id },
+      create: {
+        id: s.id,
+        name: s.name,
+        role: "student",
+        loginIcon: s.loginIcon,
+        xp: 0,
+        level: "Novice",
+      },
+      update: { name: s.name, loginIcon: s.loginIcon },
+    });
+    await prisma.enrollment.upsert({
+      where: { studentId_courseId: { studentId: kid.id, courseId: starsClass.id } },
+      create: { studentId: kid.id, courseId: starsClass.id },
+      update: {},
+    });
+  }
+  console.log(
+    "Seeded K-2 emoji-login class STARS1 (band k2) with",
+    starStudents.length,
+    "star students.",
+  );
+
   // 5. Seed Content
   console.log("Seeding modules...");
 

--- a/docs/intern-credentials.md
+++ b/docs/intern-credentials.md
@@ -22,7 +22,7 @@ All accounts are seeded in `prisma/seed.cjs` with bcrypt-hashed passwords. The s
 | `student@test.com` | `password` | Fresh K-2 student, Set 1 incomplete |
 | `explorer@test.com` | `explore123` | Set 1 complete, Set 2 unlocked |
 
-**Class code (emoji-picker flow):** `STARS1` — enter under "I'm a Student" → "Join with a Code", then pick your emoji to log in without a password.
+**Class code (emoji-picker flow):** `STARS1` — enter under "I'm a Student" → "Join with a Code", then pick your emoji to log in without a password. Seeded class **"Ms. Frizzle's Star Class"** (band k2) with three emoji students, no PIN: **Nova ⭐ · Comet 🚀 · Luna 🌙**.
 
 ## Grade 3-5 Student Account
 

--- a/prisma/__tests__/seedStars1.test.ts
+++ b/prisma/__tests__/seedStars1.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #698 — "STARS1 class code fails to unlock K-2".
+ *
+ * Root cause was a SEED OMISSION: STARS1 was documented as the K-2
+ * emoji-login class code but never seeded, so `/auth/lookup-code` 404'd and
+ * the K-2 section never unlocked. A mocked-endpoint test cannot catch this
+ * (it would mock the class into existence); the honest guard asserts the
+ * seed actually defines the STARS1 K-2 class + a non-empty emoji roster —
+ * the exact conditions the join chain (lookup-code → by-code roster →
+ * class-login → useGradeBand=k2) depends on. The end-to-end endpoint chain
+ * itself was verified live against the seeded stack (see the PR).
+ */
+const ROOT_SEED = resolve(__dirname, "../seed.cjs");
+const BACKEND_SEED = resolve(__dirname, "../../backend/prisma/seed.cjs");
+
+const src = readFileSync(ROOT_SEED, "utf8");
+
+describe("seed defines the STARS1 K-2 emoji-login class (#698)", () => {
+  it("creates a Course with joinCode STARS1", () => {
+    expect(src).toMatch(/joinCode:\s*"STARS1"/);
+  });
+
+  it("leaves STARS1 on the k2 band (never forces g3_5) so useGradeBand resolves k2", () => {
+    // Isolate the STARS1 upsert block and assert it is not created/updated as g3_5.
+    const block = src.slice(
+      src.indexOf('joinCode: "STARS1"') - 200,
+      src.indexOf('joinCode: "STARS1"') + 400,
+    );
+    expect(block).not.toMatch(/gradeBand:\s*"g3_5"/);
+    // Course.gradeBand defaults "k2" in the schema; the update path pins k2.
+    expect(block).toMatch(/gradeBand:\s*"k2"/);
+  });
+
+  it("enrolls emoji-login students (loginIcon set) so the roster is non-empty", () => {
+    // At least one student defined with a loginIcon…
+    expect(src).toMatch(/loginIcon:\s*"[^"]+"/);
+    // …and the star cohort is wired to the class via enrollment.
+    expect(src).toMatch(/star-nova|starStudents/);
+    expect(src).toMatch(/enrollment\.upsert/);
+  });
+
+  it("keeps STARS1 students PIN-less (emoji-only login path)", () => {
+    const block = src.slice(src.indexOf("starStudents"), src.indexOf("starStudents") + 600);
+    expect(block).not.toMatch(/loginPin/);
+  });
+
+  it("root and backend seed files stay byte-identical (sync invariant)", () => {
+    expect(readFileSync(BACKEND_SEED, "utf8")).toBe(src);
+  });
+});

--- a/prisma/seed.cjs
+++ b/prisma/seed.cjs
@@ -249,6 +249,55 @@ async function main() {
     update: {},
   });
 
+  // ---------------------------------------------------------------------
+  // K-2 emoji-login demo class — join code STARS1  (fixes #698)
+  //
+  // STARS1 was documented (intern-credentials.md, SETUP.md) as the K-2
+  // emoji-login class code but was NEVER seeded, so "Join with a Code" →
+  // STARS1 returned 404 and the K-2 section never unlocked. This seeds the
+  // class (Course.gradeBand defaults "k2") plus a few dedicated emoji-login
+  // students so the emoji-picker roster is non-empty. Effectively resolves
+  // #665. Idempotent (upsert by joinCode / stable student ids).
+  // ---------------------------------------------------------------------
+  const starsClass = await prisma.course.upsert({
+    where: { joinCode: "STARS1" },
+    // gradeBand intentionally omitted on create — schema default is "k2".
+    create: { name: "Ms. Frizzle's Star Class", joinCode: "STARS1", teacherId: teacher.id },
+    update: { gradeBand: "k2", teacherId: teacher.id },
+  });
+
+  // Dedicated emoji-login K-2 students: loginIcon set, NO PIN, NO email —
+  // fresh accounts so student@/explorer@ keep their existing semantics.
+  const starStudents = [
+    { id: "star-nova", name: "Nova", loginIcon: "⭐" },
+    { id: "star-comet", name: "Comet", loginIcon: "🚀" },
+    { id: "star-luna", name: "Luna", loginIcon: "🌙" },
+  ];
+  for (const s of starStudents) {
+    const kid = await prisma.user.upsert({
+      where: { id: s.id },
+      create: {
+        id: s.id,
+        name: s.name,
+        role: "student",
+        loginIcon: s.loginIcon,
+        xp: 0,
+        level: "Novice",
+      },
+      update: { name: s.name, loginIcon: s.loginIcon },
+    });
+    await prisma.enrollment.upsert({
+      where: { studentId_courseId: { studentId: kid.id, courseId: starsClass.id } },
+      create: { studentId: kid.id, courseId: starsClass.id },
+      update: {},
+    });
+  }
+  console.log(
+    "Seeded K-2 emoji-login class STARS1 (band k2) with",
+    starStudents.length,
+    "star students.",
+  );
+
   // 5. Seed Content
   console.log("Seeding modules...");
 


### PR DESCRIPTION
## Root cause

STARS1 was **documented** as the K-2 emoji-login class code (`intern-credentials.md`, `SETUP.md`, the smoke-test) but was **never created by the seed** — so entering it in "Join with a Code" hit `/auth/lookup-code`, found no course, and returned **404**; the K-2 section never unlocked. The join endpoints and band resolution were never broken (a real code like `GRADE35` resolves fine, and `Course.gradeBand` defaults `k2`); the class simply did not exist.

## The fix (minimal, seed-only)

Seed the missing class: `"Ms. Frizzle's Star Class"` with `joinCode: "STARS1"` (band defaults `k2`), plus three dedicated emoji-login students (Nova ⭐ / Comet 🚀 / Luna 🌙 — `loginIcon` set, no PIN, no email) so the emoji-picker roster is non-empty. Fresh accounts, so `student@`/`explorer@` keep their existing semantics.

**Blast radius:** both seed files (kept byte-identical), one regression test, two doc surfaces. **Zero schema/migration, zero route/validation changes** — the join endpoints were already correct, so nothing on the #669/#670 audit surface was touched or loosened. db-check stays green by construction (schema untouched).

## Verified end-to-end against the live seeded stack

| Step | Before | After |
|---|---|---|
| `lookup-code STARS1` | 404 | **200 k8_class** |
| `by-code/STARS1` roster | 404 | **3 emoji students** |
| `class-login` (Nova) | — | **token, login successful** |
| `useGradeBand` for that student | — | **k2** (only enrolled in the k2 Star Class) |

Regression guard: `prisma/__tests__/seedStars1.test.ts` asserts the seed defines the STARS1 k2 class + a non-empty emoji roster + seed-file sync. This targets the actual failure mode — a **seed omission** — which a mocked-endpoint test structurally cannot catch (it would mock the class into existence). The endpoint chain itself is the table above.

## Docs reconciled (part of this PR, not a footnote)

- **CLAUDE.md**: removed the stale "⚠️ Conflict flagged — STARS1 not in seed" block and the "in docs, not in seed" line; added STARS1 (+ its roster) to the seeded-codes list.
- **intern-credentials.md**: enriched the STARS1 line with the class name and emoji roster for testers.
- **SETUP.md** and **pre-launch-smoke-test.md**: their claims ("STARS1 → emoji login works") are now **true with no text edit** — the seed makes them accurate.

## Scope note

**Closes #698.** Effectively resolves **#665** (seed a K-2 emoji-login class). A separate re-seed ordering bug found during diagnosis (explorer enrolled before courses exist → resolves g3_5 on re-seeds) is filed as **#700** and deliberately left out of here.

**Deliberately does not address the band-architecture question (#699)** — this restores the broken path under the current design; where grade-banding should canonically live is a Build-pod decision for Alice's return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
