### PR TITLE
feat(progress): persist gameSpecific on activity complete

### DIFF
--- a/backend/prisma/migrations/20260716015000_add_progress_game_specific/migration.sql
+++ b/backend/prisma/migrations/20260716015000_add_progress_game_specific/migration.sql
@@ -1,0 +1,3 @@
+-- Add per-activity telemetry payload storage for ticket #672.
+ALTER TABLE "Progress"
+ADD COLUMN "gameSpecific" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -191,6 +191,7 @@ model Progress {
   activityId String
   status     ProgressStatus
   timeSpentS Int            @default(0)
+  gameSpecific Json?
   updatedAt  DateTime       @updatedAt
 
   User       User @relation(fields: [studentId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { GAME_SPECIFIC_SCHEMAS } from "../../validation/gameSpecific";
+
+const prismaMock = vi.hoisted(() => ({
+  user: { findUnique: vi.fn() },
+  progress: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    count: vi.fn(),
+  },
+  avatar: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+  activity: { findUnique: vi.fn() },
+  ability: { findMany: vi.fn() },
+  unlockedAbility: { findMany: vi.fn(), createMany: vi.fn() },
+  gamePersonalBest: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("../../utils/prisma", () => ({ default: prismaMock }));
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: class {
+    constructor() {
+      return prismaMock;
+    }
+  },
+}));
+
+vi.mock("../../services/analytics", () => ({
+  trackServer: vi.fn(),
+  shutdownAnalytics: vi.fn(),
+  getAnalyticsClient: vi.fn(() => null),
+}));
+
+import app from "../../server";
+
+const VALID_ACTIVITY = {
+  id: "valid-activity",
+  lessonId: "lesson-1",
+  title: "Test Activity",
+  kind: "INFO",
+  order: 1,
+  content: "{}",
+};
+
+const AVATAR = {
+  id: "avatar-1",
+  studentId: "student-123",
+  archetype: "AI",
+  xp: 100,
+  energy: 100,
+  hp: 100,
+  level: 1,
+};
+
+const validMoveMeasure = {
+  dash: 3,
+  jump: 4,
+  toss: 5,
+  impEvent: "dash" as const,
+  impScore: 2,
+  exitCorrect: true,
+};
+
+describe("POST /api/progress/complete-activity gameSpecific persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.avatar.findUnique.mockResolvedValue(AVATAR);
+    prismaMock.avatar.update.mockResolvedValue({ ...AVATAR, xp: 150 });
+    prismaMock.activity.findUnique.mockResolvedValue(VALID_ACTIVITY);
+    prismaMock.progress.count.mockResolvedValue(1);
+    prismaMock.ability.findMany.mockResolvedValue([]);
+    prismaMock.unlockedAbility.findMany.mockResolvedValue([]);
+    prismaMock.unlockedAbility.createMany.mockResolvedValue({ count: 0 });
+    prismaMock.gamePersonalBest.findUnique.mockResolvedValue(null);
+    prismaMock.gamePersonalBest.create.mockResolvedValue({});
+    prismaMock.gamePersonalBest.update.mockResolvedValue({});
+    prismaMock.gamePersonalBest.upsert.mockResolvedValue({});
+  });
+
+  it("C1-01: persists re-parsed move_measure gameSpecific on create", async () => {
+    prismaMock.progress.findUnique.mockResolvedValue(null);
+    prismaMock.progress.create.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: validMoveMeasure,
+    });
+
+    const res = await request(app)
+      .post("/api/progress/complete-activity")
+      .set("Authorization", "Bearer mock-token-for-mvp")
+      .send({
+        moduleSlug: "test-module",
+        lessonId: "lesson-1",
+        activityId: "valid-activity",
+        timeSpentS: 12,
+        result: {
+          gameKey: "move_measure",
+          score: 8,
+          gameSpecific: validMoveMeasure,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.create).toHaveBeenCalled();
+    const createArg = prismaMock.progress.create.mock.calls[0][0];
+    const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
+    expect(createArg.data.gameSpecific).toEqual(expected);
+  });
+
+  it("E-3: when gameSpecific is absent, update omits the field (preserves stored value)", async () => {
+    const stored = {
+      dash: 1,
+      jump: 2,
+      toss: 3,
+      impEvent: null,
+      impScore: 0,
+      exitCorrect: false,
+    };
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "IN_PROGRESS",
+      gameSpecific: stored,
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: stored,
+    });
+
+    const res = await request(app)
+      .post("/api/progress/complete-activity")
+      .set("Authorization", "Bearer mock-token-for-mvp")
+      .send({
+        moduleSlug: "test-module",
+        lessonId: "lesson-1",
+        activityId: "valid-activity",
+        timeSpentS: 5,
+        result: { gameKey: "move_measure", score: 3 },
+      });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.update).toHaveBeenCalled();
+    const updateArg = prismaMock.progress.update.mock.calls[0][0];
+    expect(updateArg.data).not.toHaveProperty("gameSpecific");
+  });
+
+  it("E-12: invalid gameSpecific returns 400 before any Progress write", async () => {
+    prismaMock.progress.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post("/api/progress/complete-activity")
+      .set("Authorization", "Bearer mock-token-for-mvp")
+      .send({
+        moduleSlug: "test-module",
+        lessonId: "lesson-1",
+        activityId: "valid-activity",
+        timeSpentS: 5,
+        result: {
+          gameKey: "move_measure",
+          gameSpecific: { ...validMoveMeasure, smuggle: true },
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.progress.create).not.toHaveBeenCalled();
+    expect(prismaMock.progress.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import request from "supertest";
-import { GAME_SPECIFIC_SCHEMAS } from "../../validation/gameSpecific";
+import {
+  GAME_SPECIFIC_MAX_BYTES,
+  GAME_SPECIFIC_SCHEMAS,
+  type RegisteredGameKey,
+} from "../../validation/gameSpecific";
 
 const prismaMock = vi.hoisted(() => ({
   user: { findUnique: vi.fn() },
@@ -64,14 +68,42 @@ const AVATAR = {
   level: 1,
 };
 
-const validMoveMeasure = {
-  dash: 3,
-  jump: 4,
-  toss: 5,
-  impEvent: "dash" as const,
-  impScore: 2,
-  exitCorrect: true,
+/** A2-01 inventoried payloads (remember.md) — self-contained for route suite. */
+const validByKey: Record<RegisteredGameKey, unknown> = {
+  move_measure: {
+    dash: 3,
+    jump: 4,
+    toss: 5,
+    impEvent: "dash",
+    impScore: 2,
+    exitCorrect: true,
+  },
+  quantum_quest: {
+    maxStreak: 3,
+    totalAttempted: 10,
+    sectorsCleared: 2,
+    powerUpsUsed: 1,
+  },
+  tank_trek: { totalChips: 4, retries: 1 },
+  qualify_tune_race: {
+    upgrade: "grip",
+    run1: { time: 12.5, bumps: 2, smoothness: 70 },
+    run2: null,
+    exitCorrect: true,
+  },
+  boost_path_planner: { attempts: 2 },
 };
+
+const validMoveMeasure = validByKey.move_measure as {
+  dash: number;
+  jump: number;
+  toss: number;
+  impEvent: "dash" | "jump" | "toss";
+  impScore: number;
+  exitCorrect: boolean;
+};
+
+const REGISTRY_KEYS = Object.keys(GAME_SPECIFIC_SCHEMAS) as RegisteredGameKey[];
 
 /** Isolate each request under the test gameActionLimiter (5/IP). */
 let ipSeq = 0;
@@ -82,6 +114,12 @@ function completeActivity(body: Record<string, unknown>) {
     .set("Authorization", "Bearer mock-token-for-mvp")
     .set("X-Forwarded-For", `198.51.100.${ipSeq}`)
     .send(body);
+}
+
+function expectNoProgressWrites() {
+  expect(prismaMock.progress.findUnique).not.toHaveBeenCalled();
+  expect(prismaMock.progress.create).not.toHaveBeenCalled();
+  expect(prismaMock.progress.update).not.toHaveBeenCalled();
 }
 
 describe("POST /api/progress/complete-activity gameSpecific persistence", () => {
@@ -100,7 +138,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     prismaMock.gamePersonalBest.upsert.mockResolvedValue({});
   });
 
-  it("C1-01: persists re-parsed move_measure gameSpecific on create", async () => {
+  it("T2-1-01 / AC-1 / C1-01: persists re-parsed move_measure gameSpecific on create", async () => {
     prismaMock.progress.findUnique.mockResolvedValue(null);
     prismaMock.progress.create.mockResolvedValue({
       id: "prog-1",
@@ -128,6 +166,66 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
     expect(createArg.data.gameSpecific).toEqual(expected);
     // §5.5 / §7: persist only — do not surface gameSpecific on the wire.
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+  });
+
+  it.each(REGISTRY_KEYS)(
+    "T2-1-02 / AC-1: round-trip persists gameSpecific for %s",
+    async (gameKey) => {
+      const payload = validByKey[gameKey];
+      const expected = GAME_SPECIFIC_SCHEMAS[gameKey].parse(payload);
+
+      prismaMock.progress.findUnique.mockResolvedValue(null);
+      prismaMock.progress.create.mockResolvedValue({
+        id: "prog-1",
+        studentId: "student-123",
+        activityId: "valid-activity",
+        status: "COMPLETED",
+        gameSpecific: expected,
+      });
+
+      const res = await completeActivity({
+        moduleSlug: "test-module",
+        lessonId: "lesson-1",
+        activityId: "valid-activity",
+        timeSpentS: 10,
+        result: {
+          gameKey,
+          score: 5,
+          gameSpecific: payload,
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(prismaMock.progress.create).toHaveBeenCalled();
+      const createArg = prismaMock.progress.create.mock.calls[0][0];
+      expect(createArg.data.gameSpecific).toEqual(expected);
+      expect(res.body.progress).not.toHaveProperty("gameSpecific");
+    },
+  );
+
+  it("T2-1-03 / E-1: POST without gameSpecific succeeds and omits column on create", async () => {
+    prismaMock.progress.findUnique.mockResolvedValue(null);
+    prismaMock.progress.create.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: null,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: { gameKey: "move_measure", score: 3 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.create).toHaveBeenCalled();
+    const createArg = prismaMock.progress.create.mock.calls[0][0];
+    expect(createArg.data).not.toHaveProperty("gameSpecific");
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
@@ -167,7 +265,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
-  it("E-3: when gameSpecific is absent, update omits the field (preserves stored value)", async () => {
+  it("T2-1-04 / E-3: when gameSpecific is absent, update omits the field (preserves stored value)", async () => {
     const stored = {
       dash: 1,
       jump: 2,
@@ -206,7 +304,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
-  it("E-3: POST with telemetry then POST without preserves via idempotent re-complete", async () => {
+  it("T2-1-04 / E-3: POST with telemetry then POST without preserves via idempotent re-complete", async () => {
     const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
 
     // First completion stores telemetry.
@@ -259,7 +357,26 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(second.body.progress).not.toHaveProperty("gameSpecific");
   });
 
-  it("E-12: invalid gameSpecific returns 400 before any Progress write", async () => {
+  it("T2-1-05 / E-4: unregistered gameKey with gameSpecific → 400, no Progress write", async () => {
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "not_a_registered_game",
+        gameSpecific: validMoveMeasure,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expectNoProgressWrites();
+    // T2-1-06 / G-103: do not echo payload fields.
+    expect(JSON.stringify(res.body)).not.toContain("dash");
+    expect(JSON.stringify(res.body)).not.toContain("impScore");
+  });
+
+  it("T2-1-05 / E-5 / E-12: unknown key inside gameSpecific → 400 before any Progress write", async () => {
     const res = await completeActivity({
       moduleSlug: "test-module",
       lessonId: "lesson-1",
@@ -272,11 +389,89 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     });
 
     expect(res.status).toBe(400);
-    expect(prismaMock.progress.findUnique).not.toHaveBeenCalled();
-    expect(prismaMock.progress.create).not.toHaveBeenCalled();
-    expect(prismaMock.progress.update).not.toHaveBeenCalled();
-    // G-103: 400 must not echo the submitted payload.
+    expectNoProgressWrites();
+    // T2-1-06 / G-103: 400 must not echo the submitted payload.
     expect(JSON.stringify(res.body)).not.toContain("smuggle");
+  });
+
+  it("T2-1-05 / E-7: oversized gameSpecific → 400 before any Progress write", async () => {
+    const padded: Record<string, unknown> = { ...validMoveMeasure };
+    let i = 0;
+    while (JSON.stringify(padded).length <= GAME_SPECIFIC_MAX_BYTES) {
+      padded[`pad_${i++}`] = "x".repeat(64);
+    }
+    expect(JSON.stringify(padded).length).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "move_measure",
+        gameSpecific: padded,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expectNoProgressWrites();
+    // T2-1-06 / G-103: do not echo pad keys or long filler.
+    expect(JSON.stringify(res.body)).not.toContain("pad_0");
+    expect(JSON.stringify(res.body)).not.toContain("x".repeat(64));
+  });
+
+  it("T2-1-07: IN_PROGRESS with stored A then POST with B overwrites (last-write-wins)", async () => {
+    const storedA = {
+      dash: 1,
+      jump: 1,
+      toss: 1,
+      impEvent: null as null,
+      impScore: 0,
+      exitCorrect: false,
+    };
+    const payloadB = {
+      dash: 9,
+      jump: 8,
+      toss: 7,
+      impEvent: "toss" as const,
+      impScore: 6,
+      exitCorrect: true,
+    };
+    const expectedB = GAME_SPECIFIC_SCHEMAS.move_measure.parse(payloadB);
+
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "IN_PROGRESS",
+      gameSpecific: storedA,
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expectedB,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 9,
+        gameSpecific: payloadB,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.update).toHaveBeenCalled();
+    const updateArg = prismaMock.progress.update.mock.calls[0][0];
+    expect(updateArg.data.gameSpecific).toEqual(expectedB);
+    expect(updateArg.data.gameSpecific).not.toEqual(storedA);
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
   it("C2-04 / §5.9.2: warns on unregistered gameKey when gameSpecific is sent (400 path)", async () => {

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -103,6 +103,15 @@ const validMoveMeasure = validByKey.move_measure as {
   exitCorrect: boolean;
 };
 
+/** A2-01 inventoried gameKeys (remember.md) — T2-1-02 must cover each. */
+const A2_01_KEYS = [
+  "move_measure",
+  "quantum_quest",
+  "tank_trek",
+  "qualify_tune_race",
+  "boost_path_planner",
+] as const satisfies readonly RegisteredGameKey[];
+
 const REGISTRY_KEYS = Object.keys(GAME_SPECIFIC_SCHEMAS) as RegisteredGameKey[];
 
 /** Isolate each request under the test gameActionLimiter (5/IP). */
@@ -174,9 +183,12 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
-  it.each(REGISTRY_KEYS)(
+  it.each(A2_01_KEYS)(
     "T2-1-02 / AC-1: round-trip Progress.gameSpecific deep-equals what was sent for %s",
     async (gameKey) => {
+      // Guard: registry must still include every A2-01 sender (inventory is authoritative).
+      expect(REGISTRY_KEYS).toContain(gameKey);
+
       const payload = validByKey[gameKey];
       const expected = GAME_SPECIFIC_SCHEMAS[gameKey].parse(payload);
 
@@ -210,6 +222,10 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
       expect(res.body.progress).not.toHaveProperty("gameSpecific");
     },
   );
+
+  it("T2-1-02: registry keys equal the A2-01 inventory (no missing/extra senders)", () => {
+    expect([...REGISTRY_KEYS].sort()).toEqual([...A2_01_KEYS].sort());
+  });
 
   it("T2-1-03 / E-1: POST without gameSpecific → 200, column null (omitted on create), no error", async () => {
     prismaMock.progress.findUnique.mockResolvedValue(null);
@@ -457,7 +473,8 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(body).toContain("move_measure");
   });
 
-  it("E-11: deeply nested gameSpecific is rejected (schemas allow only bounded primitives)", async () => {
+  it("E-11: deeply nested value in a primitive field is rejected (bounded primitives only)", async () => {
+    // Distinct from E-5 (unknown key): nest inside an allowlisted field that must be a number.
     const res = await completeActivity({
       moduleSlug: "test-module",
       lessonId: "lesson-1",
@@ -467,7 +484,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
         gameKey: "move_measure",
         gameSpecific: {
           ...validMoveMeasure,
-          nested: { deeper: { still: true } },
+          dash: { deeper: { still: 1 } },
         },
       },
     });

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -552,6 +552,261 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
+  it("R-1: COMPLETED replay overwrites gameSpecific (last-write-wins on idempotent path)", async () => {
+    const storedA = {
+      dash: 1,
+      jump: 1,
+      toss: 1,
+      impEvent: null as null,
+      impScore: 0,
+      exitCorrect: false,
+    };
+    const payloadB = {
+      dash: 9,
+      jump: 8,
+      toss: 7,
+      impEvent: "toss" as const,
+      impScore: 6,
+      exitCorrect: true,
+    };
+    const expectedB = GAME_SPECIFIC_SCHEMAS.move_measure.parse(payloadB);
+
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: storedA,
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-after-replay",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expectedB,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 9,
+        gameSpecific: payloadB,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.update).toHaveBeenCalledTimes(1);
+    const updateArg = prismaMock.progress.update.mock.calls[0][0];
+    expect(updateArg.where).toEqual({ id: "prog-1" });
+    expect(updateArg.data).toEqual({ gameSpecific: expectedB });
+  });
+
+  it("R-2: COMPLETED replay awards nothing (no XP/avatar/streak/GamePersonalBest)", async () => {
+    const payloadB = {
+      dash: 9,
+      jump: 8,
+      toss: 7,
+      impEvent: "toss" as const,
+      impScore: 6,
+      exitCorrect: true,
+    };
+    const expectedB = GAME_SPECIFIC_SCHEMAS.move_measure.parse(payloadB);
+
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: {
+        dash: 1,
+        jump: 1,
+        toss: 1,
+        impEvent: null,
+        impScore: 0,
+        exitCorrect: false,
+      },
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expectedB,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 9,
+        gameSpecific: payloadB,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Already completed");
+    expect(res.body.reward.xpDelta).toBe(0);
+    expect(res.body.reward.levelDelta).toBe(0);
+    expect(prismaMock.avatar.update).not.toHaveBeenCalled();
+    expect(prismaMock.avatar.create).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.create).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.update).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.upsert).not.toHaveBeenCalled();
+  });
+
+  it("R-3: COMPLETED replay without gameSpecific does not call update (E-3)", async () => {
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: validMoveMeasure,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: { gameKey: "move_measure", score: 3 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Already completed");
+    expect(prismaMock.progress.update).not.toHaveBeenCalled();
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+  });
+
+  it("R-4: COMPLETED replay with wasBackfilled writes telemetry and keeps backfilledXp", async () => {
+    const payloadB = {
+      dash: 9,
+      jump: 8,
+      toss: 7,
+      impEvent: "toss" as const,
+      impScore: 6,
+      exitCorrect: true,
+    };
+    const expectedB = GAME_SPECIFIC_SCHEMAS.move_measure.parse(payloadB);
+    // completedCount=1 → XP_PER_ACTIVITY(50) + levelUpBonus(0) = 50
+    const backfilledXp = 50;
+    const backfilledAvatar = {
+      id: "avatar-backfilled",
+      studentId: "student-123",
+      archetype: null,
+      xp: backfilledXp,
+      energy: 100,
+      hp: 100,
+      level: 1,
+    };
+
+    prismaMock.avatar.findUnique.mockResolvedValue(null);
+    prismaMock.progress.count.mockResolvedValue(1);
+    prismaMock.avatar.create.mockResolvedValue(backfilledAvatar);
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: {
+        dash: 1,
+        jump: 1,
+        toss: 1,
+        impEvent: null,
+        impScore: 0,
+        exitCorrect: false,
+      },
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expectedB,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 9,
+        gameSpecific: payloadB,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Already completed (avatar backfilled)");
+    expect(prismaMock.progress.update).toHaveBeenCalledTimes(1);
+    expect(prismaMock.progress.update.mock.calls[0][0].data).toEqual({
+      gameSpecific: expectedB,
+    });
+    expect(res.body.reward.xpDelta).toBe(backfilledXp);
+    expect(prismaMock.gamePersonalBest.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.create).not.toHaveBeenCalled();
+    expect(prismaMock.gamePersonalBest.update).not.toHaveBeenCalled();
+  });
+
+  it("R-5: COMPLETED replay response uses post-write row and omits gameSpecific", async () => {
+    const payloadB = {
+      dash: 9,
+      jump: 8,
+      toss: 7,
+      impEvent: "toss" as const,
+      impScore: 6,
+      exitCorrect: true,
+    };
+    const expectedB = GAME_SPECIFIC_SCHEMAS.move_measure.parse(payloadB);
+
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: {
+        dash: 1,
+        jump: 1,
+        toss: 1,
+        impEvent: null,
+        impScore: 0,
+        exitCorrect: false,
+      },
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-after-replay",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      moduleSlug: "test-module",
+      gameSpecific: expectedB,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 9,
+        gameSpecific: payloadB,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.progress.id).toBe("prog-after-replay");
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+  });
+
   it("C2-04 / §5.9.2: warns on unregistered gameKey when gameSpecific is sent (400 path)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -138,7 +138,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     prismaMock.gamePersonalBest.upsert.mockResolvedValue({});
   });
 
-  it("T2-1-01 / AC-1 / C1-01: persists re-parsed move_measure gameSpecific on create", async () => {
+  it("T2-1-01 / AC-1 / C1-01: POST move_measure → 200 → Progress row gameSpecific deep-equals what was sent", async () => {
     prismaMock.progress.findUnique.mockResolvedValue(null);
     prismaMock.progress.create.mockResolvedValue({
       id: "prog-1",
@@ -162,15 +162,20 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
     expect(res.status).toBe(200);
     expect(prismaMock.progress.create).toHaveBeenCalled();
-    const createArg = prismaMock.progress.create.mock.calls[0][0];
-    const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
-    expect(createArg.data.gameSpecific).toEqual(expected);
+    // A1-03 mock strategy: create data is the Progress row write (§14.4 "read the row").
+    const row = prismaMock.progress.create.mock.calls[0][0].data;
+    // AC-1: deep-equals what was sent.
+    expect(row.gameSpecific).toEqual(validMoveMeasure);
+    // C1-01 / E-8: stored value is the re-parsed registry object (same for a clean payload).
+    expect(row.gameSpecific).toEqual(
+      GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure),
+    );
     // §5.5 / §7: persist only — do not surface gameSpecific on the wire.
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
   it.each(REGISTRY_KEYS)(
-    "T2-1-02 / AC-1: round-trip persists gameSpecific for %s",
+    "T2-1-02 / AC-1: round-trip Progress.gameSpecific deep-equals what was sent for %s",
     async (gameKey) => {
       const payload = validByKey[gameKey];
       const expected = GAME_SPECIFIC_SCHEMAS[gameKey].parse(payload);
@@ -198,13 +203,15 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
       expect(res.status).toBe(200);
       expect(prismaMock.progress.create).toHaveBeenCalled();
-      const createArg = prismaMock.progress.create.mock.calls[0][0];
-      expect(createArg.data.gameSpecific).toEqual(expected);
+      const row = prismaMock.progress.create.mock.calls[0][0].data;
+      // AC-1: deep-equals what was sent (and the re-parsed registry value).
+      expect(row.gameSpecific).toEqual(payload);
+      expect(row.gameSpecific).toEqual(expected);
       expect(res.body.progress).not.toHaveProperty("gameSpecific");
     },
   );
 
-  it("T2-1-03 / E-1: POST without gameSpecific succeeds and omits column on create", async () => {
+  it("T2-1-03 / E-1: POST without gameSpecific → 200, column null (omitted on create), no error", async () => {
     prismaMock.progress.findUnique.mockResolvedValue(null);
     prismaMock.progress.create.mockResolvedValue({
       id: "prog-1",
@@ -224,8 +231,9 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
     expect(res.status).toBe(200);
     expect(prismaMock.progress.create).toHaveBeenCalled();
-    const createArg = prismaMock.progress.create.mock.calls[0][0];
-    expect(createArg.data).not.toHaveProperty("gameSpecific");
+    const row = prismaMock.progress.create.mock.calls[0][0].data;
+    // Omit from create ⇒ column stays null (Prisma default); never write null explicitly.
+    expect(row).not.toHaveProperty("gameSpecific");
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
@@ -357,7 +365,7 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(second.body.progress).not.toHaveProperty("gameSpecific");
   });
 
-  it("T2-1-05 / E-4: unregistered gameKey with gameSpecific → 400, no Progress write", async () => {
+  it("T2-1-05 / E-4 / E-12 / T2-1-06: unregistered gameKey + gameSpecific → 400, no write, no payload echo", async () => {
     const res = await completeActivity({
       moduleSlug: "test-module",
       lessonId: "lesson-1",
@@ -371,12 +379,15 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
     expect(res.status).toBe(400);
     expectNoProgressWrites();
-    // T2-1-06 / G-103: do not echo payload fields.
-    expect(JSON.stringify(res.body)).not.toContain("dash");
-    expect(JSON.stringify(res.body)).not.toContain("impScore");
+    const body = JSON.stringify(res.body);
+    // §5.9.1: name the field and gameKey; G-103: never echo payload content.
+    expect(body).toContain("gameSpecific");
+    expect(body).toContain("not_a_registered_game");
+    expect(body).not.toContain("dash");
+    expect(body).not.toContain("impScore");
   });
 
-  it("T2-1-05 / E-5 / E-12: unknown key inside gameSpecific → 400 before any Progress write", async () => {
+  it("T2-1-05 / E-5 / E-12 / T2-1-06: unknown key inside gameSpecific → 400 before any Progress write", async () => {
     const res = await completeActivity({
       moduleSlug: "test-module",
       lessonId: "lesson-1",
@@ -390,11 +401,14 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
     expect(res.status).toBe(400);
     expectNoProgressWrites();
-    // T2-1-06 / G-103: 400 must not echo the submitted payload.
-    expect(JSON.stringify(res.body)).not.toContain("smuggle");
+    const body = JSON.stringify(res.body);
+    // §5.9.1: name field + gameKey; G-103: do not echo smuggled key.
+    expect(body).toContain("gameSpecific");
+    expect(body).toContain("move_measure");
+    expect(body).not.toContain("smuggle");
   });
 
-  it("T2-1-05 / E-7: oversized gameSpecific → 400 before any Progress write", async () => {
+  it("T2-1-05 / E-7 / E-12 / T2-1-06: oversized gameSpecific → 400 before any Progress write", async () => {
     const padded: Record<string, unknown> = { ...validMoveMeasure };
     let i = 0;
     while (JSON.stringify(padded).length <= GAME_SPECIFIC_MAX_BYTES) {
@@ -415,12 +429,15 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
 
     expect(res.status).toBe(400);
     expectNoProgressWrites();
-    // T2-1-06 / G-103: do not echo pad keys or long filler.
-    expect(JSON.stringify(res.body)).not.toContain("pad_0");
-    expect(JSON.stringify(res.body)).not.toContain("x".repeat(64));
+    const body = JSON.stringify(res.body);
+    // §5.9.1: name field + gameKey; G-103: do not echo pad keys or filler.
+    expect(body).toContain("gameSpecific");
+    expect(body).toContain("move_measure");
+    expect(body).not.toContain("pad_0");
+    expect(body).not.toContain("x".repeat(64));
   });
 
-  it("T2-1-07: IN_PROGRESS with stored A then POST with B overwrites (last-write-wins)", async () => {
+  it("T2-1-07 / §5.2.3: IN_PROGRESS stored A then POST with B overwrites (last-write-wins on update path)", async () => {
     const storedA = {
       dash: 1,
       jump: 1,

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -73,6 +73,17 @@ const validMoveMeasure = {
   exitCorrect: true,
 };
 
+/** Isolate each request under the test gameActionLimiter (5/IP). */
+let ipSeq = 0;
+function completeActivity(body: Record<string, unknown>) {
+  ipSeq += 1;
+  return request(app)
+    .post("/api/progress/complete-activity")
+    .set("Authorization", "Bearer mock-token-for-mvp")
+    .set("X-Forwarded-For", `198.51.100.${ipSeq}`)
+    .send(body);
+}
+
 describe("POST /api/progress/complete-activity gameSpecific persistence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,20 +110,17 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
       gameSpecific: validMoveMeasure,
     });
 
-    const res = await request(app)
-      .post("/api/progress/complete-activity")
-      .set("Authorization", "Bearer mock-token-for-mvp")
-      .send({
-        moduleSlug: "test-module",
-        lessonId: "lesson-1",
-        activityId: "valid-activity",
-        timeSpentS: 12,
-        result: {
-          gameKey: "move_measure",
-          score: 8,
-          gameSpecific: validMoveMeasure,
-        },
-      });
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 12,
+      result: {
+        gameKey: "move_measure",
+        score: 8,
+        gameSpecific: validMoveMeasure,
+      },
+    });
 
     expect(res.status).toBe(200);
     expect(prismaMock.progress.create).toHaveBeenCalled();
@@ -120,6 +128,42 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
     expect(createArg.data.gameSpecific).toEqual(expected);
     // §5.5 / §7: persist only — do not surface gameSpecific on the wire.
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+  });
+
+  it("C2-01: persists re-parsed gameSpecific on update (IN_PROGRESS → COMPLETED)", async () => {
+    prismaMock.progress.findUnique.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "IN_PROGRESS",
+      gameSpecific: null,
+    });
+    prismaMock.progress.update.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: validMoveMeasure,
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 8,
+      result: {
+        gameKey: "move_measure",
+        score: 8,
+        gameSpecific: validMoveMeasure,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.progress.update).toHaveBeenCalled();
+    const updateArg = prismaMock.progress.update.mock.calls[0][0];
+    const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
+    expect(updateArg.data.gameSpecific).toEqual(expected);
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
@@ -147,42 +191,116 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
       gameSpecific: stored,
     });
 
-    const res = await request(app)
-      .post("/api/progress/complete-activity")
-      .set("Authorization", "Bearer mock-token-for-mvp")
-      .send({
-        moduleSlug: "test-module",
-        lessonId: "lesson-1",
-        activityId: "valid-activity",
-        timeSpentS: 5,
-        result: { gameKey: "move_measure", score: 3 },
-      });
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: { gameKey: "move_measure", score: 3 },
+    });
 
     expect(res.status).toBe(200);
     expect(prismaMock.progress.update).toHaveBeenCalled();
     const updateArg = prismaMock.progress.update.mock.calls[0][0];
     expect(updateArg.data).not.toHaveProperty("gameSpecific");
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+  });
+
+  it("E-3: POST with telemetry then POST without preserves via idempotent re-complete", async () => {
+    const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
+
+    // First completion stores telemetry.
+    prismaMock.progress.findUnique.mockResolvedValueOnce(null);
+    prismaMock.progress.create.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expected,
+    });
+
+    const first = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 12,
+      result: {
+        gameKey: "move_measure",
+        score: 8,
+        gameSpecific: validMoveMeasure,
+      },
+    });
+    expect(first.status).toBe(200);
+    expect(prismaMock.progress.create.mock.calls[0][0].data.gameSpecific).toEqual(
+      expected,
+    );
+
+    // Old client re-completes without gameSpecific — must not null stored value.
+    prismaMock.progress.findUnique.mockResolvedValueOnce({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+      gameSpecific: expected,
+    });
+
+    const second = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: { gameKey: "move_measure", score: 3 },
+    });
+
+    expect(second.status).toBe(200);
+    expect(second.body.message).toBe("Already completed");
+    expect(prismaMock.progress.update).not.toHaveBeenCalled();
+    expect(prismaMock.progress.create).toHaveBeenCalledTimes(1);
+    expect(second.body.progress).not.toHaveProperty("gameSpecific");
   });
 
   it("E-12: invalid gameSpecific returns 400 before any Progress write", async () => {
-    prismaMock.progress.findUnique.mockResolvedValue(null);
-
-    const res = await request(app)
-      .post("/api/progress/complete-activity")
-      .set("Authorization", "Bearer mock-token-for-mvp")
-      .send({
-        moduleSlug: "test-module",
-        lessonId: "lesson-1",
-        activityId: "valid-activity",
-        timeSpentS: 5,
-        result: {
-          gameKey: "move_measure",
-          gameSpecific: { ...validMoveMeasure, smuggle: true },
-        },
-      });
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "move_measure",
+        gameSpecific: { ...validMoveMeasure, smuggle: true },
+      },
+    });
 
     expect(res.status).toBe(400);
+    expect(prismaMock.progress.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.progress.create).not.toHaveBeenCalled();
     expect(prismaMock.progress.update).not.toHaveBeenCalled();
+    // G-103: 400 must not echo the submitted payload.
+    expect(JSON.stringify(res.body)).not.toContain("smuggle");
+  });
+
+  it("C2-04 / §5.9.2: unregistered gameKey without gameSpecific does not warn (happy path)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    prismaMock.progress.findUnique.mockResolvedValue(null);
+    prismaMock.progress.create.mockResolvedValue({
+      id: "prog-1",
+      studentId: "student-123",
+      activityId: "valid-activity",
+      status: "COMPLETED",
+    });
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: { gameKey: "fast_lane", score: 10 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Unregistered gameKey"),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -119,6 +119,8 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     const createArg = prismaMock.progress.create.mock.calls[0][0];
     const expected = GAME_SPECIFIC_SCHEMAS.move_measure.parse(validMoveMeasure);
     expect(createArg.data.gameSpecific).toEqual(expected);
+    // §5.5 / §7: persist only — do not surface gameSpecific on the wire.
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
   it("E-3: when gameSpecific is absent, update omits the field (preserves stored value)", async () => {

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -437,6 +437,50 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(body).not.toContain("x".repeat(64));
   });
 
+  it("E-9: explicit null gameSpecific → 400 (null is not omitted), no Progress write", async () => {
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "move_measure",
+        gameSpecific: null,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expectNoProgressWrites();
+    const body = JSON.stringify(res.body);
+    // §5.9.1: name field + gameKey; null is not treated as omit (contrast E-1).
+    expect(body).toContain("gameSpecific");
+    expect(body).toContain("move_measure");
+  });
+
+  it("E-11: deeply nested gameSpecific is rejected (schemas allow only bounded primitives)", async () => {
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "move_measure",
+        gameSpecific: {
+          ...validMoveMeasure,
+          nested: { deeper: { still: true } },
+        },
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expectNoProgressWrites();
+    const body = JSON.stringify(res.body);
+    expect(body).toContain("gameSpecific");
+    expect(body).toContain("move_measure");
+    expect(body).not.toContain("deeper");
+    expect(body).not.toContain("still");
+  });
+
   it("T2-1-07 / §5.2.3: IN_PROGRESS stored A then POST with B overwrites (last-write-wins on update path)", async () => {
     const storedA = {
       dash: 1,

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -279,6 +279,29 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     expect(JSON.stringify(res.body)).not.toContain("smuggle");
   });
 
+  it("C2-04 / §5.9.2: warns on unregistered gameKey when gameSpecific is sent (400 path)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await completeActivity({
+      moduleSlug: "test-module",
+      lessonId: "lesson-1",
+      activityId: "valid-activity",
+      timeSpentS: 5,
+      result: {
+        gameKey: "not_a_registered_game",
+        gameSpecific: validMoveMeasure,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[complete-activity] Unregistered gameKey "not_a_registered_game" (no gameSpecific registry entry)',
+    );
+    expect(JSON.stringify(res.body)).not.toContain("dash");
+    expect(prismaMock.progress.create).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it("C2-04 / §5.9.2: unregistered gameKey without gameSpecific does not warn (happy path)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     prismaMock.progress.findUnique.mockResolvedValue(null);

--- a/backend/src/routes/__tests__/progressGameSpecific.test.ts
+++ b/backend/src/routes/__tests__/progressGameSpecific.test.ts
@@ -353,9 +353,9 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
       },
     });
     expect(first.status).toBe(200);
-    expect(prismaMock.progress.create.mock.calls[0][0].data.gameSpecific).toEqual(
-      expected,
-    );
+    expect(
+      prismaMock.progress.create.mock.calls[0][0].data.gameSpecific,
+    ).toEqual(expected);
 
     // Old client re-completes without gameSpecific — must not null stored value.
     prismaMock.progress.findUnique.mockResolvedValueOnce({
@@ -430,7 +430,9 @@ describe("POST /api/progress/complete-activity gameSpecific persistence", () => 
     while (JSON.stringify(padded).length <= GAME_SPECIFIC_MAX_BYTES) {
       padded[`pad_${i++}`] = "x".repeat(64);
     }
-    expect(JSON.stringify(padded).length).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
+    expect(JSON.stringify(padded).length).toBeGreaterThan(
+      GAME_SPECIFIC_MAX_BYTES,
+    );
 
     const res = await completeActivity({
       moduleSlug: "test-module",

--- a/backend/src/routes/__tests__/progressScoringRegression.test.ts
+++ b/backend/src/routes/__tests__/progressScoringRegression.test.ts
@@ -186,25 +186,6 @@ function completeActivity(body: Record<string, unknown>) {
     .send(body);
 }
 
-/** Outcome slice for §14.5 / AC-4 — full response body minus nothing scoring-relevant. */
-function outcomeSlice(body: {
-  progress: unknown;
-  reward: unknown;
-  avatar: unknown;
-  personalBest: unknown;
-  isNewHighScore: unknown;
-  isNewBestStreak: unknown;
-}) {
-  return {
-    progress: body.progress,
-    reward: body.reward,
-    avatar: body.avatar,
-    personalBest: body.personalBest,
-    isNewHighScore: body.isNewHighScore,
-    isNewBestStreak: body.isNewBestStreak,
-  };
-}
-
 function setupFirstCompletionMocks(progressRow: Record<string, unknown> = PROGRESS_ROW) {
   prismaMock.avatar.findUnique.mockResolvedValue(AVATAR_BEFORE);
   prismaMock.avatar.update.mockResolvedValue(AVATAR_AFTER);
@@ -231,7 +212,8 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     const res = await completeActivity(FIXED_BODY);
 
     expect(res.status).toBe(200);
-    expect(outcomeSlice(res.body)).toEqual(SCORING_BASELINE);
+    // §14.5 / T3-1-01: exact response body (progress + XP/reward + streak/GPB flags)
+    expect(res.body).toEqual(SCORING_BASELINE);
     expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
       EXPECTED_AVATAR_UPDATE,
     );
@@ -244,7 +226,7 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     const res = await completeActivity(FIXED_BODY);
 
     expect(res.status).toBe(200);
-    expect(outcomeSlice(res.body)).toEqual(SCORING_BASELINE);
+    expect(res.body).toEqual(SCORING_BASELINE);
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
   });
 
@@ -252,7 +234,7 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     // Run A: without gameSpecific
     const without = await completeActivity(FIXED_BODY);
     expect(without.status).toBe(200);
-    const withoutOutcome = outcomeSlice(without.body);
+    expect(without.body).toEqual(SCORING_BASELINE);
     const withoutAvatarUpdate = prismaMock.avatar.update.mock.calls[0][0].data;
     const withoutGpbCreate = prismaMock.gamePersonalBest.create.mock.calls[0][0].data;
 
@@ -269,9 +251,9 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     });
     expect(withGs.status).toBe(200);
 
-    // §14.5: telemetry must not perturb scoring by so much as a point
-    expect(outcomeSlice(withGs.body)).toEqual(withoutOutcome);
-    expect(outcomeSlice(withGs.body)).toEqual(SCORING_BASELINE);
+    // §14.5: telemetry must not perturb scoring / response body by so much as a point
+    expect(withGs.body).toEqual(without.body);
+    expect(withGs.body).toEqual(SCORING_BASELINE);
     expect(withGs.body.progress).not.toHaveProperty("gameSpecific");
 
     expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
@@ -335,6 +317,12 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     expect(res.body.personalBest).toBeNull();
     expect(res.body.isNewHighScore).toBe(false);
     expect(res.body.isNewBestStreak).toBe(false);
+    // Scoring write path still ran before the GPB catch
+    expect(prismaMock.avatar.update).toHaveBeenCalled();
+    expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
+      EXPECTED_AVATAR_UPDATE,
+    );
+    expect(prismaMock.gamePersonalBest.create).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(
       "[complete-activity] Failed to upsert GamePersonalBest:",
       expect.any(Error),

--- a/backend/src/routes/__tests__/progressScoringRegression.test.ts
+++ b/backend/src/routes/__tests__/progressScoringRegression.test.ts
@@ -69,8 +69,9 @@ const AVATAR_BEFORE = {
   studentId: "student-123",
   archetype: "AI",
   xp: 100,
-  energy: 100,
-  hp: 100,
+  // Below cap so energyGain(+5)/hpGain(+2) appear in reward + avatar.update (AC-4).
+  energy: 50,
+  hp: 50,
   level: 1,
   speed: 0,
   control: 0,
@@ -81,8 +82,8 @@ const AVATAR_BEFORE = {
 const AVATAR_AFTER = {
   ...AVATAR_BEFORE,
   xp: 150,
-  energy: 100,
-  hp: 100,
+  energy: 55,
+  hp: 52,
   speed: 2,
   control: 3,
   focus: 2,
@@ -114,8 +115,8 @@ const PERSONAL_BEST = {
 /** Expected avatar.update data for the fixed request (main scoring path). */
 const EXPECTED_AVATAR_UPDATE = {
   xp: { increment: 50 },
-  energy: 100,
-  hp: 100,
+  energy: 55,
+  hp: 52,
   speed: 2,
   control: 3,
   focus: 2,
@@ -135,14 +136,15 @@ const EXPECTED_GPB_CREATE = {
 /**
  * T3-1-01 — main-equivalent outcome under this mock setup (saved fixture).
  * Includes response body fields §14.5 cares about: progress, XP/reward, streak/GPB.
+ * energyDelta/hpDelta are non-zero so AC-4 actually pins energyGain(+5)/hpGain(+2).
  */
 const SCORING_BASELINE = {
   progress: PROGRESS_ROW,
   reward: {
     xpDelta: 50,
     levelDelta: 0,
-    energyDelta: 0,
-    hpDelta: 0,
+    energyDelta: 5,
+    hpDelta: 2,
     newAbilitiesDelta: 0,
   },
   avatar: AVATAR_AFTER,

--- a/backend/src/routes/__tests__/progressScoringRegression.test.ts
+++ b/backend/src/routes/__tests__/progressScoringRegression.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+/**
+ * Part T3 — scoring/XP/`GamePersonalBest` regression (AC-4 / G-002).
+ *
+ * T3-1-01 baseline: frozen under this mock setup. Scoring path vs `main` is
+ * unchanged except gameSpecific / publicProgress / warn hunks
+ * (`git diff main...HEAD -- backend/src/routes/progress.ts`). Do not checkout main.
+ */
+
+const prismaMock = vi.hoisted(() => ({
+  user: { findUnique: vi.fn() },
+  progress: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    count: vi.fn(),
+  },
+  avatar: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+  activity: { findUnique: vi.fn() },
+  ability: { findMany: vi.fn() },
+  unlockedAbility: { findMany: vi.fn(), createMany: vi.fn() },
+  gamePersonalBest: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("../../utils/prisma", () => ({ default: prismaMock }));
+
+vi.mock("@prisma/client", () => ({
+  PrismaClient: class {
+    constructor() {
+      return prismaMock;
+    }
+  },
+}));
+
+vi.mock("../../services/analytics", () => ({
+  trackServer: vi.fn(),
+  shutdownAnalytics: vi.fn(),
+  getAnalyticsClient: vi.fn(() => null),
+}));
+
+import app from "../../server";
+
+const VALID_ACTIVITY = {
+  id: "valid-activity",
+  lessonId: "lesson-1",
+  title: "Test Activity",
+  kind: "INFO",
+  order: 1,
+  content: "{}",
+};
+
+const AVATAR_BEFORE = {
+  id: "avatar-1",
+  studentId: "student-123",
+  archetype: "AI",
+  xp: 100,
+  energy: 100,
+  hp: 100,
+  level: 1,
+  speed: 0,
+  control: 0,
+  focus: 0,
+};
+
+/** After XP_PER_ACTIVITY (+50) and calculateStatGains(score=8,total=10,timeSpentS=45). */
+const AVATAR_AFTER = {
+  ...AVATAR_BEFORE,
+  xp: 150,
+  energy: 100,
+  hp: 100,
+  speed: 2,
+  control: 3,
+  focus: 2,
+};
+
+const PROGRESS_ROW = {
+  id: "prog-1",
+  studentId: "student-123",
+  moduleSlug: "test-module",
+  lessonId: "lesson-1",
+  activityId: "valid-activity",
+  status: "COMPLETED",
+  timeSpentS: 45,
+};
+
+const PERSONAL_BEST = {
+  id: "gpb-1",
+  studentId: "student-123",
+  gameKey: "move_measure",
+  bestScore: 8,
+  lastScore: 8,
+  bestStreak: 3,
+  bestRoundsCompleted: 0,
+  playCount: 1,
+  meta: null,
+};
+
+/**
+ * Main-equivalent scoring slice under this mock setup (T3-1-01).
+ * XP_PER_ACTIVITY=50; energy already at cap; GPB first-play create.
+ */
+const SCORING_BASELINE = {
+  reward: {
+    xpDelta: 50,
+    levelDelta: 0,
+    energyDelta: 0,
+    hpDelta: 0,
+    newAbilitiesDelta: 0,
+  },
+  avatar: AVATAR_AFTER,
+  personalBest: PERSONAL_BEST,
+  isNewHighScore: true,
+  isNewBestStreak: true,
+};
+
+const validMoveMeasure = {
+  dash: 3,
+  jump: 4,
+  toss: 5,
+  impEvent: "dash" as const,
+  impScore: 2,
+  exitCorrect: true,
+};
+
+const FIXED_RESULT = {
+  gameKey: "move_measure",
+  score: 8,
+  total: 10,
+  streakMax: 3,
+};
+
+const FIXED_BODY = {
+  moduleSlug: "test-module",
+  lessonId: "lesson-1",
+  activityId: "valid-activity",
+  timeSpentS: 45,
+  result: FIXED_RESULT,
+};
+
+/** Isolate each request under the test gameActionLimiter (5/IP). */
+let ipSeq = 0;
+function completeActivity(body: Record<string, unknown>) {
+  ipSeq += 1;
+  return request(app)
+    .post("/api/progress/complete-activity")
+    .set("Authorization", "Bearer mock-token-for-mvp")
+    .set("X-Forwarded-For", `203.0.113.${ipSeq}`)
+    .send(body);
+}
+
+function scoringSlice(body: {
+  reward: unknown;
+  avatar: unknown;
+  personalBest: unknown;
+  isNewHighScore: unknown;
+  isNewBestStreak: unknown;
+}) {
+  return {
+    reward: body.reward,
+    avatar: body.avatar,
+    personalBest: body.personalBest,
+    isNewHighScore: body.isNewHighScore,
+    isNewBestStreak: body.isNewBestStreak,
+  };
+}
+
+function setupFirstCompletionMocks() {
+  prismaMock.avatar.findUnique.mockResolvedValue(AVATAR_BEFORE);
+  prismaMock.avatar.update.mockResolvedValue(AVATAR_AFTER);
+  prismaMock.activity.findUnique.mockResolvedValue(VALID_ACTIVITY);
+  prismaMock.progress.findUnique.mockResolvedValue(null);
+  prismaMock.progress.create.mockResolvedValue(PROGRESS_ROW);
+  prismaMock.progress.count.mockResolvedValue(1);
+  prismaMock.ability.findMany.mockResolvedValue([]);
+  prismaMock.unlockedAbility.findMany.mockResolvedValue([]);
+  prismaMock.unlockedAbility.createMany.mockResolvedValue({ count: 0 });
+  prismaMock.gamePersonalBest.findUnique.mockResolvedValue(null);
+  prismaMock.gamePersonalBest.create.mockResolvedValue(PERSONAL_BEST);
+  prismaMock.gamePersonalBest.update.mockResolvedValue(PERSONAL_BEST);
+  prismaMock.gamePersonalBest.upsert.mockResolvedValue(PERSONAL_BEST);
+}
+
+describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFirstCompletionMocks();
+  });
+
+  it("T3-1-01: SCORING_BASELINE matches first completion without gameSpecific", async () => {
+    const res = await completeActivity(FIXED_BODY);
+
+    expect(res.status).toBe(200);
+    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
+
+    const avatarUpdate = prismaMock.avatar.update.mock.calls[0][0];
+    expect(avatarUpdate.data.xp).toEqual({ increment: 50 });
+    expect(avatarUpdate.data).not.toHaveProperty("meta");
+    expect(avatarUpdate.data).not.toHaveProperty("gameSpecific");
+  });
+
+  it("T3-1-02: without gameSpecific matches SCORING_BASELINE", async () => {
+    const res = await completeActivity(FIXED_BODY);
+
+    expect(res.status).toBe(200);
+    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
+  });
+
+  it("T3-1-03: with valid gameSpecific still matches SCORING_BASELINE scoring slice", async () => {
+    prismaMock.progress.create.mockResolvedValue({
+      ...PROGRESS_ROW,
+      gameSpecific: validMoveMeasure,
+    });
+
+    const res = await completeActivity({
+      ...FIXED_BODY,
+      result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
+    });
+
+    expect(res.status).toBe(200);
+    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
+    expect(res.body.progress).not.toHaveProperty("gameSpecific");
+
+    const avatarUpdate = prismaMock.avatar.update.mock.calls[0][0];
+    expect(avatarUpdate.data.xp).toEqual({ increment: 50 });
+
+    const gpbCreate = prismaMock.gamePersonalBest.create.mock.calls[0][0];
+    expect(gpbCreate.data).toMatchObject({
+      studentId: "student-123",
+      gameKey: "move_measure",
+      bestScore: 8,
+      lastScore: 8,
+      bestStreak: 3,
+      bestRoundsCompleted: 0,
+      playCount: 1,
+    });
+    expect(gpbCreate.data).not.toHaveProperty("meta");
+    expect(gpbCreate.data).not.toHaveProperty("gameSpecific");
+  });
+
+  it("T3-1-04: GamePersonalBest row has meta null and create never sets meta", async () => {
+    const without = await completeActivity(FIXED_BODY);
+    expect(without.status).toBe(200);
+    expect(without.body.personalBest.meta).toBeNull();
+    expect(
+      prismaMock.gamePersonalBest.create.mock.calls[0][0].data,
+    ).not.toHaveProperty("meta");
+
+    vi.clearAllMocks();
+    setupFirstCompletionMocks();
+    prismaMock.progress.create.mockResolvedValue({
+      ...PROGRESS_ROW,
+      gameSpecific: validMoveMeasure,
+    });
+
+    const withGs = await completeActivity({
+      ...FIXED_BODY,
+      result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
+    });
+    expect(withGs.status).toBe(200);
+    expect(withGs.body.personalBest.meta).toBeNull();
+    expect(
+      prismaMock.gamePersonalBest.create.mock.calls[0][0].data,
+    ).not.toHaveProperty("meta");
+    expect(scoringSlice(withGs.body)).toEqual(SCORING_BASELINE);
+  });
+
+  it("T3-1-05: GamePersonalBest failure still completes with scoring rewards + warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    prismaMock.gamePersonalBest.findUnique.mockRejectedValue(
+      new Error("forced GPB failure"),
+    );
+
+    const res = await completeActivity({
+      ...FIXED_BODY,
+      result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reward).toEqual(SCORING_BASELINE.reward);
+    expect(res.body.avatar).toEqual(SCORING_BASELINE.avatar);
+    expect(res.body.personalBest).toBeNull();
+    expect(res.body.isNewHighScore).toBe(false);
+    expect(res.body.isNewBestStreak).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[complete-activity] Failed to upsert GamePersonalBest:",
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/backend/src/routes/__tests__/progressScoringRegression.test.ts
+++ b/backend/src/routes/__tests__/progressScoringRegression.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import request from "supertest";
 
 /**
- * Part T3 — scoring/XP/`GamePersonalBest` regression (AC-4 / G-002).
+ * Part T3 — scoring/XP/`GamePersonalBest` regression (AC-4 / G-002 / overview §14.5).
  *
- * T3-1-01 baseline: frozen under this mock setup. Scoring path vs `main` is
- * unchanged except gameSpecific / publicProgress / warn hunks
+ * T3-1-01 baseline: frozen under this mock setup (A1-03 mock-Prisma strategy).
+ * Scoring path vs `main` is unchanged except gameSpecific / publicProgress / warn hunks
  * (`git diff main...HEAD -- backend/src/routes/progress.ts`). Do not checkout main.
+ *
+ * T3-1-06 is a process check (run pre-existing progress suites; confirm zero assertion
+ * edits in git diff) — not an it() below.
  */
 
 const prismaMock = vi.hoisted(() => ({
@@ -85,6 +88,7 @@ const AVATAR_AFTER = {
   focus: 2,
 };
 
+/** Public progress row — no gameSpecific (v1 §5.5). */
 const PROGRESS_ROW = {
   id: "prog-1",
   studentId: "student-123",
@@ -107,11 +111,33 @@ const PERSONAL_BEST = {
   meta: null,
 };
 
+/** Expected avatar.update data for the fixed request (main scoring path). */
+const EXPECTED_AVATAR_UPDATE = {
+  xp: { increment: 50 },
+  energy: 100,
+  hp: 100,
+  speed: 2,
+  control: 3,
+  focus: 2,
+};
+
+/** Expected GamePersonalBest.create data (first play; no meta). */
+const EXPECTED_GPB_CREATE = {
+  studentId: "student-123",
+  gameKey: "move_measure",
+  bestScore: 8,
+  lastScore: 8,
+  bestStreak: 3,
+  bestRoundsCompleted: 0,
+  playCount: 1,
+};
+
 /**
- * Main-equivalent scoring slice under this mock setup (T3-1-01).
- * XP_PER_ACTIVITY=50; energy already at cap; GPB first-play create.
+ * T3-1-01 — main-equivalent outcome under this mock setup (saved fixture).
+ * Includes response body fields §14.5 cares about: progress, XP/reward, streak/GPB.
  */
 const SCORING_BASELINE = {
+  progress: PROGRESS_ROW,
   reward: {
     xpDelta: 50,
     levelDelta: 0,
@@ -160,7 +186,9 @@ function completeActivity(body: Record<string, unknown>) {
     .send(body);
 }
 
-function scoringSlice(body: {
+/** Outcome slice for §14.5 / AC-4 — full response body minus nothing scoring-relevant. */
+function outcomeSlice(body: {
+  progress: unknown;
   reward: unknown;
   avatar: unknown;
   personalBest: unknown;
@@ -168,6 +196,7 @@ function scoringSlice(body: {
   isNewBestStreak: unknown;
 }) {
   return {
+    progress: body.progress,
     reward: body.reward,
     avatar: body.avatar,
     personalBest: body.personalBest,
@@ -176,12 +205,12 @@ function scoringSlice(body: {
   };
 }
 
-function setupFirstCompletionMocks() {
+function setupFirstCompletionMocks(progressRow: Record<string, unknown> = PROGRESS_ROW) {
   prismaMock.avatar.findUnique.mockResolvedValue(AVATAR_BEFORE);
   prismaMock.avatar.update.mockResolvedValue(AVATAR_AFTER);
   prismaMock.activity.findUnique.mockResolvedValue(VALID_ACTIVITY);
   prismaMock.progress.findUnique.mockResolvedValue(null);
-  prismaMock.progress.create.mockResolvedValue(PROGRESS_ROW);
+  prismaMock.progress.create.mockResolvedValue(progressRow);
   prismaMock.progress.count.mockResolvedValue(1);
   prismaMock.ability.findMany.mockResolvedValue([]);
   prismaMock.unlockedAbility.findMany.mockResolvedValue([]);
@@ -198,68 +227,38 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     setupFirstCompletionMocks();
   });
 
-  it("T3-1-01: SCORING_BASELINE matches first completion without gameSpecific", async () => {
+  it("T3-1-01: SCORING_BASELINE records main-equivalent outcome for fixed completion", async () => {
     const res = await completeActivity(FIXED_BODY);
 
     expect(res.status).toBe(200);
-    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
-
-    const avatarUpdate = prismaMock.avatar.update.mock.calls[0][0];
-    expect(avatarUpdate.data.xp).toEqual({ increment: 50 });
-    expect(avatarUpdate.data).not.toHaveProperty("meta");
-    expect(avatarUpdate.data).not.toHaveProperty("gameSpecific");
+    expect(outcomeSlice(res.body)).toEqual(SCORING_BASELINE);
+    expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
+      EXPECTED_AVATAR_UPDATE,
+    );
+    expect(prismaMock.gamePersonalBest.create.mock.calls[0][0].data).toEqual(
+      EXPECTED_GPB_CREATE,
+    );
   });
 
-  it("T3-1-02: without gameSpecific matches SCORING_BASELINE", async () => {
+  it("T3-1-02: without gameSpecific matches SCORING_BASELINE (byte-identical outcome)", async () => {
     const res = await completeActivity(FIXED_BODY);
 
     expect(res.status).toBe(200);
-    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
-  });
-
-  it("T3-1-03: with valid gameSpecific still matches SCORING_BASELINE scoring slice", async () => {
-    prismaMock.progress.create.mockResolvedValue({
-      ...PROGRESS_ROW,
-      gameSpecific: validMoveMeasure,
-    });
-
-    const res = await completeActivity({
-      ...FIXED_BODY,
-      result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
-    });
-
-    expect(res.status).toBe(200);
-    expect(scoringSlice(res.body)).toEqual(SCORING_BASELINE);
+    expect(outcomeSlice(res.body)).toEqual(SCORING_BASELINE);
     expect(res.body.progress).not.toHaveProperty("gameSpecific");
-
-    const avatarUpdate = prismaMock.avatar.update.mock.calls[0][0];
-    expect(avatarUpdate.data.xp).toEqual({ increment: 50 });
-
-    const gpbCreate = prismaMock.gamePersonalBest.create.mock.calls[0][0];
-    expect(gpbCreate.data).toMatchObject({
-      studentId: "student-123",
-      gameKey: "move_measure",
-      bestScore: 8,
-      lastScore: 8,
-      bestStreak: 3,
-      bestRoundsCompleted: 0,
-      playCount: 1,
-    });
-    expect(gpbCreate.data).not.toHaveProperty("meta");
-    expect(gpbCreate.data).not.toHaveProperty("gameSpecific");
   });
 
-  it("T3-1-04: GamePersonalBest row has meta null and create never sets meta", async () => {
+  it("T3-1-03: with valid gameSpecific still matches without (XP/streak/GPB/response)", async () => {
+    // Run A: without gameSpecific
     const without = await completeActivity(FIXED_BODY);
     expect(without.status).toBe(200);
-    expect(without.body.personalBest.meta).toBeNull();
-    expect(
-      prismaMock.gamePersonalBest.create.mock.calls[0][0].data,
-    ).not.toHaveProperty("meta");
+    const withoutOutcome = outcomeSlice(without.body);
+    const withoutAvatarUpdate = prismaMock.avatar.update.mock.calls[0][0].data;
+    const withoutGpbCreate = prismaMock.gamePersonalBest.create.mock.calls[0][0].data;
 
+    // Run B: same request with valid gameSpecific (DB row may carry telemetry; wire must not)
     vi.clearAllMocks();
-    setupFirstCompletionMocks();
-    prismaMock.progress.create.mockResolvedValue({
+    setupFirstCompletionMocks({
       ...PROGRESS_ROW,
       gameSpecific: validMoveMeasure,
     });
@@ -269,11 +268,52 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
       result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
     });
     expect(withGs.status).toBe(200);
+
+    // §14.5: telemetry must not perturb scoring by so much as a point
+    expect(outcomeSlice(withGs.body)).toEqual(withoutOutcome);
+    expect(outcomeSlice(withGs.body)).toEqual(SCORING_BASELINE);
+    expect(withGs.body.progress).not.toHaveProperty("gameSpecific");
+
+    expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
+      withoutAvatarUpdate,
+    );
+    expect(prismaMock.avatar.update.mock.calls[0][0].data).toEqual(
+      EXPECTED_AVATAR_UPDATE,
+    );
+    expect(prismaMock.gamePersonalBest.create.mock.calls[0][0].data).toEqual(
+      withoutGpbCreate,
+    );
+    expect(prismaMock.gamePersonalBest.create.mock.calls[0][0].data).toEqual(
+      EXPECTED_GPB_CREATE,
+    );
+  });
+
+  it("T3-1-04: GamePersonalBest after both identical to baseline; meta still null", async () => {
+    const without = await completeActivity(FIXED_BODY);
+    expect(without.status).toBe(200);
+    expect(without.body.personalBest).toEqual(SCORING_BASELINE.personalBest);
+    expect(without.body.personalBest.meta).toBeNull();
+    expect(
+      prismaMock.gamePersonalBest.create.mock.calls[0][0].data,
+    ).not.toHaveProperty("meta");
+
+    vi.clearAllMocks();
+    setupFirstCompletionMocks({
+      ...PROGRESS_ROW,
+      gameSpecific: validMoveMeasure,
+    });
+
+    const withGs = await completeActivity({
+      ...FIXED_BODY,
+      result: { ...FIXED_RESULT, gameSpecific: validMoveMeasure },
+    });
+    expect(withGs.status).toBe(200);
+    expect(withGs.body.personalBest).toEqual(SCORING_BASELINE.personalBest);
     expect(withGs.body.personalBest.meta).toBeNull();
     expect(
       prismaMock.gamePersonalBest.create.mock.calls[0][0].data,
     ).not.toHaveProperty("meta");
-    expect(scoringSlice(withGs.body)).toEqual(SCORING_BASELINE);
+    expect(withGs.body.personalBest).toEqual(without.body.personalBest);
   });
 
   it("T3-1-05: GamePersonalBest failure still completes with scoring rewards + warn", async () => {
@@ -288,8 +328,10 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     });
 
     expect(res.status).toBe(200);
+    // Rewards still awarded (GPB is best-effort; telemetry path is not)
     expect(res.body.reward).toEqual(SCORING_BASELINE.reward);
     expect(res.body.avatar).toEqual(SCORING_BASELINE.avatar);
+    expect(res.body.progress).toEqual(SCORING_BASELINE.progress);
     expect(res.body.personalBest).toBeNull();
     expect(res.body.isNewHighScore).toBe(false);
     expect(res.body.isNewBestStreak).toBe(false);

--- a/backend/src/routes/__tests__/progressScoringRegression.test.ts
+++ b/backend/src/routes/__tests__/progressScoringRegression.test.ts
@@ -188,7 +188,9 @@ function completeActivity(body: Record<string, unknown>) {
     .send(body);
 }
 
-function setupFirstCompletionMocks(progressRow: Record<string, unknown> = PROGRESS_ROW) {
+function setupFirstCompletionMocks(
+  progressRow: Record<string, unknown> = PROGRESS_ROW,
+) {
   prismaMock.avatar.findUnique.mockResolvedValue(AVATAR_BEFORE);
   prismaMock.avatar.update.mockResolvedValue(AVATAR_AFTER);
   prismaMock.activity.findUnique.mockResolvedValue(VALID_ACTIVITY);
@@ -238,7 +240,8 @@ describe("POST /api/progress/complete-activity scoring regression (AC-4 / T3)", 
     expect(without.status).toBe(200);
     expect(without.body).toEqual(SCORING_BASELINE);
     const withoutAvatarUpdate = prismaMock.avatar.update.mock.calls[0][0].data;
-    const withoutGpbCreate = prismaMock.gamePersonalBest.create.mock.calls[0][0].data;
+    const withoutGpbCreate =
+      prismaMock.gamePersonalBest.create.mock.calls[0][0].data;
 
     // Run B: same request with valid gameSpecific (DB row may carry telemetry; wire must not)
     vi.clearAllMocks();

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -117,6 +117,19 @@ router.post(
 
     const parse = completeActivitySchema.safeParse(req.body);
     if (!parse.success) {
+      // §5.9.2: deploy-bug signal — gameSpecific sent for a key with no registry entry.
+      // Must run on the 400 path; schema rejects before a successful parse reaches re-parse.
+      const bodyResult = req.body?.result;
+      if (
+        bodyResult?.gameSpecific !== undefined &&
+        typeof bodyResult?.gameKey === "string" &&
+        bodyResult.gameKey.length > 0 &&
+        !isRegisteredGameKey(bodyResult.gameKey)
+      ) {
+        console.warn(
+          `[complete-activity] Unregistered gameKey "${bodyResult.gameKey}" (no gameSpecific registry entry)`,
+        );
+      }
       return res.status(400).json({ error: parse.error.flatten() });
     }
 
@@ -129,18 +142,6 @@ router.post(
       isRegisteredGameKey(result.gameKey)
         ? GAME_SPECIFIC_SCHEMAS[result.gameKey].parse(result.gameSpecific)
         : undefined;
-
-    // §5.9.2: no happy-path logging. Only warn when gameSpecific was sent for an
-    // unregistered key (schema should 400 first; this is defense-in-depth).
-    if (
-      result?.gameSpecific !== undefined &&
-      result.gameKey &&
-      !isRegisteredGameKey(result.gameKey)
-    ) {
-      console.warn(
-        `[complete-activity] Unregistered gameKey "${result.gameKey}" (no gameSpecific registry entry)`,
-      );
-    }
 
     // 0. Fetch Existing Progress and Activity concurrently
     // ⚡ Bolt Optimization: Parallelize independent DB reads to reduce latency

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -117,18 +117,22 @@ router.post(
 
     const parse = completeActivitySchema.safeParse(req.body);
     if (!parse.success) {
-      // §5.9.2: deploy-bug signal — gameSpecific sent for a key with no registry entry.
-      // Must run on the 400 path; schema rejects before a successful parse reaches re-parse.
-      const bodyResult = req.body?.result;
-      if (
-        bodyResult?.gameSpecific !== undefined &&
-        typeof bodyResult?.gameKey === "string" &&
-        bodyResult.gameKey.length > 0 &&
-        !isRegisteredGameKey(bodyResult.gameKey)
-      ) {
-        console.warn(
-          `[complete-activity] Unregistered gameKey "${bodyResult.gameKey}" (no gameSpecific registry entry)`,
+      // §5.9.2: deploy-bug signal when schema rejected gameSpecific for an unknown key.
+      // Use the schema issue (gameKey already max-bounded) — never log raw body / payload.
+      const unregisteredIssue = parse.error.issues.find(
+        (i) =>
+          typeof i.message === "string" &&
+          i.message.startsWith('gameSpecific not accepted for gameKey "'),
+      );
+      if (unregisteredIssue) {
+        const match = unregisteredIssue.message.match(
+          /^gameSpecific not accepted for gameKey "([^"]{1,50})"$/,
         );
+        if (match) {
+          console.warn(
+            `[complete-activity] Unregistered gameKey "${match[1]}" (no gameSpecific registry entry)`,
+          );
+        }
       }
       return res.status(400).json({ error: parse.error.flatten() });
     }

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -22,6 +22,10 @@ import {
   idSchema,
   slugSchema,
 } from "../validation/schemas";
+import {
+  GAME_SPECIFIC_SCHEMAS,
+  isRegisteredGameKey,
+} from "../validation/gameSpecific";
 import { upsertCheckpoint, getAggregatedProgress } from "../services/progress";
 import { trackServer } from "../services/analytics";
 import { GameError } from "../utils/errors";
@@ -112,6 +116,20 @@ router.post(
 
     const { moduleSlug, lessonId, activityId, timeSpentS, result } = parse.data;
 
+    // Re-parse: superRefine validates but does not transform (E-8 / G-009).
+    const gs =
+      result?.gameSpecific !== undefined &&
+      result.gameKey &&
+      isRegisteredGameKey(result.gameKey)
+        ? GAME_SPECIFIC_SCHEMAS[result.gameKey].parse(result.gameSpecific)
+        : undefined;
+
+    if (result?.gameKey && !isRegisteredGameKey(result.gameKey)) {
+      console.warn(
+        `[complete-activity] Unregistered gameKey "${result.gameKey}" (no gameSpecific registry entry)`,
+      );
+    }
+
     // 0. Fetch Existing Progress and Activity concurrently
     // ⚡ Bolt Optimization: Parallelize independent DB reads to reduce latency
     // 🛡️ Sentinel: Verify activity existence to prevent Game Integrity/Infinite Leveling exploit
@@ -181,6 +199,7 @@ router.post(
         data: {
           status: ProgressStatus.COMPLETED,
           timeSpentS: { increment: timeSpentS || 0 },
+          ...(gs !== undefined ? { gameSpecific: gs } : {}),
         },
       });
     } else {
@@ -192,6 +211,7 @@ router.post(
           activityId,
           status: ProgressStatus.COMPLETED,
           timeSpentS: timeSpentS || 0,
+          ...(gs !== undefined ? { gameSpecific: gs } : {}),
         },
       });
     }

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -32,6 +32,12 @@ import { GameError } from "../utils/errors";
 
 const router = Router();
 
+/** v1 stores gameSpecific but must not expose it on any response (§5.5 / §7). */
+function publicProgress<T extends { gameSpecific?: unknown }>(row: T) {
+  const { gameSpecific: _omit, ...rest } = row;
+  return rest;
+}
+
 // Get progress for a student (MVP)
 router.get("/progress", requireAuth, async (req, res) => {
   const studentId = req.user!.id;
@@ -164,7 +170,7 @@ router.post(
       if (wasBackfilled) {
         return res.json({
           message: "Already completed (avatar backfilled)",
-          progress: existing,
+          progress: publicProgress(existing),
           reward: {
             xpDelta: backfilledXp,
             levelDelta: avatarBefore.level - 1, // Delta from level 1
@@ -179,7 +185,7 @@ router.post(
       // Normal idempotent return with 0 rewards
       return res.json({
         message: "Already completed",
-        progress: existing,
+        progress: publicProgress(existing),
         reward: {
           xpDelta: 0,
           levelDelta: 0,
@@ -366,7 +372,7 @@ router.post(
     }
 
     res.json({
-      progress: finalProgress,
+      progress: publicProgress(finalProgress),
       reward: {
         xpDelta,
         levelDelta,

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -33,6 +33,17 @@ router.get("/progress", requireAuth, async (req, res) => {
   const studentId = req.user!.id;
   const progress = await prisma.progress.findMany({
     where: { studentId },
+    // Keep v1 contract stable for #672: persist only, do not expose gameSpecific.
+    select: {
+      id: true,
+      studentId: true,
+      moduleSlug: true,
+      lessonId: true,
+      activityId: true,
+      status: true,
+      timeSpentS: true,
+      updatedAt: true,
+    },
   });
   res.json(progress);
 });

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -130,7 +130,13 @@ router.post(
         ? GAME_SPECIFIC_SCHEMAS[result.gameKey].parse(result.gameSpecific)
         : undefined;
 
-    if (result?.gameKey && !isRegisteredGameKey(result.gameKey)) {
+    // §5.9.2: no happy-path logging. Only warn when gameSpecific was sent for an
+    // unregistered key (schema should 400 first; this is defense-in-depth).
+    if (
+      result?.gameSpecific !== undefined &&
+      result.gameKey &&
+      !isRegisteredGameKey(result.gameKey)
+    ) {
       console.warn(
         `[complete-activity] Unregistered gameKey "${result.gameKey}" (no gameSpecific registry entry)`,
       );

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -175,13 +175,25 @@ router.post(
 
     // Handle idempotent case: activity already completed
     if (existing && existing.status === ProgressStatus.COMPLETED) {
+      // Replay: persist newer telemetry (last-write-wins, §5.2.3) WITHOUT re-awarding
+      // anything. XP, streak, avatar, and GamePersonalBest are deliberately untouched —
+      // this path must stay reward-free. Omitted gameSpecific never nulls a stored
+      // value (E-3), so only write when the client actually sent telemetry.
+      let replayed = existing;
+      if (gs !== undefined) {
+        replayed = await prisma.progress.update({
+          where: { id: existing.id },
+          data: { gameSpecific: gs },
+        });
+      }
+
       // If avatar was just backfilled, return the backfilled XP as the delta
       // This handles the edge case where user completed activities without an avatar
       // and later triggers completion again
       if (wasBackfilled) {
         return res.json({
           message: "Already completed (avatar backfilled)",
-          progress: publicProgress(existing),
+          progress: publicProgress(replayed),
           reward: {
             xpDelta: backfilledXp,
             levelDelta: avatarBefore.level - 1, // Delta from level 1
@@ -196,7 +208,7 @@ router.post(
       // Normal idempotent return with 0 rewards
       return res.json({
         message: "Already completed",
-        progress: publicProgress(existing),
+        progress: publicProgress(replayed),
         reward: {
           xpDelta: 0,
           levelDelta: 0,

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -272,12 +272,17 @@ router.post(
         }
       } catch {
         // If parsing fails, use default XP
-        console.warn("[complete-activity] Failed to parse activity.content for totalRounds");
+        console.warn(
+          "[complete-activity] Failed to parse activity.content for totalRounds",
+        );
       }
 
       if (totalRoundsFromContent > 0) {
         // Clamp roundsCompleted to server-known totalRounds (prevents cheating)
-        const rc = Math.min(Math.max(result.roundsCompleted, 0), totalRoundsFromContent);
+        const rc = Math.min(
+          Math.max(result.roundsCompleted, 0),
+          totalRoundsFromContent,
+        );
         xpAward = Math.round((rc / totalRoundsFromContent) * XP_PER_ACTIVITY);
         xpAward = Math.min(Math.max(xpAward, 0), XP_PER_ACTIVITY); // Final clamp
       }
@@ -311,7 +316,10 @@ router.post(
       const currentFocus = (avatarBefore as any).focus || 0;
 
       updateData.speed = Math.min(STAT_MAX, currentSpeed + statGains.speed);
-      updateData.control = Math.min(STAT_MAX, currentControl + statGains.control);
+      updateData.control = Math.min(
+        STAT_MAX,
+        currentControl + statGains.control,
+      );
       updateData.focus = Math.min(STAT_MAX, currentFocus + statGains.focus);
 
       // ⚡ Bolt Optimization: Capture updated avatar to avoid refetching in checkUnlocks
@@ -369,7 +377,10 @@ router.post(
               lastScore: newScore,
               bestScore: Math.max(existing.bestScore, newScore),
               bestStreak: Math.max(existing.bestStreak, newStreak),
-              bestRoundsCompleted: Math.max(existing.bestRoundsCompleted, newRounds),
+              bestRoundsCompleted: Math.max(
+                existing.bestRoundsCompleted,
+                newRounds,
+              ),
               playCount: { increment: 1 },
               lastPlayedAt: new Date(),
             },
@@ -390,7 +401,10 @@ router.post(
           });
         }
       } catch (e) {
-        console.warn("[complete-activity] Failed to upsert GamePersonalBest:", e);
+        console.warn(
+          "[complete-activity] Failed to upsert GamePersonalBest:",
+          e,
+        );
       }
     }
 

--- a/backend/src/validation/__tests__/completeActivitySchema.test.ts
+++ b/backend/src/validation/__tests__/completeActivitySchema.test.ts
@@ -32,8 +32,10 @@ describe("completeActivitySchema gameSpecific", () => {
     });
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
-      const paths = parsed.error.issues.map((i) => i.path.join("."));
-      expect(paths.some((p) => p.includes("gameSpecific"))).toBe(true);
+      // Spec refers to the keyed issue under `gameSpecific`; Zod may include
+      // the parent `result` segment depending on where the superRefine lives.
+      const paths = parsed.error.issues.map((i) => i.path);
+      expect(paths.some((p) => p[p.length - 1] === "gameSpecific")).toBe(true);
     }
   });
 
@@ -59,14 +61,31 @@ describe("completeActivitySchema gameSpecific", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("E-6: array/string/number gameSpecific fails", () => {
-    for (const bad of [[1, 2], "nope", 42]) {
-      const parsed = completeActivitySchema.safeParse({
+  it("E-6: array gameSpecific fails", () => {
+    expect(
+      completeActivitySchema.safeParse({
         ...base,
-        result: { gameKey: "move_measure", gameSpecific: bad },
-      });
-      expect(parsed.success, String(bad)).toBe(false);
-    }
+        result: { gameKey: "move_measure", gameSpecific: [1, 2] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("E-6: string gameSpecific fails", () => {
+    expect(
+      completeActivitySchema.safeParse({
+        ...base,
+        result: { gameKey: "move_measure", gameSpecific: "nope" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("E-6: number gameSpecific fails", () => {
+    expect(
+      completeActivitySchema.safeParse({
+        ...base,
+        result: { gameKey: "move_measure", gameSpecific: 42 },
+      }).success,
+    ).toBe(false);
   });
 
   it("E-9: explicit null gameSpecific fails", () => {

--- a/backend/src/validation/__tests__/completeActivitySchema.test.ts
+++ b/backend/src/validation/__tests__/completeActivitySchema.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { GAME_SPECIFIC_MAX_BYTES } from "../gameSpecific";
+import { completeActivitySchema } from "../schemas";
+
+const base = {
+  moduleSlug: "stem-1-intro",
+  activityId: "act-1",
+};
+
+const validMoveMeasure = {
+  dash: 5,
+  jump: 7,
+  toss: 3,
+  impEvent: "dash" as const,
+  impScore: 4,
+  exitCorrect: true,
+};
+
+describe("completeActivitySchema gameSpecific", () => {
+  it("E-1: omitted gameSpecific parses fine", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", score: 10 },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('E-2: gameSpecific without gameKey fails with path ["gameSpecific"]', () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameSpecific: validMoveMeasure },
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const paths = parsed.error.issues.map((i) => i.path.join("."));
+      expect(paths.some((p) => p.includes("gameSpecific"))).toBe(true);
+    }
+  });
+
+  it("E-4: unregistered gameKey fails", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: {
+        gameKey: "not_a_registered_game",
+        gameSpecific: validMoveMeasure,
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("E-5: extra key inside gameSpecific fails via .strict()", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: {
+        gameKey: "move_measure",
+        gameSpecific: { ...validMoveMeasure, smuggle: true },
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("E-6: array/string/number gameSpecific fails", () => {
+    for (const bad of [[1, 2], "nope", 42]) {
+      const parsed = completeActivitySchema.safeParse({
+        ...base,
+        result: { gameKey: "move_measure", gameSpecific: bad },
+      });
+      expect(parsed.success, String(bad)).toBe(false);
+    }
+  });
+
+  it("E-9: explicit null gameSpecific fails", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: null },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("E-7: serialized payload larger than GAME_SPECIFIC_MAX_BYTES fails", () => {
+    const padded: Record<string, unknown> = { ...validMoveMeasure };
+    let i = 0;
+    while (JSON.stringify(padded).length <= GAME_SPECIFIC_MAX_BYTES) {
+      padded[`pad_${i++}`] = "x".repeat(64);
+    }
+    expect(JSON.stringify(padded).length).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
+
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: padded },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("E-8: after parse(), result.gameSpecific is the raw value (superRefine does not transform)", () => {
+    const raw = { ...validMoveMeasure };
+    const parsed = completeActivitySchema.parse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: raw },
+    });
+    // Documents that superRefine validates without transforming — Part C must re-parse.
+    expect(parsed.result?.gameSpecific).toEqual(raw);
+    expect(parsed.result?.gameSpecific).toBe(raw);
+  });
+
+  it("R-1 via schema: valid move_measure gameSpecific is retained after parse", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: validMoveMeasure },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.result?.gameSpecific).toEqual(validMoveMeasure);
+    }
+  });
+
+  it("G-002: existing result fields still parse identically", () => {
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: {
+        gameKey: "move_measure",
+        score: 42,
+        total: 100,
+        streakMax: 7,
+        roundsCompleted: 3,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.result).toEqual({
+        gameKey: "move_measure",
+        score: 42,
+        total: 100,
+        streakMax: 7,
+        roundsCompleted: 3,
+      });
+    }
+  });
+});

--- a/backend/src/validation/__tests__/completeActivitySchema.test.ts
+++ b/backend/src/validation/__tests__/completeActivitySchema.test.ts
@@ -101,10 +101,14 @@ describe("completeActivitySchema gameSpecific", () => {
   it("E-7: serialized payload larger than GAME_SPECIFIC_MAX_BYTES fails", () => {
     const padded: Record<string, unknown> = { ...validMoveMeasure };
     let i = 0;
-    while (JSON.stringify(padded).length <= GAME_SPECIFIC_MAX_BYTES) {
+    while (
+      Buffer.byteLength(JSON.stringify(padded), "utf8") <= GAME_SPECIFIC_MAX_BYTES
+    ) {
       padded[`pad_${i++}`] = "x".repeat(64);
     }
-    expect(JSON.stringify(padded).length).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
+    expect(
+      Buffer.byteLength(JSON.stringify(padded), "utf8"),
+    ).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
 
     const parsed = completeActivitySchema.safeParse({
       ...base,
@@ -118,6 +122,57 @@ describe("completeActivitySchema gameSpecific", () => {
         "gameSpecific",
       ]);
     }
+  });
+
+  it("E-7b: payload under by String.length but over by UTF-8 bytes is rejected", () => {
+    // CJK ideograph U+4E00 is 1 UTF-16 code unit but 3 UTF-8 bytes.
+    // Pad until .length is under the cap while byteLength is over it.
+    const padded: Record<string, unknown> = { ...validMoveMeasure };
+    let i = 0;
+    while (
+      Buffer.byteLength(JSON.stringify(padded), "utf8") <= GAME_SPECIFIC_MAX_BYTES
+    ) {
+      padded[`pad_${i++}`] = "一".repeat(64);
+    }
+    const serialized = JSON.stringify(padded);
+    expect(serialized.length).toBeLessThanOrEqual(GAME_SPECIFIC_MAX_BYTES);
+    expect(Buffer.byteLength(serialized, "utf8")).toBeGreaterThan(
+      GAME_SPECIFIC_MAX_BYTES,
+    );
+
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: padded },
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues.map((i) => i.path)).toContainEqual([
+        "result",
+        "gameSpecific",
+      ]);
+    }
+  });
+
+  it("E-7c: maximal valid ASCII move_measure payload is unaffected by byteLength gate", () => {
+    const maximal = {
+      dash: 10,
+      jump: 10,
+      toss: 10,
+      impEvent: "toss" as const,
+      impScore: 10,
+      exitCorrect: true,
+    };
+    const serialized = JSON.stringify(maximal);
+    expect(Buffer.byteLength(serialized, "utf8")).toBe(serialized.length);
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThan(
+      GAME_SPECIFIC_MAX_BYTES,
+    );
+
+    const parsed = completeActivitySchema.safeParse({
+      ...base,
+      result: { gameKey: "move_measure", gameSpecific: maximal },
+    });
+    expect(parsed.success).toBe(true);
   });
 
   it("E-8: after parse(), result.gameSpecific is the raw value (superRefine does not transform)", () => {

--- a/backend/src/validation/__tests__/completeActivitySchema.test.ts
+++ b/backend/src/validation/__tests__/completeActivitySchema.test.ts
@@ -32,10 +32,12 @@ describe("completeActivitySchema gameSpecific", () => {
     });
     expect(parsed.success).toBe(false);
     if (!parsed.success) {
-      // Spec refers to the keyed issue under `gameSpecific`; Zod may include
-      // the parent `result` segment depending on where the superRefine lives.
-      const paths = parsed.error.issues.map((i) => i.path);
-      expect(paths.some((p) => p[p.length - 1] === "gameSpecific")).toBe(true);
+      // overview.md §14.2 / §5.3.3: addIssue path is ["gameSpecific"] on the
+      // result object → full Zod path is ["result", "gameSpecific"].
+      expect(parsed.error.issues.map((i) => i.path)).toContainEqual([
+        "result",
+        "gameSpecific",
+      ]);
     }
   });
 
@@ -109,6 +111,13 @@ describe("completeActivitySchema gameSpecific", () => {
       result: { gameKey: "move_measure", gameSpecific: padded },
     });
     expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      // Size gate rejects via the gameSpecific issue path (§5.3.4).
+      expect(parsed.error.issues.map((i) => i.path)).toContainEqual([
+        "result",
+        "gameSpecific",
+      ]);
+    }
   });
 
   it("E-8: after parse(), result.gameSpecific is the raw value (superRefine does not transform)", () => {

--- a/backend/src/validation/__tests__/completeActivitySchema.test.ts
+++ b/backend/src/validation/__tests__/completeActivitySchema.test.ts
@@ -102,13 +102,14 @@ describe("completeActivitySchema gameSpecific", () => {
     const padded: Record<string, unknown> = { ...validMoveMeasure };
     let i = 0;
     while (
-      Buffer.byteLength(JSON.stringify(padded), "utf8") <= GAME_SPECIFIC_MAX_BYTES
+      Buffer.byteLength(JSON.stringify(padded), "utf8") <=
+      GAME_SPECIFIC_MAX_BYTES
     ) {
       padded[`pad_${i++}`] = "x".repeat(64);
     }
-    expect(
-      Buffer.byteLength(JSON.stringify(padded), "utf8"),
-    ).toBeGreaterThan(GAME_SPECIFIC_MAX_BYTES);
+    expect(Buffer.byteLength(JSON.stringify(padded), "utf8")).toBeGreaterThan(
+      GAME_SPECIFIC_MAX_BYTES,
+    );
 
     const parsed = completeActivitySchema.safeParse({
       ...base,
@@ -130,7 +131,8 @@ describe("completeActivitySchema gameSpecific", () => {
     const padded: Record<string, unknown> = { ...validMoveMeasure };
     let i = 0;
     while (
-      Buffer.byteLength(JSON.stringify(padded), "utf8") <= GAME_SPECIFIC_MAX_BYTES
+      Buffer.byteLength(JSON.stringify(padded), "utf8") <=
+      GAME_SPECIFIC_MAX_BYTES
     ) {
       padded[`pad_${i++}`] = "一".repeat(64);
     }

--- a/backend/src/validation/__tests__/gameSpecific.test.ts
+++ b/backend/src/validation/__tests__/gameSpecific.test.ts
@@ -63,7 +63,7 @@ const FIELD_BOUNDS: Array<{
   { key: "tank_trek", field: "totalChips", max: 10000 },
   { key: "tank_trek", field: "retries", max: 10000 },
   { key: "boost_path_planner", field: "attempts", max: 10000 },
-  { key: "qualify_tune_race", field: "time", max: 300, nest: "run1" },
+  { key: "qualify_tune_race", field: "time", max: 86400, nest: "run1" },
   { key: "qualify_tune_race", field: "bumps", max: 10, nest: "run1" },
   { key: "qualify_tune_race", field: "smoothness", max: 100, nest: "run1" },
 ];

--- a/backend/src/validation/__tests__/gameSpecific.test.ts
+++ b/backend/src/validation/__tests__/gameSpecific.test.ts
@@ -233,7 +233,10 @@ describe("R-4/R-5 guard bite (local loose copy)", () => {
       );
     }
     const prodSource = readFileSync(moduleSourcePath, "utf8");
+    // Full R-5 set (overview.md §14.2 + T1-1-03)
     expect(prodSource).not.toMatch(/z\.any\b/);
+    expect(prodSource).not.toMatch(/z\.record\b/);
+    expect(prodSource).not.toMatch(/z\.unknown\b/);
     expect(prodSource).not.toContain(".passthrough(");
   });
 });

--- a/backend/src/validation/__tests__/gameSpecific.test.ts
+++ b/backend/src/validation/__tests__/gameSpecific.test.ts
@@ -1,0 +1,226 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  GAME_SPECIFIC_MAX_BYTES,
+  GAME_SPECIFIC_SCHEMAS,
+  isRegisteredGameKey,
+  type RegisteredGameKey,
+} from "../gameSpecific";
+
+/** A2-01 inventoried gameKeys (remember.md). */
+const INVENTORIED_KEYS = [
+  "move_measure",
+  "quantum_quest",
+  "tank_trek",
+  "qualify_tune_race",
+  "boost_path_planner",
+] as const satisfies readonly RegisteredGameKey[];
+
+const validMoveMeasure = {
+  dash: 5,
+  jump: 7,
+  toss: 3,
+  impEvent: "dash" as const,
+  impScore: 4,
+  exitCorrect: true,
+};
+
+const validByKey: Record<RegisteredGameKey, unknown> = {
+  move_measure: validMoveMeasure,
+  quantum_quest: {
+    maxStreak: 3,
+    totalAttempted: 10,
+    sectorsCleared: 2,
+    powerUpsUsed: 1,
+  },
+  tank_trek: { totalChips: 4, retries: 1 },
+  qualify_tune_race: {
+    upgrade: "grip",
+    run1: { time: 12.5, bumps: 2, smoothness: 70 },
+    run2: null,
+    exitCorrect: true,
+  },
+  boost_path_planner: { attempts: 2 },
+};
+
+/** Bounds match gameSpecific.ts (A2-04). */
+const FIELD_BOUNDS: Array<{
+  key: RegisteredGameKey;
+  field: string;
+  max: number;
+  nest?: string;
+}> = [
+  { key: "move_measure", field: "dash", max: 10 },
+  { key: "move_measure", field: "jump", max: 10 },
+  { key: "move_measure", field: "toss", max: 10 },
+  { key: "move_measure", field: "impScore", max: 10 },
+  { key: "quantum_quest", field: "maxStreak", max: 200 },
+  { key: "quantum_quest", field: "totalAttempted", max: 10000 },
+  { key: "quantum_quest", field: "sectorsCleared", max: 50 },
+  { key: "quantum_quest", field: "powerUpsUsed", max: 10000 },
+  { key: "tank_trek", field: "totalChips", max: 10000 },
+  { key: "tank_trek", field: "retries", max: 10000 },
+  { key: "boost_path_planner", field: "attempts", max: 10000 },
+  { key: "qualify_tune_race", field: "time", max: 300, nest: "run1" },
+  { key: "qualify_tune_race", field: "bumps", max: 10, nest: "run1" },
+  { key: "qualify_tune_race", field: "smoothness", max: 100, nest: "run1" },
+];
+
+function withField(
+  base: Record<string, unknown>,
+  field: string,
+  value: unknown,
+  nest?: string,
+): Record<string, unknown> {
+  const clone = structuredClone(base);
+  if (!nest) {
+    clone[field] = value;
+    return clone;
+  }
+  (clone[nest] as Record<string, unknown>)[field] = value;
+  return clone;
+}
+
+// Resolve from repo root (vitest cwd). Avoid import.meta — backend tsconfig is CommonJS.
+const moduleSourcePath = join(
+  process.cwd(),
+  "backend/src/validation/gameSpecific.ts",
+);
+
+describe("GAME_SPECIFIC_SCHEMAS", () => {
+  it("R-1: valid move_measure payload parses", () => {
+    const parsed = GAME_SPECIFIC_SCHEMAS.move_measure.safeParse(validMoveMeasure);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).toEqual(validMoveMeasure);
+    }
+  });
+
+  it("R-1: every inventoried game parses a valid payload", () => {
+    for (const [key, payload] of Object.entries(validByKey)) {
+      const schema = GAME_SPECIFIC_SCHEMAS[key as RegisteredGameKey];
+      const parsed = schema.safeParse(payload);
+      expect(parsed.success, key).toBe(true);
+    }
+  });
+
+  it("R-2: each bounded field passes at its max and fails at max+1", () => {
+    for (const { key, field, max, nest } of FIELD_BOUNDS) {
+      const base = validByKey[key] as Record<string, unknown>;
+      // qualify_tune_race needs a non-null run1 for nested bounds
+      const fixture =
+        key === "qualify_tune_race"
+          ? {
+              upgrade: null,
+              run1: { time: 1, bumps: 0, smoothness: 50 },
+              run2: null,
+              exitCorrect: false,
+            }
+          : { ...base };
+
+      expect(
+        GAME_SPECIFIC_SCHEMAS[key].safeParse(withField(fixture, field, max, nest))
+          .success,
+        `${key}.${nest ? `${nest}.` : ""}${field}@max`,
+      ).toBe(true);
+
+      expect(
+        GAME_SPECIFIC_SCHEMAS[key].safeParse(
+          withField(fixture, field, max + 1, nest),
+        ).success,
+        `${key}.${nest ? `${nest}.` : ""}${field}@max+1`,
+      ).toBe(false);
+    }
+  });
+
+  it("R-3: nullable fields (impEvent: null, upgrade: null, run*: null) accepted", () => {
+    const mm = GAME_SPECIFIC_SCHEMAS.move_measure.safeParse({
+      ...validMoveMeasure,
+      impEvent: null,
+    });
+    expect(mm.success).toBe(true);
+
+    const qtr = GAME_SPECIFIC_SCHEMAS.qualify_tune_race.safeParse({
+      upgrade: null,
+      run1: null,
+      run2: null,
+      exitCorrect: false,
+    });
+    expect(qtr.success).toBe(true);
+  });
+
+  it("R-4: every registry schema rejects an unknown key", () => {
+    for (const [key, schema] of Object.entries(GAME_SPECIFIC_SCHEMAS)) {
+      const base = validByKey[key as RegisteredGameKey] as Record<string, unknown>;
+      const parsed = schema.safeParse({ ...base, smuggle: "nope" });
+      expect(parsed.success, key).toBe(false);
+    }
+  });
+
+  it("R-5: gameSpecific.ts source has no z.any, z.record, z.unknown, or .passthrough(", () => {
+    const source = readFileSync(moduleSourcePath, "utf8");
+    expect(source).not.toMatch(/z\.any\b/);
+    expect(source).not.toMatch(/z\.record\b/);
+    expect(source).not.toMatch(/z\.unknown\b/);
+    expect(source).not.toContain(".passthrough(");
+  });
+
+  it("E-10: registry keys unique, snake_case, and match A2-01 inventory", () => {
+    const keys = Object.keys(GAME_SPECIFIC_SCHEMAS);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const key of keys) {
+      expect(key).toMatch(/^[a-z][a-z0-9]*(_[a-z0-9]+)*$/);
+      expect(isRegisteredGameKey(key)).toBe(true);
+    }
+    expect(isRegisteredGameKey("not_a_game")).toBe(false);
+    expect(keys.sort()).toEqual([...INVENTORIED_KEYS].sort());
+  });
+
+  it("G-102: registry module does not import prisma, routes, or express", () => {
+    const source = readFileSync(moduleSourcePath, "utf8");
+    expect(source).not.toMatch(/from\s+["'].*prisma/);
+    expect(source).not.toMatch(/from\s+["'].*routes/);
+    expect(source).not.toMatch(/from\s+["']express["']/);
+  });
+
+  it("exports GAME_SPECIFIC_MAX_BYTES = 4096", () => {
+    expect(GAME_SPECIFIC_MAX_BYTES).toBe(4096);
+  });
+});
+
+/**
+ * T1-2-06 / G-202: prove structural guards would catch a loose entry.
+ * Local copy only — never sabotages production gameSpecific.ts.
+ */
+describe("R-4/R-5 guard bite (local loose copy)", () => {
+  it("T1-2-06: loose passthrough/any schema fails the same R-4/R-5 checks", () => {
+    const looseSchemas = {
+      loose_game: z.object({ score: z.any() }).passthrough(),
+    };
+
+    // Without the guard, unknown keys slip through
+    expect(
+      looseSchemas.loose_game.safeParse({ score: 1, unexpectedKey: true }).success,
+    ).toBe(true);
+
+    // Production-style R-4 loop would go red on this registry
+    const r4Holds = Object.entries(looseSchemas).every(([, schema]) => {
+      return !schema.safeParse({ score: 1, unexpectedKey: true }).success;
+    });
+    expect(r4Holds).toBe(false);
+
+    const fakeSource = `
+      export const GAME_SPECIFIC_SCHEMAS = {
+        loose_game: z.object({ score: z.any() }).passthrough(),
+      };
+    `;
+    const hasForbidden =
+      /\bz\.any\b/.test(fakeSource) ||
+      /\bz\.record\b/.test(fakeSource) ||
+      /\bz\.unknown\b/.test(fakeSource) ||
+      /\.passthrough\s*\(/.test(fakeSource);
+    expect(hasForbidden).toBe(true);
+  });
+});

--- a/backend/src/validation/__tests__/gameSpecific.test.ts
+++ b/backend/src/validation/__tests__/gameSpecific.test.ts
@@ -191,36 +191,49 @@ describe("GAME_SPECIFIC_SCHEMAS", () => {
 });
 
 /**
- * T1-2-06 / G-202: prove structural guards would catch a loose entry.
- * Local copy only — never sabotages production gameSpecific.ts.
+ * T1-2-06 / G-202: temporarily add a loose entry to a *local copy* of the
+ * registry, confirm R-4/R-5 go red, then discard the copy (never touch prod).
  */
 describe("R-4/R-5 guard bite (local loose copy)", () => {
-  it("T1-2-06: loose passthrough/any schema fails the same R-4/R-5 checks", () => {
-    const looseSchemas = {
+  it("T1-2-06: loose entry on a local registry copy makes R-4 and R-5 go red", () => {
+    // Local copy of the real registry + one deliberately loose entry
+    const localCopy: Record<string, z.ZodTypeAny> = {
+      ...GAME_SPECIFIC_SCHEMAS,
       loose_game: z.object({ score: z.any() }).passthrough(),
     };
 
-    // Without the guard, unknown keys slip through
-    expect(
-      looseSchemas.loose_game.safeParse({ score: 1, unexpectedKey: true }).success,
-    ).toBe(true);
-
-    // Production-style R-4 loop would go red on this registry
-    const r4Holds = Object.entries(looseSchemas).every(([, schema]) => {
-      return !schema.safeParse({ score: 1, unexpectedKey: true }).success;
+    // R-4 against the local copy: production keys still reject; loose accepts → overall red
+    const r4AllRejectUnknown = Object.entries(localCopy).every(([key, schema]) => {
+      const base =
+        key === "loose_game"
+          ? { score: 1 }
+          : (validByKey[key as RegisteredGameKey] as Record<string, unknown>);
+      return !schema.safeParse({ ...base, smuggle: "nope" }).success;
     });
-    expect(r4Holds).toBe(false);
+    expect(r4AllRejectUnknown).toBe(false);
 
-    const fakeSource = `
-      export const GAME_SPECIFIC_SCHEMAS = {
-        loose_game: z.object({ score: z.any() }).passthrough(),
-      };
+    // R-5 against a source string that includes the loose entry → red
+    const localSource = `
+      ${readFileSync(moduleSourcePath, "utf8")}
+      // sabotaged local addition:
+      loose_game: z.object({ score: z.any() }).passthrough(),
     `;
-    const hasForbidden =
-      /\bz\.any\b/.test(fakeSource) ||
-      /\bz\.record\b/.test(fakeSource) ||
-      /\bz\.unknown\b/.test(fakeSource) ||
-      /\.passthrough\s*\(/.test(fakeSource);
-    expect(hasForbidden).toBe(true);
+    const r5Clean =
+      !/\bz\.any\b/.test(localSource) &&
+      !/\bz\.record\b/.test(localSource) &&
+      !/\bz\.unknown\b/.test(localSource) &&
+      !/\.passthrough\s*\(/.test(localSource);
+    expect(r5Clean).toBe(false);
+
+    // Production registry itself remains clean (revert = discard localCopy)
+    for (const [key, schema] of Object.entries(GAME_SPECIFIC_SCHEMAS)) {
+      const base = validByKey[key as RegisteredGameKey] as Record<string, unknown>;
+      expect(schema.safeParse({ ...base, smuggle: "nope" }).success, key).toBe(
+        false,
+      );
+    }
+    const prodSource = readFileSync(moduleSourcePath, "utf8");
+    expect(prodSource).not.toMatch(/z\.any\b/);
+    expect(prodSource).not.toContain(".passthrough(");
   });
 });

--- a/backend/src/validation/__tests__/gameSpecific.test.ts
+++ b/backend/src/validation/__tests__/gameSpecific.test.ts
@@ -91,7 +91,8 @@ const moduleSourcePath = join(
 
 describe("GAME_SPECIFIC_SCHEMAS", () => {
   it("R-1: valid move_measure payload parses", () => {
-    const parsed = GAME_SPECIFIC_SCHEMAS.move_measure.safeParse(validMoveMeasure);
+    const parsed =
+      GAME_SPECIFIC_SCHEMAS.move_measure.safeParse(validMoveMeasure);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data).toEqual(validMoveMeasure);
@@ -121,8 +122,9 @@ describe("GAME_SPECIFIC_SCHEMAS", () => {
           : { ...base };
 
       expect(
-        GAME_SPECIFIC_SCHEMAS[key].safeParse(withField(fixture, field, max, nest))
-          .success,
+        GAME_SPECIFIC_SCHEMAS[key].safeParse(
+          withField(fixture, field, max, nest),
+        ).success,
         `${key}.${nest ? `${nest}.` : ""}${field}@max`,
       ).toBe(true);
 
@@ -153,7 +155,10 @@ describe("GAME_SPECIFIC_SCHEMAS", () => {
 
   it("R-4: every registry schema rejects an unknown key", () => {
     for (const [key, schema] of Object.entries(GAME_SPECIFIC_SCHEMAS)) {
-      const base = validByKey[key as RegisteredGameKey] as Record<string, unknown>;
+      const base = validByKey[key as RegisteredGameKey] as Record<
+        string,
+        unknown
+      >;
       const parsed = schema.safeParse({ ...base, smuggle: "nope" });
       expect(parsed.success, key).toBe(false);
     }
@@ -203,13 +208,15 @@ describe("R-4/R-5 guard bite (local loose copy)", () => {
     };
 
     // R-4 against the local copy: production keys still reject; loose accepts → overall red
-    const r4AllRejectUnknown = Object.entries(localCopy).every(([key, schema]) => {
-      const base =
-        key === "loose_game"
-          ? { score: 1 }
-          : (validByKey[key as RegisteredGameKey] as Record<string, unknown>);
-      return !schema.safeParse({ ...base, smuggle: "nope" }).success;
-    });
+    const r4AllRejectUnknown = Object.entries(localCopy).every(
+      ([key, schema]) => {
+        const base =
+          key === "loose_game"
+            ? { score: 1 }
+            : (validByKey[key as RegisteredGameKey] as Record<string, unknown>);
+        return !schema.safeParse({ ...base, smuggle: "nope" }).success;
+      },
+    );
     expect(r4AllRejectUnknown).toBe(false);
 
     // R-5 against a source string that includes the loose entry → red
@@ -227,7 +234,10 @@ describe("R-4/R-5 guard bite (local loose copy)", () => {
 
     // Production registry itself remains clean (revert = discard localCopy)
     for (const [key, schema] of Object.entries(GAME_SPECIFIC_SCHEMAS)) {
-      const base = validByKey[key as RegisteredGameKey] as Record<string, unknown>;
+      const base = validByKey[key as RegisteredGameKey] as Record<
+        string,
+        unknown
+      >;
       expect(schema.safeParse({ ...base, smuggle: "nope" }).success, key).toBe(
         false,
       );

--- a/backend/src/validation/gameSpecific.ts
+++ b/backend/src/validation/gameSpecific.ts
@@ -7,7 +7,9 @@ const smallInt = (max: number) => z.number().int().nonnegative().max(max);
 
 const runResultSchema = z
   .object({
-    time: z.number().min(0).max(300),
+    // Wall-clock seconds from QualifyTuneRaceGame (performance.now), not scroll-time.
+    // Cap matches timeSpentSchema (24h) so AFK/tab-switch mid-lap cannot 400 a completion (§5.3.5).
+    time: z.number().min(0).max(86400),
     bumps: z.number().int().nonnegative().max(10),
     smoothness: z.number().int().nonnegative().max(100),
   })

--- a/backend/src/validation/gameSpecific.ts
+++ b/backend/src/validation/gameSpecific.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+/** Belt-and-braces serialized size cap for `result.gameSpecific` (#672). */
+export const GAME_SPECIFIC_MAX_BYTES = 4096;
+
+const smallInt = (max: number) => z.number().int().nonnegative().max(max);
+
+const runResultSchema = z
+  .object({
+    time: z.number().min(0).max(300),
+    bumps: z.number().int().nonnegative().max(10),
+    smoothness: z.number().int().nonnegative().max(100),
+  })
+  .strict();
+
+/**
+ * Per-game telemetry allowlist. Every schema ends in `.strict()`.
+ * Shapes derived from A2-01 inventory — not speculative.
+ */
+export const GAME_SPECIFIC_SCHEMAS = {
+  move_measure: z
+    .object({
+      dash: smallInt(10),
+      jump: smallInt(10),
+      toss: smallInt(10),
+      impEvent: z.enum(["dash", "jump", "toss"]).nullable(),
+      impScore: smallInt(10),
+      exitCorrect: z.boolean(),
+    })
+    .strict(),
+  quantum_quest: z
+    .object({
+      maxStreak: smallInt(200),
+      totalAttempted: smallInt(10000),
+      sectorsCleared: smallInt(50),
+      powerUpsUsed: smallInt(10000),
+    })
+    .strict(),
+  tank_trek: z
+    .object({
+      totalChips: smallInt(10000),
+      retries: smallInt(10000),
+    })
+    .strict(),
+  qualify_tune_race: z
+    .object({
+      upgrade: z.enum(["grip", "speed", "steering"]).nullable(),
+      run1: runResultSchema.nullable(),
+      run2: runResultSchema.nullable(),
+      exitCorrect: z.boolean(),
+    })
+    .strict(),
+  boost_path_planner: z
+    .object({
+      attempts: smallInt(10000),
+    })
+    .strict(),
+} as const satisfies Record<string, z.ZodTypeAny>;
+
+export type RegisteredGameKey = keyof typeof GAME_SPECIFIC_SCHEMAS;
+
+export function isRegisteredGameKey(k: string): k is RegisteredGameKey {
+  return Object.prototype.hasOwnProperty.call(GAME_SPECIFIC_SCHEMAS, k);
+}

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -110,7 +110,7 @@ export const completeActivitySchema = z.object({
         ctx.addIssue({
           code: "custom",
           path: ["gameSpecific"],
-          message: "gameSpecific failed validation for this game",
+          message: `gameSpecific failed validation for gameKey "${val.gameKey}"`,
         });
         return;
       }
@@ -119,7 +119,7 @@ export const completeActivitySchema = z.object({
         ctx.addIssue({
           code: "custom",
           path: ["gameSpecific"],
-          message: "gameSpecific failed validation for this game",
+          message: `gameSpecific failed validation for gameKey "${val.gameKey}"`,
         });
         return;
       }
@@ -129,7 +129,7 @@ export const completeActivitySchema = z.object({
         ctx.addIssue({
           code: "custom",
           path: ["gameSpecific"],
-          message: "gameSpecific failed validation for this game",
+          message: `gameSpecific failed validation for gameKey "${val.gameKey}"`,
         });
       }
     })

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -115,7 +115,7 @@ export const completeActivitySchema = z.object({
         return;
       }
 
-      if (serialized.length > GAME_SPECIFIC_MAX_BYTES) {
+      if (Buffer.byteLength(serialized, "utf8") > GAME_SPECIFIC_MAX_BYTES) {
         ctx.addIssue({
           code: "custom",
           path: ["gameSpecific"],

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  GAME_SPECIFIC_MAX_BYTES,
+  GAME_SPECIFIC_SCHEMAS,
+  isRegisteredGameKey,
+} from "./gameSpecific";
 
 // 🛡️ Sentinel: Shared validation schemas for consistent security
 
@@ -67,13 +72,68 @@ export const completeActivitySchema = z.object({
   lessonId: z.string().max(100).optional().nullable(),
   activityId: z.string().min(1, "Activity ID required").max(100),
   timeSpentS: timeSpentSchema.optional().default(0),
-  result: z.object({
-    gameKey: z.string().max(50).optional(),
-    score: z.number().int().nonnegative().max(10000).optional(),
-    total: z.number().int().nonnegative().max(10000).optional(),
-    streakMax: z.number().int().nonnegative().max(10000).optional(),
-    roundsCompleted: z.number().int().nonnegative().max(1000).optional(),
-  }).optional(),
+  result: z
+    .object({
+      gameKey: z.string().max(50).optional(),
+      score: z.number().int().nonnegative().max(10000).optional(),
+      total: z.number().int().nonnegative().max(10000).optional(),
+      streakMax: z.number().int().nonnegative().max(10000).optional(),
+      roundsCompleted: z.number().int().nonnegative().max(1000).optional(),
+      // Declared so zod does not strip it; shape enforced by superRefine.
+      gameSpecific: z.unknown().optional(),
+    })
+    .superRefine((val, ctx) => {
+      if (val.gameSpecific === undefined) return;
+
+      if (!val.gameKey) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["gameSpecific"],
+          message: "gameSpecific requires gameKey",
+        });
+        return;
+      }
+
+      if (!isRegisteredGameKey(val.gameKey)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["gameSpecific"],
+          message: `gameSpecific not accepted for gameKey "${val.gameKey}"`,
+        });
+        return;
+      }
+
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(val.gameSpecific);
+      } catch {
+        ctx.addIssue({
+          code: "custom",
+          path: ["gameSpecific"],
+          message: "gameSpecific failed validation for this game",
+        });
+        return;
+      }
+
+      if (serialized.length > GAME_SPECIFIC_MAX_BYTES) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["gameSpecific"],
+          message: "gameSpecific failed validation for this game",
+        });
+        return;
+      }
+
+      const parsed = GAME_SPECIFIC_SCHEMAS[val.gameKey].safeParse(val.gameSpecific);
+      if (!parsed.success) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["gameSpecific"],
+          message: "gameSpecific failed validation for this game",
+        });
+      }
+    })
+    .optional(),
 });
 
 export const selectArchetypeSchema = z.object({

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,7 +124,9 @@ export const completeActivitySchema = z.object({
         return;
       }
 
-      const parsed = GAME_SPECIFIC_SCHEMAS[val.gameKey].safeParse(val.gameSpecific);
+      const parsed = GAME_SPECIFIC_SCHEMAS[val.gameKey].safeParse(
+        val.gameSpecific,
+      );
       if (!parsed.success) {
         ctx.addIssue({
           code: "custom",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:unit": "vitest run --project unit",
     "test:coverage:quiz": "vitest run --project unit --coverage",
     "test:coverage:ci-guard": "vitest run --project unit --coverage",
+    "test:coverage:gamespecific": "vitest run --project unit --coverage",
     "test:e2e": "cypress run",
     "test:e2e:ci": "cypress run --spec \"cypress/e2e/ci-shell.cy.ts\"",
     "test:e2e:staging": "cypress run --spec \"cypress/e2e/staging/*.cy.ts\"",

--- a/prisma/migrations/20260716015000_add_progress_game_specific/migration.sql
+++ b/prisma/migrations/20260716015000_add_progress_game_specific/migration.sql
@@ -1,0 +1,3 @@
+-- Add per-activity telemetry payload storage for ticket #672.
+ALTER TABLE "Progress"
+ADD COLUMN "gameSpecific" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -193,6 +193,7 @@ model Progress {
   activityId String
   status     ProgressStatus
   timeSpentS Int            @default(0)
+  gameSpecific Json?
   updatedAt  DateTime       @updatedAt
 
   User       User @relation(fields: [studentId], references: [id], onDelete: Cascade)

--- a/prompts/2026-07-17-ticket-672-persist-game-specific.md
+++ b/prompts/2026-07-17-ticket-672-persist-game-specific.md
@@ -1,0 +1,50 @@
+# Persist gameSpecific on activity complete (Issue #672)
+
+**Author:** Jack
+**Date:** 2026-07-17
+**Sprint:** —
+**Pod:** Build
+
+## Intent
+
+Persist validated per-game telemetry (`gameSpecific`) from `POST /progress/complete-activity` onto `Progress`, without changing scoring/XP and without exposing kid-authored JSON on existing progress responses.
+
+## Prompt
+
+```
+Followed the ticket spec and drove work in Cursor in a few passes — inventory
+what games already send, add a strict per-game validation registry, wire it into
+complete-activity, persist on Progress with an additive migration, align the
+client result type, and cover it with colocated unit/route tests plus coverage
+thresholds.
+
+Before PR, ran lint, both typechecks, unit tests, coverage, and build, then
+drafted the PR description and this prompt log.
+```
+
+## What Claude Code Did
+
+- Files created/modified: `backend/src/validation/gameSpecific.ts`, `backend/src/validation/schemas.ts`, `backend/src/routes/progress.ts`, `prisma/schema.prisma`, `backend/prisma/schema.prisma`, `prisma/migrations/20260716015000_add_progress_game_specific/`, `src/services/api.ts`, colocated validation/route tests, `vitest.config.ts`, `package.json`
+- Tests passed: lint ✓, root + backend typecheck ✓, `test:unit` 528 passed ✓, `test:coverage:gamespecific` (gameSpecific.ts 100%) ✓, `build` ✓
+
+## What Worked
+
+- Registry + `superRefine` + handler re-parse pattern kept validation pure and testable
+- Colocated backend tests under the existing root Vitest unit project
+- Keeping games read-only and fixing only the persistence / type path
+
+## What Needed Editing
+
+- Strip `gameSpecific` from complete-activity responses and pin `GET /progress` select so v1 does not change API shapes
+- Narrow unregistered-`gameKey` warn to the 400 path (schema-derived key, no payload echo)
+- Raise `qualify_tune_race` run `time` cap to 24h (wall-clock) so AFK mid-lap cannot 400 a completion
+
+## Lessons
+
+- Declaring a field as `z.unknown()` is what stops zod from stripping it; `superRefine` validates but does not transform — persist only after re-parse
+- “Store but do not expose” needs both response stripping and explicit selects on list endpoints when Prisma would otherwise return new Json columns
+- One prompt log at ticket close; keep Prompt vague and cite product paths only
+
+## Rating
+
+4/5 — AI carried implementation and tests; review still needed on the 400-vs-tolerate trade-off and the GPB.meta rationale.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -557,6 +557,8 @@ export const api = {
       total?: number;
       streakMax?: number;
       roundsCompleted?: number;
+      gameSpecific?: unknown;
+      accuracy?: number;
     };
   }) => {
     const res = await fetch(join(API_BASE, "/progress/complete-activity"), {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -344,7 +344,8 @@ export const useApi = () => {
         });
 
         if (!response.ok) {
-          if (response.status === 401) throw new ApiError(t("api.sessionExpired"), 401);
+          if (response.status === 401)
+            throw new ApiError(t("api.sessionExpired"), 401);
           if (response.status === 403)
             throw new ApiError(t("api.dashboardUnavailable"), 403);
           // Parse error body safely — backend may return HTML for unknown routes
@@ -364,7 +365,9 @@ export const useApi = () => {
       } catch (error) {
         // Only retry on network errors or 5xx — never retry 4xx client errors
         const isClientError =
-          error instanceof ApiError && error.status >= 400 && error.status < 500;
+          error instanceof ApiError &&
+          error.status >= 400 &&
+          error.status < 500;
         const isAuthError =
           error instanceof Error && error.message.includes("Authentication");
         const isSessionExpired =
@@ -595,55 +598,83 @@ export const api = {
   // ── Module Catalog & Assignments ──────────────────────────────────────
 
   getModuleFamilies: async () => {
-    const res = await fetch(join(API_BASE, "/module-catalog/families"), { headers: getHeaders() });
+    const res = await fetch(join(API_BASE, "/module-catalog/families"), {
+      headers: getHeaders(),
+    });
     return res.json();
   },
 
   getModuleVariants: async (band?: string) => {
-    const url = new URL(join(API_BASE, "/module-catalog/variants"), window.location.origin);
+    const url = new URL(
+      join(API_BASE, "/module-catalog/variants"),
+      window.location.origin,
+    );
     if (band) url.searchParams.append("band", band);
     const res = await fetch(url.toString(), { headers: getHeaders() });
     return res.json();
   },
 
   updateCourseBand: async (courseId: string, gradeBand: string) => {
-    const res = await fetch(join(API_BASE, `/teacher/courses/${courseId}/band`), {
-      method: "PUT",
-      headers: getHeaders(),
-      body: JSON.stringify({ gradeBand }),
-    });
+    const res = await fetch(
+      join(API_BASE, `/teacher/courses/${courseId}/band`),
+      {
+        method: "PUT",
+        headers: getHeaders(),
+        body: JSON.stringify({ gradeBand }),
+      },
+    );
     return res.json();
   },
 
   getCourseAssignments: async (courseId: string) => {
-    const res = await fetch(join(API_BASE, `/teacher/courses/${courseId}/module-assignments`), { headers: getHeaders() });
+    const res = await fetch(
+      join(API_BASE, `/teacher/courses/${courseId}/module-assignments`),
+      { headers: getHeaders() },
+    );
     return res.json();
   },
 
-  assignModuleToClass: async (courseId: string, moduleVariantId: string, opts?: { orderIndex?: number; isLocked?: boolean }) => {
-    const res = await fetch(join(API_BASE, `/teacher/courses/${courseId}/module-assignments`), {
-      method: "POST",
-      headers: getHeaders(),
-      body: JSON.stringify({ moduleVariantId, ...opts }),
-    });
+  assignModuleToClass: async (
+    courseId: string,
+    moduleVariantId: string,
+    opts?: { orderIndex?: number; isLocked?: boolean },
+  ) => {
+    const res = await fetch(
+      join(API_BASE, `/teacher/courses/${courseId}/module-assignments`),
+      {
+        method: "POST",
+        headers: getHeaders(),
+        body: JSON.stringify({ moduleVariantId, ...opts }),
+      },
+    );
     return res.json();
   },
 
   removeModuleAssignment: async (courseId: string, assignmentId: string) => {
-    const res = await fetch(join(API_BASE, `/teacher/courses/${courseId}/module-assignments/${assignmentId}`), {
-      method: "DELETE",
-      headers: getHeaders(),
-    });
+    const res = await fetch(
+      join(
+        API_BASE,
+        `/teacher/courses/${courseId}/module-assignments/${assignmentId}`,
+      ),
+      {
+        method: "DELETE",
+        headers: getHeaders(),
+      },
+    );
     return res.json();
   },
 
   getStudentCourses: async () => {
-    const res = await fetch(join(API_BASE, "/student/courses"), { headers: getHeaders() });
+    const res = await fetch(join(API_BASE, "/student/courses"), {
+      headers: getHeaders(),
+    });
     return res.json().catch(() => []);
   },
 
   getStudentAssignedModules: async () => {
-    const res = await fetch(join(API_BASE, "/student/assigned-modules"), { headers: getHeaders() });
+    const res = await fetch(join(API_BASE, "/student/assigned-modules"), {
+      headers: getHeaders(),
+    });
     return res.json();
   },
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,11 @@ export default defineConfig({
     ],
     coverage: {
       provider: "v8",
-      include: ["src/components/activities/quiz/**", "cypress/support/**/*.ts"],
+      include: [
+        "src/components/activities/quiz/**",
+        "backend/src/validation/gameSpecific.ts",
+        "cypress/support/**/*.ts",
+      ],
       exclude: [
         "**/__tests__/**",
         "**/*.test.{ts,tsx}",


### PR DESCRIPTION
## Summary

Completing an activity can now store per-game telemetry (`result.gameSpecific`) on the activity’s `Progress` row. Payloads are validated against a strict per-game zod registry (allowlist + size cap); invalid or unregistered shapes return **400**. Scoring, XP, streak, and `GamePersonalBest` are unchanged. v1 **stores only** — nothing new is added to progress API responses (kid-authored JSON stays off the wire).

Closes #672

## What changed

**For backend / #618 consumers**
- New `backend/src/validation/gameSpecific.ts` — strict per-`gameKey` schemas for the five games that already send telemetry
- `completeActivitySchema` accepts optional `result.gameSpecific`, dispatches on sibling `gameKey`, rejects unknown keys / oversize (>4096 serialized bytes)
- Handler re-parses before persist and writes `Progress.gameSpecific` only when present (omitting it on update preserves an existing value)
- Additive migration `prisma/migrations/20260716015000_add_progress_game_specific/` — nullable `Progress.gameSpecific JSONB`

**For API contract stability**
- Complete-activity responses strip `gameSpecific`; `GET /progress` uses an explicit `select` that excludes it
- Unregistered `gameKey` + `gameSpecific` logs a single `console.warn` on the 400 path (no payload echo)

**For frontend types**
- `src/services/api.ts` — type-only: `gameSpecific?: unknown`, `accuracy?: number` on complete-activity `result`

**Also included**
- Colocated validation + route tests; `vitest.config.ts` coverage `include` appends `backend/src/validation/gameSpecific.ts` (keeps the existing quiz entry); `npm run test:coverage:gamespecific`

## How it was tested

- `npm run lint` ✓ (`--max-warnings 0`)
- `npm run typecheck` ✓
- `cd backend && npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:unit` — 528 passed / 19 skipped
- `npm run test:coverage:gamespecific` — thresholds pass; `gameSpecific.ts` **100%** lines/branches/funcs/stmts
- Pre-existing `progress*.test.ts` assertion files: **zero** edits vs `main`
- Migration: `prisma migrate deploy` on a fresh local DB applies `0_init` + `20260716015000_add_progress_game_specific`; second run idempotent
- Full Cypress suite / staging URL: **not claimed**

## Notes for reviewers

**Why not `GamePersonalBest.meta`?**
1. Wrong grain — GPB is per `(studentId, gameKey)`; telemetry is per activity completion (`Progress` unique on `(studentId, activityId)`).
2. Wrong semantics — bests vs latest-attempt telemetry.
3. Best-effort write path — GPB upsert is `try/catch` + warn; “retrievably” requires the main upsert.
4. Not every completion has a `gameKey`.

**Deliberate limits**
- Last-write-wins on `Progress` (no per-attempt history).
- Nothing exposed on progress responses in v1 (#668 class of risk).
- Invalid `gameSpecific` → 400 (same as other malformed `result` fields); a game that ships an unregistered shape costs the kid the completion/XP — mitigated by inventorying current senders + round-trip tests.
- Top-level `accuracy` is still dropped by the same zod strip as before; client type now declares it, but persistence stays out of scope (follow-up if desired).
- `#618` / PR #688: adding `predictions` later is a one-entry change to the `move_measure` registry schema once the shape settles — not pre-built here.
- `qualify_tune_race` run `time` is bounded `0..86400` (wall-clock seconds), matching `timeSpentSchema`, so AFK/tab-switch mid-lap cannot 400 a completion.

**Scope**
- Zero changes under `src/components/games/`.
- No new dependencies; no `.env*` staged.
- Pod: Build — Alice Lin (primary); flag Nathaniel as needed.