### PR TITLE
fix(creations): serialize content by type

### DIFF
--- a/backend/src/routes/creations.test.ts
+++ b/backend/src/routes/creations.test.ts
@@ -53,6 +53,29 @@ const validChallenge = {
   inferRule: "growthSpeed",
 };
 
+const validRaceTrack = {
+  v: 1,
+  name: "Turbo Loop",
+  grid: { w: 6, h: 6 },
+  pieces: [
+    { x: 1, y: 2, type: "start", rot: 0 },
+    { x: 2, y: 2, type: "finish", rot: 0 },
+  ],
+};
+
+const validSoundDuet = {
+  v: 1,
+  name: "Moon Echo",
+  band: "k2",
+  pulses: 4,
+  layers: {
+    lead: [{ t: 0, soundId: "step" }],
+    partner: [{ t: 3, soundId: "clap" }],
+  },
+  spots: ["tunnel"],
+  coverPose: "highFive",
+};
+
 const dbCreation = {
   id: "creation-1",
   authorId: KID,
@@ -125,7 +148,12 @@ describe("Creations routes", () => {
           courseId: COURSE,
           type: "data_dash_challenge",
           // Too few cards — fails the solvability guard.
-          content: { v: 1, cardIds: ["bean"], sortRule: "waterNeed", inferRule: "growthSpeed" },
+          content: {
+            v: 1,
+            cardIds: ["bean"],
+            sortRule: "waterNeed",
+            inferRule: "growthSpeed",
+          },
         });
 
       expect(res.status).toBe(422);
@@ -158,15 +186,15 @@ describe("Creations routes", () => {
           content: validChallenge,
         });
 
-        expect(res.status).toBe(201);
-        expect(prismaMock.creation.create).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              title: "Sort by Water need",
-            })
-          })
-        )
-    })
+      expect(res.status).toBe(201);
+      expect(prismaMock.creation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: "Sort by Water need",
+          }),
+        }),
+      );
+    });
 
     it("rejects a challenge with unexpected extra keys (422)", async () => {
       prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
@@ -180,9 +208,9 @@ describe("Creations routes", () => {
           content: { ...validChallenge, surprise: "not allowed" },
         });
 
-        expect(res.status).toBe(422);
-        expect(prismaMock.creation.create).not.toHaveBeenCalled();
-    })
+      expect(res.status).toBe(422);
+      expect(prismaMock.creation.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("PATCH /api/creations/:id", () => {
@@ -253,15 +281,15 @@ describe("Creations routes", () => {
           content: validChallenge,
         });
 
-        expect(res.status).toBe(200);
-        expect(prismaMock.creation.update).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              title: "Sort by Water need",
-            })
-          })
-        )
-    })
+      expect(res.status).toBe(200);
+      expect(prismaMock.creation.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: "Sort by Water need",
+          }),
+        }),
+      );
+    });
 
     it("rejects unexpected extra keys on update (422)", async () => {
       prismaMock.creation.findUnique.mockResolvedValue({
@@ -276,11 +304,11 @@ describe("Creations routes", () => {
         .set(asStudent(KID))
         .send({
           content: { ...validChallenge, surprise: "not allowed" },
-        })
+        });
 
       expect(res.status).toBe(422);
       expect(prismaMock.creation.update).not.toHaveBeenCalled();
-    })
+    });
   });
 
   describe("GET /api/creations?courseId=", () => {
@@ -321,9 +349,7 @@ describe("Creations routes", () => {
     });
 
     it("400s when courseId is missing", async () => {
-      const res = await request(app)
-        .get("/api/creations")
-        .set(asStudent(KID));
+      const res = await request(app).get("/api/creations").set(asStudent(KID));
 
       expect(res.status).toBe(400);
     });
@@ -345,6 +371,29 @@ describe("Creations routes", () => {
       expect(res.body.content).toEqual(validChallenge); // playable payload
       expect(res.body.authorName).toBe("Ada");
     });
+
+    it.each([
+      ["race_track", validRaceTrack],
+      ["sound_duet", validSoundDuet],
+    ])(
+      "returns complete %s content instead of a Data Dash projection",
+      async (type, content) => {
+        prismaMock.creation.findUnique.mockResolvedValue({
+          ...dbCreation,
+          type,
+          content,
+          status: "SHARED",
+        });
+        prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
+
+        const res = await request(app)
+          .get("/api/creations/creation-1")
+          .set(asStudent(OTHER_KID));
+
+        expect(res.status).toBe(200);
+        expect(res.body.content).toEqual(content);
+      },
+    );
 
     it("lets the author fetch their own unshared draft", async () => {
       prismaMock.creation.findUnique.mockResolvedValue(dbCreation); // IN_PROGRESS
@@ -396,10 +445,10 @@ describe("Creations routes", () => {
       prismaMock.creation.findUnique.mockResolvedValue({
         ...dbCreation,
         status: "SHARED",
-        content: { ...validChallenge, surprise: "not shared" }
+        content: { ...validChallenge, surprise: "not shared" },
       });
       prismaMock.enrollment.findUnique.mockResolvedValue({ id: "enr-1" });
-      
+
       const res = await request(app)
         .get("/api/creations/creation-1")
         .set(asStudent(OTHER_KID));
@@ -407,7 +456,7 @@ describe("Creations routes", () => {
       expect(res.status).toBe(200);
       expect(res.body.content).toEqual(validChallenge);
       expect(res.body.content).not.toHaveProperty("surprise");
-    })
+    });
   });
 
   describe("POST /api/creations/:id/encourage", () => {

--- a/backend/src/routes/creations.ts
+++ b/backend/src/routes/creations.ts
@@ -8,6 +8,7 @@ import {
   validateCreationContent,
   type CreationType,
 } from "../services/creationContent";
+import { serializeCreationContent } from "../services/creationContentSerializer";
 
 // Phase 0 — Creations CRUD (the "kid makes something" foundation).
 //
@@ -245,42 +246,34 @@ router.patch(
 // GET /creations?courseId= — group-scoped gallery read
 // ---------------------------------------------------------------------------
 
-router.get(
-  "/creations",
-  requireAuth,
-  async (req: Request, res: Response) => {
-    const parsed = listQuerySchema.safeParse(req.query);
-    if (!parsed.success) {
-      return res.status(400).json({ error: "courseId is required" });
-    }
-    const { courseId } = parsed.data;
+router.get("/creations", requireAuth, async (req: Request, res: Response) => {
+  const parsed = listQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "courseId is required" });
+  }
+  const { courseId } = parsed.data;
 
-    const member = await isGroupMember(
-      req.user!.id,
-      req.user!.role,
+  const member = await isGroupMember(req.user!.id, req.user!.role, courseId);
+  if (!member) {
+    return res.status(403).json({ error: "not a member of this group" });
+  }
+
+  // Gallery shows SHARED|COMPLETE to the group; the author additionally sees
+  // their own IN_PROGRESS drafts.
+  const creations = await prisma.creation.findMany({
+    where: {
       courseId,
-    );
-    if (!member) {
-      return res.status(403).json({ error: "not a member of this group" });
-    }
+      OR: [
+        { status: { in: ["SHARED", "COMPLETE"] } },
+        { authorId: req.user!.id },
+      ],
+    },
+    include: { author: { select: { name: true } } },
+    orderBy: { updatedAt: "desc" },
+  });
 
-    // Gallery shows SHARED|COMPLETE to the group; the author additionally sees
-    // their own IN_PROGRESS drafts.
-    const creations = await prisma.creation.findMany({
-      where: {
-        courseId,
-        OR: [
-          { status: { in: ["SHARED", "COMPLETE"] } },
-          { authorId: req.user!.id },
-        ],
-      },
-      include: { author: { select: { name: true } } },
-      orderBy: { updatedAt: "desc" },
-    });
-
-    return res.json(creations.map(toDTO));
-  },
-);
+  return res.json(creations.map(toDTO));
+});
 
 // ---------------------------------------------------------------------------
 // GET /creations/:id — single creation WITH content (to play it). Group-scoped.
@@ -316,20 +309,11 @@ router.get(
       return res.status(403).json({ error: "creation is not shared" });
     }
 
-    const safeContent =
-      typeof creation.content === "object" &&
-      creation.content !== null &&
-      !Array.isArray(creation.content)
-        ? {
-          v: creation.content.v,
-          cardIds: creation.content.cardIds,
-          sortRule: creation.content.sortRule,
-          inferRule: creation.content.inferRule,
-        }
-        : creation.content;
-
     // Single-get includes content so the creation can actually be played.
-    return res.json({ ...toDTO(creation), content: safeContent });
+    return res.json({
+      ...toDTO(creation),
+      content: serializeCreationContent(creation.type, creation.content),
+    });
   },
 );
 

--- a/backend/src/services/creationContentSerializer.test.ts
+++ b/backend/src/services/creationContentSerializer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { serializeCreationContent } from "./creationContentSerializer";
+
+describe("serializeCreationContent", () => {
+  it("projects Data Dash content to its owned fields", () => {
+    expect(
+      serializeCreationContent("data_dash_challenge", {
+        v: 1,
+        cardIds: ["bean", "fern", "pine", "moss"],
+        sortRule: "waterNeed",
+        inferRule: "growthSpeed",
+        internalNote: "do not expose",
+      }),
+    ).toEqual({
+      v: 1,
+      cardIds: ["bean", "fern", "pine", "moss"],
+      sortRule: "waterNeed",
+      inferRule: "growthSpeed",
+    });
+  });
+
+  it("preserves a race track while stripping unknown nested fields", () => {
+    expect(
+      serializeCreationContent("race_track", {
+        v: 1,
+        name: "Turbo Loop",
+        grid: { w: 6, h: 6, privateGridNote: "hidden" },
+        pieces: [
+          { x: 1, y: 2, type: "start", rot: 0, privatePieceNote: "hidden" },
+          { x: 2, y: 2, type: "finish", rot: 0 },
+        ],
+        privateRootNote: "hidden",
+      }),
+    ).toEqual({
+      v: 1,
+      name: "Turbo Loop",
+      grid: { w: 6, h: 6 },
+      pieces: [
+        { x: 1, y: 2, type: "start", rot: 0 },
+        { x: 2, y: 2, type: "finish", rot: 0 },
+      ],
+    });
+  });
+
+  it("preserves a sound duet while stripping unknown nested fields", () => {
+    expect(
+      serializeCreationContent("sound_duet", {
+        v: 1,
+        name: "Moon Echo",
+        band: "k2",
+        pulses: 4,
+        layers: {
+          lead: [{ t: 0, soundId: "step", privateEventNote: "hidden" }],
+          partner: [{ t: 3, soundId: "clap" }],
+          privateLayer: [{ secret: true }],
+        },
+        spots: ["tunnel"],
+        coverPose: "highFive",
+        privateRootNote: "hidden",
+      }),
+    ).toEqual({
+      v: 1,
+      name: "Moon Echo",
+      band: "k2",
+      pulses: 4,
+      layers: {
+        lead: [{ t: 0, soundId: "step" }],
+        partner: [{ t: 3, soundId: "clap" }],
+      },
+      spots: ["tunnel"],
+      coverPose: "highFive",
+    });
+  });
+
+  it("fails closed for an unsupported creation type", () => {
+    expect(
+      serializeCreationContent("unknown_type", { secret: "not exposed" }),
+    ).toBeNull();
+  });
+
+  it("fails closed for malformed top-level content", () => {
+    expect(
+      serializeCreationContent("race_track", ["not", "an", "object"]),
+    ).toBeNull();
+  });
+});

--- a/backend/src/services/creationContentSerializer.ts
+++ b/backend/src/services/creationContentSerializer.ts
@@ -1,0 +1,125 @@
+// Read-time projection for Creation.content.
+//
+// Creation content is validated before it is written, but projecting it again
+// at the API boundary keeps a malformed or manually inserted JSON value from
+// exposing fields a creation type does not own. Keep each shape aligned with
+// that type's write validator.
+
+const LEAF = Symbol("creation-content-leaf");
+const OMIT = Symbol("creation-content-omit");
+
+type Projection =
+  | typeof LEAF
+  | { readonly [key: string]: Projection }
+  | readonly [Projection];
+
+const CONTENT_PROJECTIONS = {
+  data_dash_challenge: {
+    v: LEAF,
+    cardIds: [LEAF],
+    sortRule: LEAF,
+    inferRule: LEAF,
+  },
+  race_track: {
+    v: LEAF,
+    name: LEAF,
+    grid: {
+      w: LEAF,
+      h: LEAF,
+    },
+    pieces: [
+      {
+        x: LEAF,
+        y: LEAF,
+        type: LEAF,
+        rot: LEAF,
+      },
+    ],
+  },
+  sound_duet: {
+    v: LEAF,
+    name: LEAF,
+    band: LEAF,
+    pulses: LEAF,
+    layers: {
+      lead: [
+        {
+          t: LEAF,
+          soundId: LEAF,
+        },
+      ],
+      partner: [
+        {
+          t: LEAF,
+          soundId: LEAF,
+        },
+      ],
+    },
+    spots: [LEAF],
+    coverPose: LEAF,
+  },
+} as const satisfies Record<string, Projection>;
+
+export type SerializedCreationContent = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonPrimitive(
+  value: unknown,
+): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+function projectValue(
+  value: unknown,
+  projection: Projection,
+): unknown | typeof OMIT {
+  if (projection === LEAF) {
+    return isJsonPrimitive(value) ? value : OMIT;
+  }
+
+  if (Array.isArray(projection)) {
+    if (!Array.isArray(value)) return OMIT;
+
+    const itemProjection = projection[0];
+    const projectedItems: unknown[] = [];
+    for (const item of value) {
+      const projected = projectValue(item, itemProjection);
+      if (projected !== OMIT) projectedItems.push(projected);
+    }
+    return projectedItems;
+  }
+
+  if (!isPlainObject(value)) return OMIT;
+
+  const projectedObject: Record<string, unknown> = {};
+  for (const [key, childProjection] of Object.entries(projection)) {
+    const projected = projectValue(value[key], childProjection);
+    if (projected !== OMIT) projectedObject[key] = projected;
+  }
+  return projectedObject;
+}
+
+/**
+ * Return only the fields owned by a creation type. Unsupported types and
+ * malformed top-level content fail closed instead of returning raw JSON.
+ */
+export function serializeCreationContent(
+  type: string,
+  content: unknown,
+): SerializedCreationContent | null {
+  const projection = CONTENT_PROJECTIONS[
+    type as keyof typeof CONTENT_PROJECTIONS
+  ] as Projection | undefined;
+  if (!projection) return null;
+
+  const projected = projectValue(content, projection);
+  return projected !== OMIT && isPlainObject(projected) ? projected : null;
+}


### PR DESCRIPTION
## Summary

- replace the Data-Dash-only inline `safeContent` projection with a shared, type-aware serializer
- preserve the complete playable schemas for `data_dash_challenge`, `race_track`, and `sound_duet`
- strip unknown fields recursively, including nested grid, piece, layer, and event data
- fail closed for unsupported creation types or malformed top-level content
- add endpoint and serializer regression coverage

## Why

PR #696 correctly stopped returning unexpected Data Dash keys, but the projection was embedded in the single-creation endpoint and assumed every creation was a Data Dash challenge. Once #691 or #694 landed, the endpoint would reduce their content to Data Dash fields and make shared tracks or duets unplayable.

Returning raw JSON, as the two game branches currently do, restores playability but removes the read-time defense-in-depth boundary. This foundation keeps both properties: complete type-owned content and recursive field allowlisting.

## Integration contract

This PR does **not** add the pending game types to the write allowlist. Their validators and authoring support remain in #691 and #694. After this lands, both branches should rebase and retain `serializeCreationContent(...)` in the single-creation endpoint instead of restoring raw `creation.content`.

## Verification

- focused creation tests: 32 passed
- full local unit run: 493 passed; one unrelated suite was blocked by the container's incomplete generated Prisma client
- root TypeScript check
- isolated strict TypeScript check for the serializer
- repository lint
- changed-file Prettier check
- commitlint

GitHub CI is the authoritative full-suite run because it generates Prisma under the repository's pinned Node 20 environment.