### PR TITLE
chore(test): Storybook vitest path-with-spaces

### DIFF
--- a/src/stories/Page.stories.ts
+++ b/src/stories/Page.stories.ts
@@ -6,6 +6,10 @@ import { Page } from "./Page";
 const meta = {
   title: "Example/Page",
   component: Page,
+  // Workspace path contains spaces; Storybook vitest addon then reports
+  // "No test suite found" for this file (storybookjs/storybook#29572).
+  // Opt out via tags.exclude ["no-vitest"] in vitest.workspace.ts.
+  tags: ["no-vitest"],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -18,7 +18,13 @@ export default defineWorkspace([
     plugins: [
       // The plugin will run tests for the stories defined in your Storybook config
       // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
-      storybookTest({ configDir: path.join(dirname, ".storybook") }),
+      storybookTest({
+        configDir: path.join(dirname, ".storybook"),
+        // autodocs: docs-only stories have no vitest suite after tag filtering.
+        // no-vitest: opt-out for stories that trip Storybook issue #29572
+        // ("No test suite found" when the workspace path contains spaces).
+        tags: { exclude: ["autodocs", "no-vitest"] },
+      }),
     ],
     test: {
       name: "storybook",


### PR DESCRIPTION
## Summary

Closes #707.

Makes `npm run test` green on Windows workspaces whose path contains spaces by excluding Storybook Vitest suites that trip [storybookjs/storybook#29572](https://github.com/storybookjs/storybook/issues/29572) (`No test suite found`).

- `vitest.workspace.ts`: `tags: { exclude: ["autodocs", "no-vitest"] }` in `storybookTest`
- `src/stories/Page.stories.ts`: `tags: ["no-vitest"]` + comment citing #29572

## Before / after (spaces path `…/Bright Bots/brightboost-test-infra`)

| | Result |
|---|---|
| **Before** | 5 Storybook files fail with `No test suite found` (Page + 4 `autodocs` stories) |
| **After** | `npm test` green — 90 passed / 12 skipped; Storybook false failures gone |

`npm run test:unit`: 486 passed / 19 skipped (unchanged by Storybook excludes).

## Caveat (local-only vs CI)

GitHub Actions uses `ubuntu-latest` + `actions/checkout` → paths like `/home/runner/work/brightboost/brightboost` **have no spaces**. This is a **local** Windows/spaces-path fix; do not treat it as a CI suite improvement.

## V-4 note

Repo currently has **only 5** `*.stories.*` files — all are either `autodocs` or Example/Page. After excludes, the Storybook project has **no remaining suites to run** (skipped). That is inventory reality, not a silent nuke of other stories. Tag proof: removing `no-vitest` from Page restores `No test suite found` for that file.

## Non-goals (deliberate)

- No Vitest worker / `maxWorkers` tuning
- No global `vitest.config.ts` `testTimeout` (rejected on #651 / #705)
- No Cypress / CI workflow changes
- No `backend/scripts/` or seed changes (#651 / #705 tree)

## Related

- Stripped from #651 / #705 on purpose — independent; can land in either order
- Coordinate with #702 if it still carries a blanket Storybook skip on spaced paths (prefer this surgical exclude)

## Test plan

- [x] `npm run lint` / `typecheck` clean
- [x] `npm run test:unit` green
- [x] `npm test` on spaces path green (no `No test suite found`)
- [x] `npm test` on no-spaces path (`D:\tmp\brightboost-test-infra` worktree) green
- [x] Temp-remove `no-vitest` → Page failure returns; restored
- [ ] CI on this PR green