### PR TITLE
feat: k2 adult support — honest Prepare Session, real /parents page, printable facilitator guide

### DIFF
--- a/backend/src/routes/teacherPrep.test.ts
+++ b/backend/src/routes/teacherPrep.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+
+// Mock Prisma — prep content is a static in-file catalog; only the per-teacher
+// checklist state touches the DB.
+vi.mock("../utils/prisma", () => ({
+  default: {
+    teacherPrepChecklist: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+// Mock auth middleware to allow role simulation (same pattern as modules.test.ts)
+vi.mock("../utils/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/auth")>();
+  return {
+    ...actual,
+    authenticateToken: (req: any, _res: any, next: any) => {
+      if (req.user) return next();
+      if (req.headers["x-test-role"]) {
+        req.user = { id: "test-teacher", role: req.headers["x-test-role"] };
+        return next();
+      }
+      next();
+    },
+  };
+});
+
+// Import app AFTER mocking
+import app from "../server";
+import { MODULE_PREP_DATA } from "./teacherPrep";
+
+// Archived module slugs (mirrors HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts —
+// the backend cannot import frontend constants, so the two archived slugs are
+// pinned here; a drift means this list needs a matching update).
+const ARCHIVED_SLUGS = ["k2-stem-sequencing", "stem-1-intro"];
+
+describe("teacher prep catalog (#K2 adult support)", () => {
+  it("contains no archived module slugs", () => {
+    for (const slug of ARCHIVED_SLUGS) {
+      expect(MODULE_PREP_DATA).not.toHaveProperty(slug);
+    }
+  });
+
+  it("covers exactly the active modules that have authored prep guides", () => {
+    expect(Object.keys(MODULE_PREP_DATA).sort()).toEqual([
+      "k2-stem-bounce-buds",
+      "k2-stem-gotcha-gears",
+      "k2-stem-rhyme-ride",
+    ]);
+  });
+
+  it("GET /api/teacher/prep lists only catalog modules, all with hasPrep", async () => {
+    const res = await request(app)
+      .get("/api/teacher/prep")
+      .set("x-test-role", "teacher");
+    expect(res.status).toBe(200);
+    const slugs = res.body.map((r: { moduleSlug: string }) => r.moduleSlug);
+    expect(slugs.sort()).toEqual(Object.keys(MODULE_PREP_DATA).sort());
+    expect(
+      res.body.every((r: { hasPrep: boolean }) => r.hasPrep === true),
+    ).toBe(true);
+    expect(slugs).not.toContain("k2-stem-sequencing");
+  });
+
+  it("GET /api/teacher/prep/:slug 404s for the archived sequencing module", async () => {
+    const res = await request(app)
+      .get("/api/teacher/prep/k2-stem-sequencing")
+      .set("x-test-role", "teacher");
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/teacher/prep/:slug serves an active module's prep data", async () => {
+    const res = await request(app)
+      .get("/api/teacher/prep/k2-stem-rhyme-ride")
+      .set("x-test-role", "teacher");
+    expect(res.status).toBe(200);
+    expect(res.body.moduleSlug).toBe("k2-stem-rhyme-ride");
+    expect(res.body.objectives.length).toBeGreaterThan(0);
+    expect(res.body.pacingGuide.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/routes/teacherPrep.ts
+++ b/backend/src/routes/teacherPrep.ts
@@ -22,56 +22,9 @@ const MODULE_PREP_DATA: Record<
     pacingGuide: { label: string; minutes: number }[];
   }
 > = {
-  "k2-stem-sequencing": {
-    objectives: [
-      "Students will understand that instructions must be followed in order (sequencing).",
-      "Students will identify when steps are out of order and correct a sequence.",
-      "Students will connect sequencing to everyday routines like getting dressed or baking.",
-    ],
-    vocabulary: [
-      { term: "Sequence", definition: "The order in which things happen, one after another." },
-      { term: "Algorithm", definition: "A set of step-by-step instructions to solve a problem." },
-      { term: "Debug", definition: "To find and fix a mistake in instructions." },
-      { term: "Step", definition: "One single action in a sequence of instructions." },
-    ],
-    prerequisites: [
-      "Ability to follow simple 2-3 step verbal instructions.",
-      "Understanding of first, next, and last.",
-      "Familiarity with everyday routines (morning routine, cooking, etc.).",
-    ],
-    estimatedMinutes: 45,
-    misconceptions: [
-      "Students may think any order works as long as all steps are included.",
-      "Students may confuse 'steps' with 'choices' — emphasize that order matters.",
-      "Some students believe computers can figure out the right order on their own.",
-    ],
-    discussionBefore: [
-      "What do you do every morning to get ready for school? What happens if you put on your shoes before your socks?",
-      "If you were making a peanut butter sandwich, what would happen if you spread the peanut butter before opening the jar?",
-      "Can you think of a time when doing things in the wrong order caused a silly mistake?",
-    ],
-    discussionAfter: [
-      "What happened when Boost's steps were out of order? How did you help fix them?",
-      "Why is it important for robots (and computers) to have steps in the right order?",
-      "Can you think of something at home where the order of steps really matters?",
-    ],
-    turnAndTalk: [
-      "Tell your partner about your morning routine. What is the FIRST thing you do?",
-      "If a robot wanted to brush its teeth, what steps would it need? Tell your partner.",
-    ],
-    materials: [
-      "Tablets or computers with internet access (one per student or pair)",
-      "Optional: printed sequence cards for unplugged warm-up activity",
-      "Optional: sticky notes for students to write their own sequence steps",
-    ],
-    pacingGuide: [
-      { label: "Warm-up discussion (use Before questions)", minutes: 5 },
-      { label: "Teacher intro: What is a sequence?", minutes: 5 },
-      { label: "Students on BrightBoost platform", minutes: 20 },
-      { label: "Group debrief (use After questions)", minutes: 10 },
-      { label: "Exit ticket: Draw 3 steps in order", minutes: 5 },
-    ],
-  },
+  // Archived modules (see HIDDEN_MODULE_SLUGS in src/constants/stemSets.ts)
+  // must not have entries here: this catalog drives both /teacher/prep/:slug
+  // and the availability list the launch dialog uses to show "Prepare Session".
   "k2-stem-rhyme-ride": {
     objectives: [
       "Students will identify words that rhyme (have the same ending sound).",
@@ -79,10 +32,23 @@ const MODULE_PREP_DATA: Record<
       "Students will connect rhyming to reading fluency and word patterns.",
     ],
     vocabulary: [
-      { term: "Rhyme", definition: "Words that have the same ending sound, like cat and hat." },
-      { term: "Sound", definition: "What we hear when we say a word out loud." },
-      { term: "Pattern", definition: "Something that repeats in a regular way." },
-      { term: "Word family", definition: "A group of words that end with the same letters and sound." },
+      {
+        term: "Rhyme",
+        definition: "Words that have the same ending sound, like cat and hat.",
+      },
+      {
+        term: "Sound",
+        definition: "What we hear when we say a word out loud.",
+      },
+      {
+        term: "Pattern",
+        definition: "Something that repeats in a regular way.",
+      },
+      {
+        term: "Word family",
+        definition:
+          "A group of words that end with the same letters and sound.",
+      },
     ],
     prerequisites: [
       "Ability to hear and identify individual sounds in words.",
@@ -129,10 +95,24 @@ const MODULE_PREP_DATA: Record<
       "Students will connect biology to everyday health habits like handwashing.",
     ],
     vocabulary: [
-      { term: "Cell", definition: "The smallest building block of all living things." },
-      { term: "Microbe", definition: "A tiny living thing too small to see without a microscope." },
-      { term: "Microscope", definition: "A tool that makes tiny things look big so we can see them." },
-      { term: "Healthy", definition: "When your body is working well and feeling good." },
+      {
+        term: "Cell",
+        definition: "The smallest building block of all living things.",
+      },
+      {
+        term: "Microbe",
+        definition:
+          "A tiny living thing too small to see without a microscope.",
+      },
+      {
+        term: "Microscope",
+        definition:
+          "A tool that makes tiny things look big so we can see them.",
+      },
+      {
+        term: "Healthy",
+        definition: "When your body is working well and feeling good.",
+      },
     ],
     prerequisites: [
       "Understanding that plants, animals, and people are living things.",
@@ -179,10 +159,23 @@ const MODULE_PREP_DATA: Record<
       "Students will learn that debugging means finding and fixing mistakes in a plan.",
     ],
     vocabulary: [
-      { term: "Robot", definition: "A machine that follows instructions to do a job." },
-      { term: "AI (Artificial Intelligence)", definition: "When a computer can learn and make decisions, like a smart helper." },
-      { term: "Plan", definition: "Thinking about what to do before you do it." },
-      { term: "Debug", definition: "Finding and fixing a mistake in your plan or code." },
+      {
+        term: "Robot",
+        definition: "A machine that follows instructions to do a job.",
+      },
+      {
+        term: "AI (Artificial Intelligence)",
+        definition:
+          "When a computer can learn and make decisions, like a smart helper.",
+      },
+      {
+        term: "Plan",
+        definition: "Thinking about what to do before you do it.",
+      },
+      {
+        term: "Debug",
+        definition: "Finding and fixing a mistake in your plan or code.",
+      },
     ],
     prerequisites: [
       "Basic understanding that machines and computers are built by people.",
@@ -216,7 +209,10 @@ const MODULE_PREP_DATA: Record<
     ],
     pacingGuide: [
       { label: "Warm-up: What do you know about robots?", minutes: 5 },
-      { label: "Teacher intro: How do robots follow instructions?", minutes: 5 },
+      {
+        label: "Teacher intro: How do robots follow instructions?",
+        minutes: 5,
+      },
       { label: "Students on BrightBoost platform", minutes: 20 },
       { label: "Group debrief (use After questions)", minutes: 10 },
       { label: "Exit ticket: Draw your own robot helper", minutes: 5 },
@@ -235,7 +231,9 @@ router.get(
 
       const prepData = MODULE_PREP_DATA[moduleSlug];
       if (!prepData) {
-        return res.status(404).json({ error: "No prep data found for this module" });
+        return res
+          .status(404)
+          .json({ error: "No prep data found for this module" });
       }
 
       // Fetch teacher's checklist state
@@ -309,7 +307,10 @@ router.get(
       });
 
       const checklistMap = Object.fromEntries(
-        checklists.map((c) => [c.moduleSlug, { items: c.items, completedAt: c.completedAt }]),
+        checklists.map((c) => [
+          c.moduleSlug,
+          { items: c.items, completedAt: c.completedAt },
+        ]),
       );
 
       const moduleSlugs = Object.keys(MODULE_PREP_DATA);

--- a/prompts/2026-07-27-k2-adult-support.md
+++ b/prompts/2026-07-27-k2-adult-support.md
@@ -1,0 +1,42 @@
+# 2026-07-27 — K–2 Adult Support foundation (Prepare Session repair + /parents + printable Quick Start)
+
+## Context
+
+External K–2 user feedback surfaced three top value/effort items for adults
+supporting young learners:
+
+1. The Launch Session dialog offers "Prepare Session" for **every** module,
+   but prep data exists for only three active K–2 games (plus the archived
+   Sequencing module) — teachers selecting any other module land on the prep
+   page's "not found" dead end.
+2. The public `/parents` route is a placeholder.
+3. There is no printable quick-start guide for parents / program volunteers.
+
+## Prompt (summary)
+
+Build one focused PR:
+
+- **Prepare Session**: data-driven availability via the existing
+  `GET /teacher/prep` list endpoint; show the link only when the selected
+  module has prep data; remove the archived `k2-stem-sequencing` entry from
+  the prep catalog; a failed availability request degrades safely (link
+  hidden, launch unaffected). Tests for supported / unsupported / archived.
+  Do NOT author the seven missing per-game guides here.
+- **`/parents`**: real responsive page; honest progression (Foundation
+  available → Exploration after Foundation → Mastery in development, framed
+  around Imagine → Create → Play → Share → Reflect); canonical set/game/strand
+  names imported from `src/constants/stemSets.ts`; adults as guides, not
+  proctors; CTAs to `/try`, `/student-login`, `/teacher/signup?intent=home`;
+  leave the Students/Teachers/Organizations placeholders untouched.
+- **`/parents/guide`**: public print-friendly K–2 Facilitator Quick Start
+  (before / during / after + ready-to-use prompts + independence note),
+  surfaced from both the parents page and Teacher Resources as ONE shared
+  route (no duplicated content); accessible Print button, no auto-print;
+  no read-aloud/audio claims (that limitation is tracked in #625).
+- i18n-keyed copy (en + es authored; vi/zh-CN fall back to English pending
+  human translation), `defaultValue` convention as in `/try`.
+
+## Checks requested
+
+lint, frontend + backend typecheck, unit tests (new route/dialog/catalog
+tests included), production build, locale JSON validity.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ import ResetPassword from "./pages/ResetPassword";
 import ForReviewers from "./pages/ForReviewers";
 import TryDemo from "./pages/TryDemo";
 import PlanDetail from "./pages/PlanDetail";
+import Parents from "./pages/Parents";
+import ParentGuide from "./pages/ParentGuide";
 import StudentBenchmark from "./pages/StudentBenchmark";
 import StudentSettings from "./pages/StudentSettings";
 import ExperimentDashboard from "./components/admin/ExperimentDashboard";
@@ -115,9 +117,18 @@ function App() {
               <Route path="/student-login" element={<LoginSelection />} />
               <Route path="/class-login" element={<StudentClassLogin />} />
               {/* Legacy redirects for old login routes */}
-              <Route path="/login" element={<Navigate to="/student-login" replace />} />
-              <Route path="/teacher/login" element={<Navigate to="/teacher-login" replace />} />
-              <Route path="/student/login" element={<Navigate to="/student-login" replace />} />
+              <Route
+                path="/login"
+                element={<Navigate to="/student-login" replace />}
+              />
+              <Route
+                path="/teacher/login"
+                element={<Navigate to="/teacher-login" replace />}
+              />
+              <Route
+                path="/student/login"
+                element={<Navigate to="/student-login" replace />}
+              />
               <Route path="/signup" element={<SignupSelection />} />
               <Route path="/teacher/signup" element={<TeacherSignup />} />
               <Route path="/student/signup" element={<StudentSignup />} />
@@ -134,12 +145,30 @@ function App() {
               <Route path="/plans/:plan" element={<PlanDetail />} />
               <Route path="/privacy" element={<PrivacyPolicy />} />
               <Route path="/terms" element={<TermsOfService />} />
-              <Route path="/feedback" element={<HomeSectionRedirect sectionId="feedback" />} />
-              <Route path="/donate" element={<HomeSectionRedirect sectionId="donation" />} />
-              <Route path="/students" element={<AudiencePlaceholder audience="Students" />} />
-              <Route path="/teachers" element={<AudiencePlaceholder audience="Teachers" />} />
-              <Route path="/parents" element={<AudiencePlaceholder audience="Parents" />} />
-              <Route path="/organizations" element={<AudiencePlaceholder audience="Organizations" />} />
+              <Route
+                path="/feedback"
+                element={<HomeSectionRedirect sectionId="feedback" />}
+              />
+              <Route
+                path="/donate"
+                element={<HomeSectionRedirect sectionId="donation" />}
+              />
+              <Route
+                path="/students"
+                element={<AudiencePlaceholder audience="Students" />}
+              />
+              <Route
+                path="/teachers"
+                element={<AudiencePlaceholder audience="Teachers" />}
+              />
+              <Route path="/parents" element={<Parents />} />
+              {/* Public print-friendly K-2 facilitator guide — linked from
+                  /parents and Teacher Resources (single source, no copies). */}
+              <Route path="/parents/guide" element={<ParentGuide />} />
+              <Route
+                path="/organizations"
+                element={<AudiencePlaceholder audience="Organizations" />}
+              />
 
               {/* Protected Teacher routes (nested) */}
               <Route
@@ -154,7 +183,10 @@ function App() {
                 <Route path="dashboard" element={<TeacherDashboard />} />
                 <Route path="classes" element={<TeacherClasses />} />
                 <Route path="classes/:id" element={<TeacherClassDetail />} />
-                <Route path="classes/:id/gallery" element={<TeacherGallery />} />
+                <Route
+                  path="classes/:id/gallery"
+                  element={<TeacherGallery />}
+                />
                 <Route path="students" element={<TeacherStudentRoster />} />
                 <Route path="prep/:slug" element={<TeacherModulePrep />} />
                 <Route path="resources" element={<TeacherResources />} />
@@ -188,7 +220,10 @@ function App() {
                 <Route path="challenge/:id" element={<ChallengePlayer />} />
                 <Route path="gallery" element={<StudentGallery />} />
                 <Route path="settings" element={<StudentSettings />} />
-                <Route path="benchmark/:assignmentId" element={<StudentBenchmark />} />
+                <Route
+                  path="benchmark/:assignmentId"
+                  element={<StudentBenchmark />}
+                />
                 <Route
                   path="arena"
                   element={<Navigate to="/student/play?tab=pvp" replace />}
@@ -221,18 +256,63 @@ function App() {
               {/* Pathways: Cyber Skills 101 welcome flow — rendered OUTSIDE
                   PathwaysLayout so it has its own minimal chrome. Each step
                   is its own URL so users can bookmark/resume. */}
-              <Route path="/pathways/welcome" element={<ProtectedRoute><WelcomeAvatarStep /></ProtectedRoute>} />
-              <Route path="/pathways/welcome/skills" element={<ProtectedRoute><WelcomeSkillsStep /></ProtectedRoute>} />
-              <Route path="/pathways/welcome/mission" element={<ProtectedRoute><WelcomeMissionStep /></ProtectedRoute>} />
-              <Route path="/pathways/welcome/goals" element={<ProtectedRoute><WelcomeGoalsStep /></ProtectedRoute>} />
-              <Route path="/pathways/welcome/complete" element={<ProtectedRoute><WelcomeCompleteStep /></ProtectedRoute>} />
+              <Route
+                path="/pathways/welcome"
+                element={
+                  <ProtectedRoute>
+                    <WelcomeAvatarStep />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/pathways/welcome/skills"
+                element={
+                  <ProtectedRoute>
+                    <WelcomeSkillsStep />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/pathways/welcome/mission"
+                element={
+                  <ProtectedRoute>
+                    <WelcomeMissionStep />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/pathways/welcome/goals"
+                element={
+                  <ProtectedRoute>
+                    <WelcomeGoalsStep />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/pathways/welcome/complete"
+                element={
+                  <ProtectedRoute>
+                    <WelcomeCompleteStep />
+                  </ProtectedRoute>
+                }
+              />
 
               {/* Pathways: student authenticated routes */}
-              <Route path="/pathways" element={<ProtectedRoute><PathwaysLayout /></ProtectedRoute>}>
+              <Route
+                path="/pathways"
+                element={
+                  <ProtectedRoute>
+                    <PathwaysLayout />
+                  </ProtectedRoute>
+                }
+              >
                 <Route index element={<PathwaysHome />} />
                 <Route path="tracks" element={<TracksOverview />} />
                 <Route path="tracks/:trackSlug" element={<TrackDetail />} />
-                <Route path="tracks/:trackSlug/:moduleSlug" element={<ModulePlayer />} />
+                <Route
+                  path="tracks/:trackSlug/:moduleSlug"
+                  element={<ModulePlayer />}
+                />
                 <Route path="challenges" element={<ChallengesPage />} />
                 <Route path="challenges/:slug" element={<ChallengePage />} />
                 <Route path="glossary" element={<GlossaryPage />} />
@@ -243,7 +323,11 @@ function App() {
                   layout shell so the student sidebar doesn't render on top. */}
               <Route
                 path="/pathways/facilitator"
-                element={<ProtectedRoute requiredRole="teacher"><FacilitatorLayout /></ProtectedRoute>}
+                element={
+                  <ProtectedRoute requiredRole="teacher">
+                    <FacilitatorLayout />
+                  </ProtectedRoute>
+                }
               >
                 <Route index element={<FacilitatorDashboardPage />} />
                 <Route path="cohorts" element={<CohortsListPage />} />
@@ -251,7 +335,10 @@ function App() {
                 <Route path="cohorts/:id" element={<CohortDetailPage />} />
                 <Route path="tracks" element={<FacilitatorTracksPage />} />
                 <Route path="learners" element={<FacilitatorLearnersPage />} />
-                <Route path="learners/:userId" element={<FacilitatorLearnerDetailPage />} />
+                <Route
+                  path="learners/:userId"
+                  element={<FacilitatorLearnerDetailPage />}
+                />
                 <Route path="reports" element={<FacilitatorReportsPage />} />
                 <Route path="resources" element={<ProgramOverviewPage />} />
                 <Route path="settings" element={<FacilitatorSettingsPage />} />

--- a/src/components/teacher/PrepareSessionLink.tsx
+++ b/src/components/teacher/PrepareSessionLink.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+interface PrepareSessionLinkProps {
+  /** Selected module slug ("" = nothing selected). */
+  slug: string;
+  /**
+   * Slugs that have prep data (from GET /teacher/prep).
+   * null = unknown (still loading or the request failed) — render nothing so
+   * a module without prep data can never dead-end on the 404 error card.
+   */
+  prepSlugs: Set<string> | null;
+}
+
+const PrepareSessionLink = ({ slug, prepSlugs }: PrepareSessionLinkProps) => {
+  const { t } = useTranslation();
+  if (!slug || !prepSlugs || !prepSlugs.has(slug)) return null;
+  return (
+    <Link
+      to={`/teacher/prep/${slug}`}
+      className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 hover:underline"
+      target="_blank"
+    >
+      {t("teacher.classDetail.prepareSession")} &rarr;
+    </Link>
+  );
+};
+
+export default PrepareSessionLink;

--- a/src/components/teacher/__tests__/PrepareSessionLink.test.tsx
+++ b/src/components/teacher/__tests__/PrepareSessionLink.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * "Prepare Session" availability contract (K-2 adult support):
+ * the link renders ONLY for modules that actually have prep data, so a
+ * teacher can never be led to the prep page's "not found" dead end.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PrepareSessionLink from "../PrepareSessionLink";
+
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+// Mirrors the live catalog in backend/src/routes/teacherPrep.ts (asserted
+// exactly by backend/src/routes/teacherPrep.test.ts).
+const AVAILABLE = new Set([
+  "k2-stem-rhyme-ride",
+  "k2-stem-bounce-buds",
+  "k2-stem-gotcha-gears",
+]);
+
+function renderLink(slug: string, prepSlugs: Set<string> | null) {
+  return render(
+    <MemoryRouter>
+      <PrepareSessionLink slug={slug} prepSlugs={prepSlugs} />
+    </MemoryRouter>,
+  );
+}
+
+describe("PrepareSessionLink", () => {
+  it("renders the prep link for a module with prep data", () => {
+    renderLink("k2-stem-rhyme-ride", AVAILABLE);
+    const link = screen.getByRole("link", {
+      name: /prepare for this session/i,
+    });
+    expect(link).toHaveAttribute("href", "/teacher/prep/k2-stem-rhyme-ride");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders nothing for an active module without prep data", () => {
+    renderLink("k2-stem-tank-trek", AVAILABLE);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders nothing for the archived sequencing module", () => {
+    renderLink("k2-stem-sequencing", AVAILABLE);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders nothing while availability is unknown (loading or failed fetch)", () => {
+    renderLink("k2-stem-rhyme-ride", null);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders nothing when no module is selected", () => {
+    renderLink("", AVAILABLE);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1898,5 +1898,96 @@
     "boosts": "Boosts",
     "giveBoost": "Give a boost ⭐",
     "play": "Play"
+  },
+  "parents": {
+    "docTitle": "Bright Boost for Parents & Families",
+    "title": "For Parents & Families",
+    "subtitle": "Bright Boost is a multilingual STEM learning platform for kids — built for classrooms, after-school programs, and home.",
+    "fits": {
+      "title": "Where Bright Boost fits",
+      "classroom": {
+        "title": "In the classroom",
+        "desc": "Teachers run sessions and see each child's progress."
+      },
+      "afterschool": {
+        "title": "After school",
+        "desc": "Program leaders use the same activities with small groups."
+      },
+      "home": {
+        "title": "At home",
+        "desc": "Families explore together — or kids explore on their own."
+      }
+    },
+    "journey": {
+      "title": "How the learning is organized",
+      "intro": "Children move through three sets of activities. Each one builds on the last."
+    },
+    "stages": {
+      "availableNow": "Available now",
+      "afterFoundation": "Opens after Foundation",
+      "inDevelopment": "In development",
+      "foundationDesc": "Structured, highly supported introductions to STEM ideas. Every activity guides children step by step.",
+      "explorationDesc": "Children predict, plan, test, measure, and revise — with more room to make their own choices.",
+      "masteryDesc": "Creation-first experiences built around Imagine → Create → Play → Share → Reflect. Children make things of their own."
+    },
+    "role": {
+      "title": "Your role: a guide, not a proctor",
+      "p1": "Kids do best when a nearby adult is curious with them — not checking their answers.",
+      "b1": "Ask what they notice and what they want to try.",
+      "b2": "Help with reading only when they ask.",
+      "b3": "Let them experiment — unexpected results are part of the learning.",
+      "b4": "Children can also explore entirely on their own."
+    },
+    "guideCard": {
+      "title": "K–2 Facilitator Quick Start",
+      "desc": "A one-page printable guide for any adult sitting alongside a young learner.",
+      "open": "Open the guide"
+    },
+    "cta": {
+      "title": "Get started",
+      "demo": "Try a game — no signup",
+      "join": "Join with a class code",
+      "home": "Create a home group"
+    },
+    "backHome": "Return to homepage"
+  },
+  "parentGuide": {
+    "docTitle": "K–2 Facilitator Quick Start — Bright Boost",
+    "title": "K–2 Facilitator Quick Start",
+    "subtitle": "For any adult alongside a young learner — parents, tutors, program leaders, and teachers.",
+    "back": "Back",
+    "print": "Print this guide",
+    "teacherCardDesc": "Printable one-pager for parents and program volunteers — before, during, and after an activity.",
+    "before": {
+      "title": "Before you start (2 minutes)",
+      "b1": "Open the activity once yourself so you know what the child will see.",
+      "b2": "Check the device: charged, connected, sound on if you have it.",
+      "b3": "Invite curiosity: \"We get to try something new today.\""
+    },
+    "during": {
+      "title": "While they play",
+      "b1": "Help with reading only when the child asks or gets stuck.",
+      "b2": "Ask wondering questions instead of giving answers.",
+      "b3": "Encourage experimenting — trying, changing, and even \"breaking\" things is how the games are meant to be played.",
+      "b4": "If they ask you for the answer, try: \"What could we try to find out?\""
+    },
+    "after": {
+      "title": "Afterwards",
+      "b1": "Ask what they noticed and what surprised them.",
+      "b2": "Ask what they changed, made, or figured out.",
+      "b3": "Ask what they want to try next time."
+    },
+    "prompts": {
+      "title": "Prompts you can use as-is",
+      "p1": "What do you notice?",
+      "p2": "What do you think will happen if…?",
+      "p3": "How did you figure that out?",
+      "p4": "What would you change next time?",
+      "p5": "Can you show me what you made?",
+      "p6": "What surprised you?",
+      "p7": "What do you want to try next?"
+    },
+    "independence": "You don't have to be there the whole time. The activities are built so a child can explore on their own — your curiosity is a bonus, not a requirement.",
+    "footer": "brightboost.org"
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -943,32 +943,127 @@
       "r7": { "prompt": "pan", "correct": "van", "d1": "sol", "d2": "pez" }
     },
     "bounceGame": {
-      "r1": { "clue": "Una planta bebé es una ____.", "correct": "semilla", "d1": "hoja", "d2": "roca", "hint": "¡Las semillas pueden crecer!" },
-      "r2": { "clue": "Esta parte bebe agua.", "correct": "raíz", "d1": "hoja", "d2": "sol", "hint": "Las raíces están bajo la tierra." },
-      "r3": { "clue": "Las hojas ayudan a las plantas a usar ____.", "correct": "luz solar", "d1": "pizza", "d2": "zapatos", "hint": "La luz solar ayuda a las plantas a crecer." },
-      "r4": { "clue": "Pequeños ayudantes vivos en la tierra son ____.", "correct": "microbios", "d1": "carros", "d2": "nubes", "hint": "Los microbios son diminutos y están vivos." },
-      "r5": { "clue": "Los bloques diminutos se llaman ____.", "correct": "células", "d1": "sillas", "d2": "galletas", "hint": "Las células son muy pequeñas." },
-      "r6": { "clue": "Una planta necesita agua y ____.", "correct": "luz solar", "d1": "tele", "d2": "dulces", "hint": "Las plantas necesitan luz." },
-      "r7": { "clue": "Una flor puede ayudar a hacer ____.", "correct": "semillas", "d1": "calcetines", "d2": "piedras", "hint": "Las flores ayudan a las plantas a hacer semillas." }
+      "r1": {
+        "clue": "Una planta bebé es una ____.",
+        "correct": "semilla",
+        "d1": "hoja",
+        "d2": "roca",
+        "hint": "¡Las semillas pueden crecer!"
+      },
+      "r2": {
+        "clue": "Esta parte bebe agua.",
+        "correct": "raíz",
+        "d1": "hoja",
+        "d2": "sol",
+        "hint": "Las raíces están bajo la tierra."
+      },
+      "r3": {
+        "clue": "Las hojas ayudan a las plantas a usar ____.",
+        "correct": "luz solar",
+        "d1": "pizza",
+        "d2": "zapatos",
+        "hint": "La luz solar ayuda a las plantas a crecer."
+      },
+      "r4": {
+        "clue": "Pequeños ayudantes vivos en la tierra son ____.",
+        "correct": "microbios",
+        "d1": "carros",
+        "d2": "nubes",
+        "hint": "Los microbios son diminutos y están vivos."
+      },
+      "r5": {
+        "clue": "Los bloques diminutos se llaman ____.",
+        "correct": "células",
+        "d1": "sillas",
+        "d2": "galletas",
+        "hint": "Las células son muy pequeñas."
+      },
+      "r6": {
+        "clue": "Una planta necesita agua y ____.",
+        "correct": "luz solar",
+        "d1": "tele",
+        "d2": "dulces",
+        "hint": "Las plantas necesitan luz."
+      },
+      "r7": {
+        "clue": "Una flor puede ayudar a hacer ____.",
+        "correct": "semillas",
+        "d1": "calcetines",
+        "d2": "piedras",
+        "hint": "Las flores ayudan a las plantas a hacer semillas."
+      }
     },
     "gotchaGame": {
-      "r1": { "clue": "El robot sigue cometiendo errores. ¿Qué debe hacer?", "correct": "depurar", "d1": "adivinar", "d2": "ignorar", "hint": "Depurar significa arreglar el error." },
-      "r2": { "clue": "Queremos que el robot aprenda. ¿Qué ayuda más?", "correct": "practicar", "d1": "saltarse", "d2": "dormir", "hint": "Practicar significa intentar de nuevo." },
-      "r3": { "clue": "Necesitamos ordenar cosas. ¿Qué elegimos primero?", "correct": "regla", "d1": "al azar", "d2": "ruido", "hint": "Una regla dice cómo agrupar cosas." },
-      "r4": { "clue": "El robot necesita pasos a seguir. ¿Qué es eso?", "correct": "plan", "d1": "prisa", "d2": "lío", "hint": "Un plan son pasos en orden." },
-      "r5": { "clue": "Buscamos pistas para encontrar una respuesta. Eso se llama…", "correct": "patrón", "d1": "suerte", "d2": "magia", "hint": "Un patrón se repite o coincide." },
-      "r6": { "clue": "El robot prueba algo nuevo. ¿Qué está haciendo?", "correct": "probar", "d1": "dormir", "d2": "esconder", "hint": "Probar significa ver si funciona." },
-      "r7": { "clue": "Le enseñamos al robot dándole…", "correct": "datos", "d1": "dulces", "d2": "juguetes", "hint": "Los datos son información que el robot usa para aprender." }
+      "r1": {
+        "clue": "El robot sigue cometiendo errores. ¿Qué debe hacer?",
+        "correct": "depurar",
+        "d1": "adivinar",
+        "d2": "ignorar",
+        "hint": "Depurar significa arreglar el error."
+      },
+      "r2": {
+        "clue": "Queremos que el robot aprenda. ¿Qué ayuda más?",
+        "correct": "practicar",
+        "d1": "saltarse",
+        "d2": "dormir",
+        "hint": "Practicar significa intentar de nuevo."
+      },
+      "r3": {
+        "clue": "Necesitamos ordenar cosas. ¿Qué elegimos primero?",
+        "correct": "regla",
+        "d1": "al azar",
+        "d2": "ruido",
+        "hint": "Una regla dice cómo agrupar cosas."
+      },
+      "r4": {
+        "clue": "El robot necesita pasos a seguir. ¿Qué es eso?",
+        "correct": "plan",
+        "d1": "prisa",
+        "d2": "lío",
+        "hint": "Un plan son pasos en orden."
+      },
+      "r5": {
+        "clue": "Buscamos pistas para encontrar una respuesta. Eso se llama…",
+        "correct": "patrón",
+        "d1": "suerte",
+        "d2": "magia",
+        "hint": "Un patrón se repite o coincide."
+      },
+      "r6": {
+        "clue": "El robot prueba algo nuevo. ¿Qué está haciendo?",
+        "correct": "probar",
+        "d1": "dormir",
+        "d2": "esconder",
+        "hint": "Probar significa ver si funciona."
+      },
+      "r7": {
+        "clue": "Le enseñamos al robot dándole…",
+        "correct": "datos",
+        "d1": "dulces",
+        "d2": "juguetes",
+        "hint": "Los datos son información que el robot usa para aprender."
+      }
     },
     "seqGame": {
       "l1": {
-        "c1": "Verter", "c2": "Hornear", "c3": "Decorar", "c4": "Comer"
+        "c1": "Verter",
+        "c2": "Hornear",
+        "c3": "Decorar",
+        "c4": "Comer"
       },
       "l2": {
-        "c1": "Abrir el agua", "c2": "Lavar", "c3": "Jabón", "c4": "Enjuagar", "c5": "Secar"
+        "c1": "Abrir el agua",
+        "c2": "Lavar",
+        "c3": "Jabón",
+        "c4": "Enjuagar",
+        "c5": "Secar"
       },
       "l3": {
-        "c1": "Planear", "c2": "Programar", "c3": "Probar", "c4": "Arreglar", "c5": "Compartir"
+        "c1": "Planear",
+        "c2": "Programar",
+        "c3": "Probar",
+        "c4": "Arreglar",
+        "c5": "Compartir"
       }
     }
   },
@@ -1636,5 +1731,96 @@
     "boosts": "Ánimos",
     "giveBoost": "Dar ánimo ⭐",
     "play": "Jugar"
+  },
+  "parents": {
+    "docTitle": "Bright Boost para padres y familias",
+    "title": "Para padres y familias",
+    "subtitle": "Bright Boost es una plataforma multilingüe de aprendizaje STEM para niños — pensada para el aula, los programas extraescolares y el hogar.",
+    "fits": {
+      "title": "Dónde encaja Bright Boost",
+      "classroom": {
+        "title": "En el aula",
+        "desc": "Los maestros dirigen sesiones y ven el progreso de cada niño."
+      },
+      "afterschool": {
+        "title": "Después de clases",
+        "desc": "Los líderes de programas usan las mismas actividades con grupos pequeños."
+      },
+      "home": {
+        "title": "En casa",
+        "desc": "Las familias exploran juntas — o los niños exploran por su cuenta."
+      }
+    },
+    "journey": {
+      "title": "Cómo se organiza el aprendizaje",
+      "intro": "Los niños avanzan por tres conjuntos de actividades. Cada uno se apoya en el anterior."
+    },
+    "stages": {
+      "availableNow": "Disponible ahora",
+      "afterFoundation": "Se abre después de Fundamentos",
+      "inDevelopment": "En desarrollo",
+      "foundationDesc": "Introducciones a las ideas STEM con mucha estructura y apoyo. Cada actividad guía a los niños paso a paso.",
+      "explorationDesc": "Los niños predicen, planean, prueban, miden y revisan — con más espacio para tomar sus propias decisiones.",
+      "masteryDesc": "Experiencias centradas en crear, construidas alrededor de Imaginar → Crear → Jugar → Compartir → Reflexionar. Los niños hacen cosas propias."
+    },
+    "role": {
+      "title": "Tu papel: guía, no supervisor",
+      "p1": "A los niños les va mejor cuando un adulto cercano siente curiosidad con ellos — no cuando revisa sus respuestas.",
+      "b1": "Pregunta qué notan y qué quieren intentar.",
+      "b2": "Ayuda con la lectura solo cuando lo pidan.",
+      "b3": "Deja que experimenten — los resultados inesperados son parte del aprendizaje.",
+      "b4": "Los niños también pueden explorar completamente por su cuenta."
+    },
+    "guideCard": {
+      "title": "Guía rápida para facilitadores K–2",
+      "desc": "Una guía imprimible de una página para cualquier adulto que acompañe a un pequeño aprendiz.",
+      "open": "Abrir la guía"
+    },
+    "cta": {
+      "title": "Empieza ahora",
+      "demo": "Prueba un juego — sin registro",
+      "join": "Únete con un código de clase",
+      "home": "Crea un grupo de hogar"
+    },
+    "backHome": "Volver a la página principal"
+  },
+  "parentGuide": {
+    "docTitle": "Guía rápida para facilitadores K–2 — Bright Boost",
+    "title": "Guía rápida para facilitadores K–2",
+    "subtitle": "Para cualquier adulto que acompañe a un pequeño aprendiz — padres, tutores, líderes de programas y maestros.",
+    "back": "Volver",
+    "print": "Imprimir esta guía",
+    "teacherCardDesc": "Una página imprimible para padres y voluntarios — antes, durante y después de una actividad.",
+    "before": {
+      "title": "Antes de empezar (2 minutos)",
+      "b1": "Abre la actividad una vez tú mismo para saber qué verá el niño.",
+      "b2": "Revisa el dispositivo: con carga, conectado, con sonido si lo tienes.",
+      "b3": "Invita a la curiosidad: \"Hoy vamos a probar algo nuevo\"."
+    },
+    "during": {
+      "title": "Mientras juegan",
+      "b1": "Ayuda con la lectura solo cuando el niño lo pida o se atasque.",
+      "b2": "Haz preguntas de asombro en lugar de dar respuestas.",
+      "b3": "Anima a experimentar — probar, cambiar e incluso \"romper\" cosas es como se juegan estos juegos.",
+      "b4": "Si te piden la respuesta, prueba con: \"¿Qué podríamos intentar para descubrirlo?\""
+    },
+    "after": {
+      "title": "Después",
+      "b1": "Pregunta qué notaron y qué les sorprendió.",
+      "b2": "Pregunta qué cambiaron, hicieron o descubrieron.",
+      "b3": "Pregunta qué quieren intentar la próxima vez."
+    },
+    "prompts": {
+      "title": "Frases listas para usar",
+      "p1": "¿Qué notas?",
+      "p2": "¿Qué crees que pasará si…?",
+      "p3": "¿Cómo lo descubriste?",
+      "p4": "¿Qué cambiarías la próxima vez?",
+      "p5": "¿Me enseñas lo que hiciste?",
+      "p6": "¿Qué te sorprendió?",
+      "p7": "¿Qué quieres intentar ahora?"
+    },
+    "independence": "No tienes que estar presente todo el tiempo. Las actividades están hechas para que un niño pueda explorar por su cuenta — tu curiosidad es un extra, no un requisito.",
+    "footer": "brightboost.org"
   }
 }

--- a/src/pages/ParentGuide.tsx
+++ b/src/pages/ParentGuide.tsx
@@ -1,0 +1,184 @@
+/**
+ * /parents/guide — public, print-friendly K–2 Facilitator Quick Start.
+ *
+ * One source of truth for the guide: the parents page and Teacher Resources
+ * both link HERE rather than carrying their own copies. Print styling uses
+ * Tailwind `print:` utilities (same pattern as TeacherModulePrep); the Print
+ * button calls window.print() on click — never automatically.
+ */
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Printer, ChevronLeft } from "lucide-react";
+
+const ParentGuide = () => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    document.title = t("parentGuide.docTitle", {
+      defaultValue: "K–2 Facilitator Quick Start — Bright Boost",
+    });
+  }, [t]);
+
+  const sections = [
+    {
+      key: "before",
+      title: t("parentGuide.before.title", {
+        defaultValue: "Before you start (2 minutes)",
+      }),
+      items: [
+        t("parentGuide.before.b1", {
+          defaultValue:
+            "Open the activity once yourself so you know what the child will see.",
+        }),
+        t("parentGuide.before.b2", {
+          defaultValue:
+            "Check the device: charged, connected, sound on if you have it.",
+        }),
+        t("parentGuide.before.b3", {
+          defaultValue:
+            'Invite curiosity: "We get to try something new today."',
+        }),
+      ],
+    },
+    {
+      key: "during",
+      title: t("parentGuide.during.title", { defaultValue: "While they play" }),
+      items: [
+        t("parentGuide.during.b1", {
+          defaultValue:
+            "Help with reading only when the child asks or gets stuck.",
+        }),
+        t("parentGuide.during.b2", {
+          defaultValue: "Ask wondering questions instead of giving answers.",
+        }),
+        t("parentGuide.during.b3", {
+          defaultValue:
+            'Encourage experimenting — trying, changing, and even "breaking" things is how the games are meant to be played.',
+        }),
+        t("parentGuide.during.b4", {
+          defaultValue:
+            'If they ask you for the answer, try: "What could we try to find out?"',
+        }),
+      ],
+    },
+    {
+      key: "after",
+      title: t("parentGuide.after.title", { defaultValue: "Afterwards" }),
+      items: [
+        t("parentGuide.after.b1", {
+          defaultValue: "Ask what they noticed and what surprised them.",
+        }),
+        t("parentGuide.after.b2", {
+          defaultValue: "Ask what they changed, made, or figured out.",
+        }),
+        t("parentGuide.after.b3", {
+          defaultValue: "Ask what they want to try next time.",
+        }),
+      ],
+    },
+  ];
+
+  const prompts = [
+    t("parentGuide.prompts.p1", { defaultValue: "What do you notice?" }),
+    t("parentGuide.prompts.p2", {
+      defaultValue: "What do you think will happen if…?",
+    }),
+    t("parentGuide.prompts.p3", {
+      defaultValue: "How did you figure that out?",
+    }),
+    t("parentGuide.prompts.p4", {
+      defaultValue: "What would you change next time?",
+    }),
+    t("parentGuide.prompts.p5", {
+      defaultValue: "Can you show me what you made?",
+    }),
+    t("parentGuide.prompts.p6", { defaultValue: "What surprised you?" }),
+    t("parentGuide.prompts.p7", {
+      defaultValue: "What do you want to try next?",
+    }),
+  ];
+
+  return (
+    <main className="min-h-screen bg-white px-4 py-8 print:p-0">
+      <div className="max-w-2xl mx-auto">
+        {/* Screen-only chrome */}
+        <div className="print:hidden flex items-center justify-between mb-6">
+          <Link
+            to="/parents"
+            className="inline-flex items-center text-sm text-brightboost-blue font-bold hover:underline"
+          >
+            <ChevronLeft className="w-4 h-4 mr-1" />
+            {t("parentGuide.back", { defaultValue: "Back" })}
+          </Link>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+          >
+            <Printer className="w-4 h-4" aria-hidden="true" />
+            {t("parentGuide.print", { defaultValue: "Print this guide" })}
+          </button>
+        </div>
+
+        {/* Printable content */}
+        <header className="print:break-inside-avoid">
+          <h1 className="text-2xl font-extrabold text-brightboost-navy">
+            {t("parentGuide.title", {
+              defaultValue: "K–2 Facilitator Quick Start",
+            })}
+          </h1>
+          <p className="mt-1 text-sm text-brightboost-navy/75">
+            {t("parentGuide.subtitle", {
+              defaultValue:
+                "For any adult alongside a young learner — parents, tutors, program leaders, and teachers.",
+            })}
+          </p>
+        </header>
+
+        <div className="mt-6 space-y-5">
+          {sections.map((section) => (
+            <section key={section.key} className="print:break-inside-avoid">
+              <h2 className="text-lg font-bold text-brightboost-navy border-b border-gray-200 pb-1">
+                {section.title}
+              </h2>
+              <ul className="mt-2 space-y-1.5 text-sm text-gray-800 list-disc pl-5">
+                {section.items.map((item, i) => (
+                  <li key={i}>{item}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+
+          <section className="print:break-inside-avoid rounded-xl border border-brightboost-blue/30 bg-brightboost-blue/5 p-4 print:bg-white">
+            <h2 className="text-lg font-bold text-brightboost-navy">
+              {t("parentGuide.prompts.title", {
+                defaultValue: "Prompts you can use as-is",
+              })}
+            </h2>
+            <ul className="mt-2 grid gap-1.5 sm:grid-cols-2 text-sm text-gray-800">
+              {prompts.map((prompt, i) => (
+                <li key={i} className="italic">
+                  &ldquo;{prompt}&rdquo;
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <p className="print:break-inside-avoid text-sm text-gray-700 border-l-4 border-brightboost-blue/40 pl-3">
+            {t("parentGuide.independence", {
+              defaultValue:
+                "You don't have to be there the whole time. The activities are built so a child can explore on their own — your curiosity is a bonus, not a requirement.",
+            })}
+          </p>
+
+          <p className="hidden print:block text-xs text-gray-400 pt-2">
+            {t("parentGuide.footer", { defaultValue: "brightboost.org" })}
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default ParentGuide;

--- a/src/pages/Parents.tsx
+++ b/src/pages/Parents.tsx
@@ -1,0 +1,310 @@
+/**
+ * /parents — public page for parents & families.
+ *
+ * Replaces the AudiencePlaceholder for the Parents audience only (the
+ * Students / Teachers / Organizations placeholders are untouched). Set and
+ * game names come from the canonical constants in src/constants/stemSets.ts —
+ * never duplicated here — so this page can't drift from the product.
+ */
+import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import GameBackground from "@/components/GameBackground";
+import {
+  STEM_SET_1_IDS,
+  STEM_SET_1_NAMES,
+  STEM_SET_1_STRANDS,
+  STEM_SET_2_IDS,
+  STEM_SET_2_NAMES,
+  STEM_SET_2_STRANDS,
+  SET_LABELS,
+} from "@/constants/stemSets";
+
+const Parents = () => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    document.title = t("parents.docTitle", {
+      defaultValue: "Bright Boost for Parents & Families",
+    });
+  }, [t]);
+
+  const stages = [
+    {
+      key: "foundation",
+      label: SET_LABELS[0],
+      badge: t("parents.stages.availableNow", {
+        defaultValue: "Available now",
+      }),
+      badgeClass: "bg-green-100 text-green-800",
+      desc: t("parents.stages.foundationDesc", {
+        defaultValue:
+          "Structured, highly supported introductions to STEM ideas. Every activity guides children step by step.",
+      }),
+      games: STEM_SET_1_IDS.map((id) => ({
+        name: STEM_SET_1_NAMES[id],
+        strand: STEM_SET_1_STRANDS[id],
+      })),
+    },
+    {
+      key: "exploration",
+      label: SET_LABELS[1],
+      badge: t("parents.stages.afterFoundation", {
+        defaultValue: "Opens after Foundation",
+      }),
+      badgeClass: "bg-blue-100 text-blue-800",
+      desc: t("parents.stages.explorationDesc", {
+        defaultValue:
+          "Children predict, plan, test, measure, and revise — with more room to make their own choices.",
+      }),
+      games: STEM_SET_2_IDS.map((id) => ({
+        name: STEM_SET_2_NAMES[id],
+        strand: STEM_SET_2_STRANDS[id],
+      })),
+    },
+    {
+      key: "mastery",
+      label: SET_LABELS[2],
+      badge: t("parents.stages.inDevelopment", {
+        defaultValue: "In development",
+      }),
+      badgeClass: "bg-amber-100 text-amber-800",
+      desc: t("parents.stages.masteryDesc", {
+        defaultValue:
+          "Creation-first experiences built around Imagine → Create → Play → Share → Reflect. Children make things of their own.",
+      }),
+      games: [] as { name: string; strand: string }[],
+    },
+  ];
+
+  return (
+    <GameBackground>
+      <main className="min-h-screen px-4 py-12">
+        <div className="max-w-4xl mx-auto space-y-8">
+          {/* Hero */}
+          <section className="rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+            <h1 className="text-3xl md:text-4xl font-extrabold text-brightboost-navy">
+              {t("parents.title", { defaultValue: "For Parents & Families" })}
+            </h1>
+            <p className="mt-3 text-lg text-brightboost-navy/85">
+              {t("parents.subtitle", {
+                defaultValue:
+                  "Bright Boost is a multilingual STEM learning platform for kids — built for classrooms, after-school programs, and home.",
+              })}
+            </p>
+          </section>
+
+          {/* Where it fits */}
+          <section className="rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+            <h2 className="text-2xl font-bold text-brightboost-navy">
+              {t("parents.fits.title", {
+                defaultValue: "Where Bright Boost fits",
+              })}
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              {(
+                [
+                  {
+                    key: "classroom",
+                    title: t("parents.fits.classroom.title", {
+                      defaultValue: "In the classroom",
+                    }),
+                    desc: t("parents.fits.classroom.desc", {
+                      defaultValue:
+                        "Teachers run sessions and see each child's progress.",
+                    }),
+                  },
+                  {
+                    key: "afterschool",
+                    title: t("parents.fits.afterschool.title", {
+                      defaultValue: "After school",
+                    }),
+                    desc: t("parents.fits.afterschool.desc", {
+                      defaultValue:
+                        "Program leaders use the same activities with small groups.",
+                    }),
+                  },
+                  {
+                    key: "home",
+                    title: t("parents.fits.home.title", {
+                      defaultValue: "At home",
+                    }),
+                    desc: t("parents.fits.home.desc", {
+                      defaultValue:
+                        "Families explore together — or kids explore on their own.",
+                    }),
+                  },
+                ] as const
+              ).map((item) => (
+                <div
+                  key={item.key}
+                  className="rounded-xl border border-brightboost-blue/20 bg-white p-4"
+                >
+                  <h3 className="font-bold text-brightboost-navy">
+                    {item.title}
+                  </h3>
+                  <p className="mt-1 text-sm text-brightboost-navy/80">
+                    {item.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Curriculum progression */}
+          <section className="rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+            <h2 className="text-2xl font-bold text-brightboost-navy">
+              {t("parents.journey.title", {
+                defaultValue: "How the learning is organized",
+              })}
+            </h2>
+            <p className="mt-2 text-brightboost-navy/80">
+              {t("parents.journey.intro", {
+                defaultValue:
+                  "Children move through three sets of activities. Each one builds on the last.",
+              })}
+            </p>
+            <div className="mt-4 space-y-4">
+              {stages.map((stage) => (
+                <div
+                  key={stage.key}
+                  className="rounded-xl border border-brightboost-blue/20 bg-white p-5"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-bold text-brightboost-navy">
+                      {stage.label}
+                    </h3>
+                    <span
+                      className={`text-xs font-semibold px-2 py-0.5 rounded-full ${stage.badgeClass}`}
+                    >
+                      {stage.badge}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm text-brightboost-navy/80">
+                    {stage.desc}
+                  </p>
+                  {stage.games.length > 0 && (
+                    <ul className="mt-3 flex flex-wrap gap-2">
+                      {stage.games.map((game) => (
+                        <li
+                          key={game.name}
+                          className="text-xs rounded-full bg-brightboost-blue/10 text-brightboost-navy px-3 py-1"
+                        >
+                          <span className="font-semibold">{game.name}</span>
+                          <span className="text-brightboost-navy/60">
+                            {" "}
+                            · {game.strand}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Adult role */}
+          <section className="rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+            <h2 className="text-2xl font-bold text-brightboost-navy">
+              {t("parents.role.title", {
+                defaultValue: "Your role: a guide, not a proctor",
+              })}
+            </h2>
+            <p className="mt-2 text-brightboost-navy/80">
+              {t("parents.role.p1", {
+                defaultValue:
+                  "Kids do best when a nearby adult is curious with them — not checking their answers.",
+              })}
+            </p>
+            <ul className="mt-3 space-y-2 text-sm text-brightboost-navy/80 list-disc pl-5">
+              <li>
+                {t("parents.role.b1", {
+                  defaultValue:
+                    "Ask what they notice and what they want to try.",
+                })}
+              </li>
+              <li>
+                {t("parents.role.b2", {
+                  defaultValue: "Help with reading only when they ask.",
+                })}
+              </li>
+              <li>
+                {t("parents.role.b3", {
+                  defaultValue:
+                    "Let them experiment — unexpected results are part of the learning.",
+                })}
+              </li>
+              <li>
+                {t("parents.role.b4", {
+                  defaultValue:
+                    "Children can also explore entirely on their own.",
+                })}
+              </li>
+            </ul>
+            <div className="mt-4 rounded-xl border border-brightboost-blue/20 bg-brightboost-blue/5 p-4">
+              <h3 className="font-bold text-brightboost-navy">
+                {t("parents.guideCard.title", {
+                  defaultValue: "K–2 Facilitator Quick Start",
+                })}
+              </h3>
+              <p className="mt-1 text-sm text-brightboost-navy/80">
+                {t("parents.guideCard.desc", {
+                  defaultValue:
+                    "A one-page printable guide for any adult sitting alongside a young learner.",
+                })}
+              </p>
+              <Link
+                to="/parents/guide"
+                className="inline-block mt-2 text-brightboost-blue font-bold underline"
+              >
+                {t("parents.guideCard.open", {
+                  defaultValue: "Open the guide",
+                })}
+              </Link>
+            </div>
+          </section>
+
+          {/* CTAs */}
+          <section className="rounded-2xl bg-white/90 p-8 shadow-lg border border-white/80">
+            <h2 className="text-2xl font-bold text-brightboost-navy">
+              {t("parents.cta.title", { defaultValue: "Get started" })}
+            </h2>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <Link
+                to="/try"
+                className="rounded-xl bg-brightboost-blue text-white font-bold text-center px-4 py-3 hover:opacity-90"
+              >
+                {t("parents.cta.demo", {
+                  defaultValue: "Try a game — no signup",
+                })}
+              </Link>
+              <Link
+                to="/student-login"
+                className="rounded-xl border-2 border-brightboost-blue text-brightboost-blue font-bold text-center px-4 py-3 hover:bg-brightboost-blue/5"
+              >
+                {t("parents.cta.join", {
+                  defaultValue: "Join with a class code",
+                })}
+              </Link>
+              <Link
+                to="/teacher/signup?intent=home"
+                className="rounded-xl border-2 border-brightboost-blue text-brightboost-blue font-bold text-center px-4 py-3 hover:bg-brightboost-blue/5"
+              >
+                {t("parents.cta.home", { defaultValue: "Create a home group" })}
+              </Link>
+            </div>
+            <Link
+              to="/"
+              className="inline-block mt-5 text-brightboost-blue font-bold underline"
+            >
+              {t("parents.backHome", { defaultValue: "Return to homepage" })}
+            </Link>
+          </section>
+        </div>
+      </main>
+    </GameBackground>
+  );
+};
+
+export default Parents;

--- a/src/pages/TeacherClassDetail.tsx
+++ b/src/pages/TeacherClassDetail.tsx
@@ -18,6 +18,7 @@ import {
   Palette,
 } from "lucide-react";
 import PrintLoginCards from "@/components/teacher/PrintLoginCards";
+import PrepareSessionLink from "@/components/teacher/PrepareSessionLink";
 import CreationStatusChip, {
   type CreationStatus,
 } from "@/components/creations/CreationStatusChip";
@@ -192,7 +193,9 @@ const TeacherClassDetail: React.FC = () => {
   const [pulse, setPulse] = useState<PulseSummary | null>(null);
 
   // Icon assignment
-  const [iconAssignments, setIconAssignments] = useState<Record<string, string>>({});
+  const [iconAssignments, setIconAssignments] = useState<
+    Record<string, string>
+  >({});
   const [savingIcons, setSavingIcons] = useState(false);
   const [showPrintCards, setShowPrintCards] = useState(false);
   const [printCardsData, setPrintCardsData] = useState<{
@@ -203,13 +206,18 @@ const TeacherClassDetail: React.FC = () => {
 
   // Benchmarks
   const [benchmarks, setBenchmarks] = useState<BenchmarkSummary[]>([]);
-  const [benchmarkTemplates, setBenchmarkTemplates] = useState<BenchmarkTemplate[]>([]);
+  const [benchmarkTemplates, setBenchmarkTemplates] = useState<
+    BenchmarkTemplate[]
+  >([]);
   const [assigningBenchmark, setAssigningBenchmark] = useState(false);
   const [growth, setGrowth] = useState<GrowthReport | null>(null);
 
   // Launch session wizard
   const [launchOpen, setLaunchOpen] = useState(false);
   const [modules, setModules] = useState<ModuleSummary[]>([]);
+  // null = availability unknown (loading or fetch failed) — the prep link
+  // stays hidden so an uncovered module can never dead-end on a 404.
+  const [prepSlugs, setPrepSlugs] = useState<Set<string> | null>(null);
   const [selModule, setSelModule] = useState<string>("");
   const [selActivity, setSelActivity] = useState<{
     id: string;
@@ -230,7 +238,16 @@ const TeacherClassDetail: React.FC = () => {
     (async () => {
       setLoading(true);
       try {
-        const [courseData, assignmentData, pulseData, benchmarkData, templateData, growthData, attentionData, creationData] = await Promise.all([
+        const [
+          courseData,
+          assignmentData,
+          pulseData,
+          benchmarkData,
+          templateData,
+          growthData,
+          attentionData,
+          creationData,
+        ] = await Promise.all([
           api.get(`/teacher/courses/${id}`),
           api.get(`/teacher/courses/${id}/assignments`),
           api.get(`/teacher/courses/${id}/pulse/summary`),
@@ -249,9 +266,15 @@ const TeacherClassDetail: React.FC = () => {
         setAttention(attentionData);
         setCreations(Array.isArray(creationData) ? creationData : []);
       } catch (err) {
-        const is404 = (err instanceof ApiError && err.status === 404) ||
-          (err instanceof Error && (/404/.test(err.message) || /not found/i.test(err.message)));
-        setError(is404 ? t("teacher.classDetail.notFound") : t("teacher.classDetail.failedLoad"));
+        const is404 =
+          (err instanceof ApiError && err.status === 404) ||
+          (err instanceof Error &&
+            (/404/.test(err.message) || /not found/i.test(err.message)));
+        setError(
+          is404
+            ? t("teacher.classDetail.notFound")
+            : t("teacher.classDetail.failedLoad"),
+        );
       } finally {
         setLoading(false);
       }
@@ -274,8 +297,26 @@ const TeacherClassDetail: React.FC = () => {
   // -------------------------------------------------------------------
 
   const AVAILABLE_ICONS = [
-    "🐱", "🐶", "🦊", "🐸", "🦁", "🐰", "🐼", "🦄", "🐢", "🦋",
-    "🐧", "🐨", "🦉", "🐙", "🦈", "🐝", "🦜", "🐳", "🦒", "🐞",
+    "🐱",
+    "🐶",
+    "🦊",
+    "🐸",
+    "🦁",
+    "🐰",
+    "🐼",
+    "🦄",
+    "🐢",
+    "🦋",
+    "🐧",
+    "🐨",
+    "🦉",
+    "🐙",
+    "🦈",
+    "🐝",
+    "🦜",
+    "🐳",
+    "🦒",
+    "🐞",
   ];
 
   const assignIcon = useCallback((studentId: string, icon: string) => {
@@ -296,11 +337,15 @@ const TeacherClassDetail: React.FC = () => {
     if (!id || Object.keys(iconAssignments).length === 0) return;
     setSavingIcons(true);
     try {
-      const students = Object.entries(iconAssignments).map(([studentId, icon]) => ({
-        studentId,
-        icon,
-      }));
-      await api.post(`/teacher/courses/${id}/setup-icons`, { students } as Record<string, unknown>);
+      const students = Object.entries(iconAssignments).map(
+        ([studentId, icon]) => ({
+          studentId,
+          icon,
+        }),
+      );
+      await api.post(`/teacher/courses/${id}/setup-icons`, {
+        students,
+      } as Record<string, unknown>);
       const updatedCourse = await api.get(`/teacher/courses/${id}`);
       setCourse(updatedCourse);
     } catch {
@@ -327,10 +372,26 @@ const TeacherClassDetail: React.FC = () => {
 
   const openLaunchWizard = async () => {
     setLaunchOpen(true);
+    if (prepSlugs === null) {
+      api
+        .get(`/teacher/prep`)
+        .then((prep) => {
+          const list = Array.isArray(prep) ? prep : [];
+          setPrepSlugs(
+            new Set(
+              list.filter((p) => p?.hasPrep).map((p) => p.moduleSlug as string),
+            ),
+          );
+        })
+        .catch(() => {
+          // Availability unknown — leave prepSlugs null; the link stays
+          // hidden and session launch is unaffected.
+        });
+    }
     if (modules.length === 0) {
       try {
         const mods = await directApi.getModules();
-        const modArray = Array.isArray(mods) ? mods : mods?.modules ?? [];
+        const modArray = Array.isArray(mods) ? mods : (mods?.modules ?? []);
         const detailed = await Promise.all(
           modArray.map((m: any) =>
             directApi.getModule(m.slug, { structureOnly: true }),
@@ -368,33 +429,49 @@ const TeacherClassDetail: React.FC = () => {
       await api.post(`/teacher/courses/${id}/benchmarks`, { templateId, kind });
       const updated = await api.get(`/teacher/courses/${id}/benchmarks`);
       setBenchmarks(Array.isArray(updated) ? updated : []);
-    } catch { /* toast handles error */ }
-    finally { setAssigningBenchmark(false); }
+    } catch {
+      /* toast handles error */
+    } finally {
+      setAssigningBenchmark(false);
+    }
   };
 
-  const toggleBenchmarkStatus = async (benchmarkId: string, currentStatus: string) => {
+  const toggleBenchmarkStatus = async (
+    benchmarkId: string,
+    currentStatus: string,
+  ) => {
     if (!id) return;
     const newStatus = currentStatus === "OPEN" ? "CLOSED" : "OPEN";
     try {
-      await api.patch(`/teacher/courses/${id}/benchmarks/${benchmarkId}`, { status: newStatus });
-      setBenchmarks((prev) => prev.map((b) => b.id === benchmarkId ? { ...b, status: newStatus } : b));
-    } catch { /* toast handles error */ }
+      await api.patch(`/teacher/courses/${id}/benchmarks/${benchmarkId}`, {
+        status: newStatus,
+      });
+      setBenchmarks((prev) =>
+        prev.map((b) =>
+          b.id === benchmarkId ? { ...b, status: newStatus } : b,
+        ),
+      );
+    } catch {
+      /* toast handles error */
+    }
   };
 
   const handleLaunch = async () => {
     if (!selActivity || !id) return;
     setLaunching(true);
     try {
-      const created = await api.post(
-        `/teacher/courses/${id}/assignments`,
-        {
-          title: sessionTitle || selActivity.title,
-          activityId: selActivity.id,
-          dueDate,
-        } as Record<string, unknown>,
-      );
+      const created = await api.post(`/teacher/courses/${id}/assignments`, {
+        title: sessionTitle || selActivity.title,
+        activityId: selActivity.id,
+        dueDate,
+      } as Record<string, unknown>);
       setAssignments((prev) => [
-        { ...created, enrolledCount: course?.enrollmentCount ?? 0, completedCount: 0, avgTimeSpentS: 0 },
+        {
+          ...created,
+          enrolledCount: course?.enrollmentCount ?? 0,
+          completedCount: 0,
+          avgTimeSpentS: 0,
+        },
         ...prev,
       ]);
       setLaunchOpen(false);
@@ -449,7 +526,9 @@ const TeacherClassDetail: React.FC = () => {
           <div className="flex items-center mt-2 space-x-4 text-sm text-gray-600 flex-wrap gap-y-2">
             <span className="flex items-center">
               <Users className="w-4 h-4 mr-1" />
-              {t("teacher.classDetail.students", { count: course.enrollmentCount })}
+              {t("teacher.classDetail.students", {
+                count: course.enrollmentCount,
+              })}
             </span>
             <span className="flex items-center font-mono bg-gray-100 px-2 py-1 rounded text-xs">
               {t(
@@ -458,8 +537,16 @@ const TeacherClassDetail: React.FC = () => {
                   : "teacher.classDetail.joinCode",
               )}{" "}
               <strong className="ml-1 text-base">{course.joinCode}</strong>
-              <button onClick={handleCopy} className="ml-2 text-brightboost-blue" title={t("teacher.classDetail.copy")}>
-                {copiedCode ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+              <button
+                onClick={handleCopy}
+                className="ml-2 text-brightboost-blue"
+                title={t("teacher.classDetail.copy")}
+              >
+                {copiedCode ? (
+                  <Check className="w-4 h-4" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
               </button>
             </span>
             <span className="flex items-center gap-1">
@@ -468,13 +555,23 @@ const TeacherClassDetail: React.FC = () => {
                 onChange={async (e) => {
                   try {
                     await directApi.updateCourseBand(course.id, e.target.value);
-                    setCourse((prev: any) => prev ? { ...prev, gradeBand: e.target.value } : prev);
-                  } catch { /* ignore */ }
+                    setCourse((prev: any) =>
+                      prev ? { ...prev, gradeBand: e.target.value } : prev,
+                    );
+                  } catch {
+                    /* ignore */
+                  }
                 }}
                 className="text-xs bg-white border border-gray-200 rounded px-2 py-1 font-medium"
               >
-                <option value="k2">{t("teacher.classDetail.bandK2", { defaultValue: "K-2" })}</option>
-                <option value="g3_5">{t("teacher.classDetail.bandG35", { defaultValue: "Grades 3-5" })}</option>
+                <option value="k2">
+                  {t("teacher.classDetail.bandK2", { defaultValue: "K-2" })}
+                </option>
+                <option value="g3_5">
+                  {t("teacher.classDetail.bandG35", {
+                    defaultValue: "Grades 3-5",
+                  })}
+                </option>
               </select>
             </span>
           </div>
@@ -518,13 +615,19 @@ const TeacherClassDetail: React.FC = () => {
                 className="flex items-center justify-between gap-3 p-3 rounded-lg bg-amber-50 border border-amber-100"
               >
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="font-medium text-slate-700">{s.studentName}</span>
+                  <span className="font-medium text-slate-700">
+                    {s.studentName}
+                  </span>
                   <span className="text-xs text-amber-700">
-                    {t("teacher.classDetail.attention.lastActive", { count: s.daysSinceActive })}
+                    {t("teacher.classDetail.attention.lastActive", {
+                      count: s.daysSinceActive,
+                    })}
                   </span>
                   {s.inProgressCount > 1 && (
                     <span className="text-xs text-amber-600">
-                      {t("teacher.classDetail.attention.more", { count: s.inProgressCount - 1 })}
+                      {t("teacher.classDetail.attention.more", {
+                        count: s.inProgressCount - 1,
+                      })}
                     </span>
                   )}
                 </div>
@@ -549,7 +652,9 @@ const TeacherClassDetail: React.FC = () => {
           </Link>
         </div>
         {creations.length === 0 ? (
-          <p className="text-sm text-gray-500">{t("teacher.classDetail.made.empty")}</p>
+          <p className="text-sm text-gray-500">
+            {t("teacher.classDetail.made.empty")}
+          </p>
         ) : (
           <div className="flex gap-3 overflow-x-auto pb-2">
             {creations.slice(0, 8).map((c) => (
@@ -583,7 +688,9 @@ const TeacherClassDetail: React.FC = () => {
         <div className="bg-white rounded-lg shadow p-5">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500">{t("teacher.classDetail.sessionsLaunched")}</p>
+              <p className="text-sm text-gray-500">
+                {t("teacher.classDetail.sessionsLaunched")}
+              </p>
               <p className="text-2xl font-bold text-brightboost-navy">
                 {assignments.length}
               </p>
@@ -595,7 +702,9 @@ const TeacherClassDetail: React.FC = () => {
         <div className="bg-white rounded-lg shadow p-5">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500">{t("teacher.classDetail.avgCompletion")}</p>
+              <p className="text-sm text-gray-500">
+                {t("teacher.classDetail.avgCompletion")}
+              </p>
               <p className="text-2xl font-bold text-brightboost-green">
                 {assignments.length > 0 && course.enrollmentCount > 0
                   ? Math.round(
@@ -614,14 +723,19 @@ const TeacherClassDetail: React.FC = () => {
         <div className="bg-white rounded-lg shadow p-5">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm text-gray-500">{t("teacher.classDetail.confidenceLift")}</p>
+              <p className="text-sm text-gray-500">
+                {t("teacher.classDetail.confidenceLift")}
+              </p>
               <p className="text-2xl font-bold text-purple-600">
                 {pulse?.delta !== null && pulse?.delta !== undefined
                   ? `${pulse.delta > 0 ? "+" : ""}${pulse.delta}`
                   : "—"}
               </p>
               <p className="text-xs text-gray-400">
-                {t("teacher.classDetail.pre")} {pulse?.avgPre ?? "—"} / {t("teacher.classDetail.post")} {pulse?.avgPost ?? "—"} ({pulse?.preCount ?? 0}/{pulse?.postCount ?? 0} {t("teacher.classDetail.responses")})
+                {t("teacher.classDetail.pre")} {pulse?.avgPre ?? "—"} /{" "}
+                {t("teacher.classDetail.post")} {pulse?.avgPost ?? "—"} (
+                {pulse?.preCount ?? 0}/{pulse?.postCount ?? 0}{" "}
+                {t("teacher.classDetail.responses")})
               </p>
             </div>
             <TrendingUp className="w-8 h-8 text-purple-400 opacity-40" />
@@ -633,7 +747,9 @@ const TeacherClassDetail: React.FC = () => {
       <section className="bg-white rounded-lg shadow p-6">
         <h2 className="text-lg font-semibold text-brightboost-navy mb-4 flex items-center">
           <Users className="w-5 h-5 mr-2" />
-          {t("teacher.classDetail.enrolledStudents", { count: course.students.length })}
+          {t("teacher.classDetail.enrolledStudents", {
+            count: course.students.length,
+          })}
         </h2>
         {course.students.length === 0 ? (
           <p className="text-sm text-gray-500 italic">
@@ -644,9 +760,15 @@ const TeacherClassDetail: React.FC = () => {
             <table className="w-full text-left text-sm">
               <thead>
                 <tr className="text-xs text-gray-500 border-b bg-gray-50">
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.name")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.email")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.enrolled")}</th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.name")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.email")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.enrolled")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -690,10 +812,14 @@ const TeacherClassDetail: React.FC = () => {
               </button>
               <button
                 onClick={saveIcons}
-                disabled={savingIcons || Object.keys(iconAssignments).length === 0}
+                disabled={
+                  savingIcons || Object.keys(iconAssignments).length === 0
+                }
                 className="px-3 py-1.5 text-sm bg-brightboost-blue text-white rounded-md hover:bg-brightboost-navy disabled:opacity-50 transition-colors"
               >
-                {savingIcons ? t("teacher.classDetail.saving") : t("teacher.classDetail.saveIcons")}
+                {savingIcons
+                  ? t("teacher.classDetail.saving")
+                  : t("teacher.classDetail.saveIcons")}
               </button>
               <button
                 onClick={handlePrintCards}
@@ -708,7 +834,10 @@ const TeacherClassDetail: React.FC = () => {
               {course.students.map((s) => {
                 const currentIcon = iconAssignments[s.id] || "";
                 return (
-                  <div key={s.id} className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50">
+                  <div
+                    key={s.id}
+                    className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50"
+                  >
                     <span className="text-3xl w-10 text-center">
                       {currentIcon || "❓"}
                     </span>
@@ -763,11 +892,21 @@ const TeacherClassDetail: React.FC = () => {
             <table className="w-full text-left text-sm">
               <thead>
                 <tr className="text-xs text-gray-500 border-b bg-gray-50">
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.session")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.due")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.completed")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.avgTime")}</th>
-                  <th className="py-2 px-3 font-medium">{t("teacher.classDetail.statusLabel")}</th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.session")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.due")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.completed")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.avgTime")}
+                  </th>
+                  <th className="py-2 px-3 font-medium">
+                    {t("teacher.classDetail.statusLabel")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -810,21 +949,34 @@ const TeacherClassDetail: React.FC = () => {
         </h2>
 
         {benchmarks.length === 0 ? (
-          <p className="text-sm text-gray-400 italic mb-4">{t("teacher.benchmark.noneYet")}</p>
+          <p className="text-sm text-gray-400 italic mb-4">
+            {t("teacher.benchmark.noneYet")}
+          </p>
         ) : (
           <div className="space-y-3 mb-4">
             {benchmarks.map((b) => (
-              <div key={b.id} className="flex items-center justify-between p-3 rounded-lg border border-gray-200">
+              <div
+                key={b.id}
+                className="flex items-center justify-between p-3 rounded-lg border border-gray-200"
+              >
                 <div>
-                  <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium mr-2 ${
-                    b.kind === "PRE" ? "bg-blue-100 text-blue-700" : "bg-purple-100 text-purple-700"
-                  }`}>
+                  <span
+                    className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium mr-2 ${
+                      b.kind === "PRE"
+                        ? "bg-blue-100 text-blue-700"
+                        : "bg-purple-100 text-purple-700"
+                    }`}
+                  >
                     {b.kind}
                   </span>
-                  <span className="text-sm font-medium text-slate-700">{b.template.title}</span>
+                  <span className="text-sm font-medium text-slate-700">
+                    {b.template.title}
+                  </span>
                   <div className="text-xs text-slate-400 mt-1">
-                    {b.completedCount}/{b.enrolledCount} {t("teacher.benchmark.completed")}
-                    {b.avgPercent !== null && ` · ${t("teacher.benchmark.avg")} ${b.avgPercent}%`}
+                    {b.completedCount}/{b.enrolledCount}{" "}
+                    {t("teacher.benchmark.completed")}
+                    {b.avgPercent !== null &&
+                      ` · ${t("teacher.benchmark.avg")} ${b.avgPercent}%`}
                   </div>
                 </div>
                 <button
@@ -835,7 +987,9 @@ const TeacherClassDetail: React.FC = () => {
                       : "bg-gray-100 text-gray-600 hover:bg-gray-200"
                   }`}
                 >
-                  {b.status === "OPEN" ? t("teacher.benchmark.open") : t("teacher.benchmark.closed")}
+                  {b.status === "OPEN"
+                    ? t("teacher.benchmark.open")
+                    : t("teacher.benchmark.closed")}
                 </button>
               </div>
             ))}
@@ -847,7 +1001,9 @@ const TeacherClassDetail: React.FC = () => {
           <div className="flex flex-wrap gap-2">
             {benchmarkTemplates.map((tmpl) =>
               (["PRE", "POST"] as const).map((kind) => {
-                const exists = benchmarks.some((b) => b.template.id === tmpl.id && b.kind === kind);
+                const exists = benchmarks.some(
+                  (b) => b.template.id === tmpl.id && b.kind === kind,
+                );
                 if (exists) return null;
                 return (
                   <button
@@ -856,7 +1012,9 @@ const TeacherClassDetail: React.FC = () => {
                     disabled={assigningBenchmark}
                     className="px-3 py-1.5 text-xs bg-brightboost-blue text-white rounded-md hover:bg-brightboost-navy disabled:opacity-50 flex items-center gap-1"
                   >
-                    {assigningBenchmark && <Loader2 className="w-3 h-3 animate-spin" />}
+                    {assigningBenchmark && (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    )}
                     {t("teacher.benchmark.assign")} {kind}
                   </button>
                 );
@@ -867,140 +1025,240 @@ const TeacherClassDetail: React.FC = () => {
       </section>
 
       {/* Benchmark Growth Report */}
-      {growth && growth.templateId && (growth.hasPreAttempts || growth.hasPostAttempts) && (
-        <section className="bg-white rounded-lg shadow p-6">
-          <h2 className="text-lg font-semibold text-brightboost-navy mb-1 flex items-center">
-            <TrendingUp className="w-5 h-5 mr-2" />
-            {t("teacher.benchmark.growth.title")}
-          </h2>
-          <p className="text-xs text-slate-400 mb-4">{growth.templateTitle}</p>
+      {growth &&
+        growth.templateId &&
+        (growth.hasPreAttempts || growth.hasPostAttempts) && (
+          <section className="bg-white rounded-lg shadow p-6">
+            <h2 className="text-lg font-semibold text-brightboost-navy mb-1 flex items-center">
+              <TrendingUp className="w-5 h-5 mr-2" />
+              {t("teacher.benchmark.growth.title")}
+            </h2>
+            <p className="text-xs text-slate-400 mb-4">
+              {growth.templateTitle}
+            </p>
 
-          {/* Class Summary Cards */}
-          {growth.classSummary && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-              <div className="bg-blue-50 rounded-lg p-3 text-center">
-                <p className="text-xs text-blue-600 font-medium">{t("teacher.benchmark.growth.preAvg")}</p>
-                <p className="text-2xl font-bold text-blue-700">
-                  {growth.classSummary.avgPrePercent !== null ? `${growth.classSummary.avgPrePercent}%` : "—"}
-                </p>
-                <p className="text-xs text-blue-400">{growth.classSummary.preCompleted}/{growth.classSummary.enrolledCount} {t("teacher.benchmark.completed")}</p>
+            {/* Class Summary Cards */}
+            {growth.classSummary && (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+                <div className="bg-blue-50 rounded-lg p-3 text-center">
+                  <p className="text-xs text-blue-600 font-medium">
+                    {t("teacher.benchmark.growth.preAvg")}
+                  </p>
+                  <p className="text-2xl font-bold text-blue-700">
+                    {growth.classSummary.avgPrePercent !== null
+                      ? `${growth.classSummary.avgPrePercent}%`
+                      : "—"}
+                  </p>
+                  <p className="text-xs text-blue-400">
+                    {growth.classSummary.preCompleted}/
+                    {growth.classSummary.enrolledCount}{" "}
+                    {t("teacher.benchmark.completed")}
+                  </p>
+                </div>
+                <div className="bg-purple-50 rounded-lg p-3 text-center">
+                  <p className="text-xs text-purple-600 font-medium">
+                    {t("teacher.benchmark.growth.postAvg")}
+                  </p>
+                  <p className="text-2xl font-bold text-purple-700">
+                    {growth.classSummary.avgPostPercent !== null
+                      ? `${growth.classSummary.avgPostPercent}%`
+                      : "—"}
+                  </p>
+                  <p className="text-xs text-purple-400">
+                    {growth.classSummary.postCompleted}/
+                    {growth.classSummary.enrolledCount}{" "}
+                    {t("teacher.benchmark.completed")}
+                  </p>
+                </div>
+                <div
+                  className={`rounded-lg p-3 text-center ${
+                    growth.classSummary.delta !== null
+                      ? growth.classSummary.delta > 0
+                        ? "bg-green-50"
+                        : growth.classSummary.delta < 0
+                          ? "bg-red-50"
+                          : "bg-gray-50"
+                      : "bg-gray-50"
+                  }`}
+                >
+                  <p className="text-xs font-medium text-slate-600">
+                    {t("teacher.benchmark.growth.delta")}
+                  </p>
+                  <p
+                    className={`text-2xl font-bold ${
+                      growth.classSummary.delta !== null
+                        ? growth.classSummary.delta > 0
+                          ? "text-green-700"
+                          : growth.classSummary.delta < 0
+                            ? "text-red-700"
+                            : "text-gray-500"
+                        : "text-gray-400"
+                    }`}
+                  >
+                    {growth.classSummary.delta !== null
+                      ? `${growth.classSummary.delta > 0 ? "+" : ""}${growth.classSummary.delta}%`
+                      : "—"}
+                  </p>
+                </div>
+                <div className="bg-slate-50 rounded-lg p-3 text-center">
+                  <p className="text-xs font-medium text-slate-600">
+                    {t("teacher.benchmark.growth.enrolled")}
+                  </p>
+                  <p className="text-2xl font-bold text-slate-700">
+                    {growth.classSummary.enrolledCount}
+                  </p>
+                </div>
               </div>
-              <div className="bg-purple-50 rounded-lg p-3 text-center">
-                <p className="text-xs text-purple-600 font-medium">{t("teacher.benchmark.growth.postAvg")}</p>
-                <p className="text-2xl font-bold text-purple-700">
-                  {growth.classSummary.avgPostPercent !== null ? `${growth.classSummary.avgPostPercent}%` : "—"}
-                </p>
-                <p className="text-xs text-purple-400">{growth.classSummary.postCompleted}/{growth.classSummary.enrolledCount} {t("teacher.benchmark.completed")}</p>
-              </div>
-              <div className={`rounded-lg p-3 text-center ${
-                growth.classSummary.delta !== null
-                  ? growth.classSummary.delta > 0 ? "bg-green-50" : growth.classSummary.delta < 0 ? "bg-red-50" : "bg-gray-50"
-                  : "bg-gray-50"
-              }`}>
-                <p className="text-xs font-medium text-slate-600">{t("teacher.benchmark.growth.delta")}</p>
-                <p className={`text-2xl font-bold ${
-                  growth.classSummary.delta !== null
-                    ? growth.classSummary.delta > 0 ? "text-green-700" : growth.classSummary.delta < 0 ? "text-red-700" : "text-gray-500"
-                    : "text-gray-400"
-                }`}>
-                  {growth.classSummary.delta !== null
-                    ? `${growth.classSummary.delta > 0 ? "+" : ""}${growth.classSummary.delta}%`
-                    : "—"}
-                </p>
-              </div>
-              <div className="bg-slate-50 rounded-lg p-3 text-center">
-                <p className="text-xs font-medium text-slate-600">{t("teacher.benchmark.growth.enrolled")}</p>
-                <p className="text-2xl font-bold text-slate-700">{growth.classSummary.enrolledCount}</p>
-              </div>
-            </div>
-          )}
+            )}
 
-          {/* Skill Breakdown */}
-          {growth.skills.length > 0 && (
-            <div className="mb-6">
-              <h3 className="text-sm font-semibold text-slate-700 mb-3">{t("teacher.benchmark.growth.bySkill")}</h3>
-              <div className="space-y-3">
-                {growth.skills.map((s) => (
-                  <div key={s.skillTag}>
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-xs font-medium text-slate-600 capitalize">{s.skillTag.replace(/-/g, " ")}</span>
-                      <span className="text-xs text-slate-400">
-                        {s.delta !== null ? (
-                          <span className={s.delta > 0 ? "text-green-600" : s.delta < 0 ? "text-red-600" : "text-gray-500"}>
-                            {s.delta > 0 ? "+" : ""}{s.delta}%
-                          </span>
-                        ) : "—"}
-                      </span>
-                    </div>
-                    <div className="flex gap-1 h-4">
-                      <div className="flex-1 bg-gray-100 rounded-full overflow-hidden" title={`PRE: ${s.preCorrectRate ?? 0}%`}>
-                        <div className="h-full bg-blue-400 rounded-full" style={{ width: `${s.preCorrectRate ?? 0}%` }} />
-                      </div>
-                      <div className="flex-1 bg-gray-100 rounded-full overflow-hidden" title={`POST: ${s.postCorrectRate ?? 0}%`}>
-                        <div className="h-full bg-purple-400 rounded-full" style={{ width: `${s.postCorrectRate ?? 0}%` }} />
-                      </div>
-                    </div>
-                    <div className="flex gap-1 mt-0.5">
-                      <span className="flex-1 text-[10px] text-blue-500">{t("teacher.benchmark.growth.pre")} {s.preCorrectRate ?? 0}%</span>
-                      <span className="flex-1 text-[10px] text-purple-500">{t("teacher.benchmark.growth.post")} {s.postCorrectRate ?? 0}%</span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Student Table */}
-          {growth.students.length > 0 && (
-            <div>
-              <h3 className="text-sm font-semibold text-slate-700 mb-3">{t("teacher.benchmark.growth.studentDetail")}</h3>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="text-left text-xs text-slate-500 border-b">
-                      <th className="py-2 px-2">{t("teacher.benchmark.growth.name")}</th>
-                      <th className="py-2 px-2 text-center">{t("teacher.benchmark.growth.pre")}</th>
-                      <th className="py-2 px-2 text-center">{t("teacher.benchmark.growth.post")}</th>
-                      <th className="py-2 px-2 text-center">{t("teacher.benchmark.growth.delta")}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {growth.students.map((s) => (
-                      <tr key={s.id} className="border-b hover:bg-gray-50">
-                        <td className="py-2 px-2 font-medium text-slate-700">{s.name}</td>
-                        <td className="py-2 px-2 text-center">
-                          {s.prePercent !== null ? `${s.prePercent}%` : <span className="text-slate-300">—</span>}
-                        </td>
-                        <td className="py-2 px-2 text-center">
-                          {s.postPercent !== null ? `${s.postPercent}%` : <span className="text-slate-300">—</span>}
-                        </td>
-                        <td className="py-2 px-2 text-center">
+            {/* Skill Breakdown */}
+            {growth.skills.length > 0 && (
+              <div className="mb-6">
+                <h3 className="text-sm font-semibold text-slate-700 mb-3">
+                  {t("teacher.benchmark.growth.bySkill")}
+                </h3>
+                <div className="space-y-3">
+                  {growth.skills.map((s) => (
+                    <div key={s.skillTag}>
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-xs font-medium text-slate-600 capitalize">
+                          {s.skillTag.replace(/-/g, " ")}
+                        </span>
+                        <span className="text-xs text-slate-400">
                           {s.delta !== null ? (
-                            <span className={`font-medium ${s.delta > 0 ? "text-green-600" : s.delta < 0 ? "text-red-600" : "text-slate-500"}`}>
-                              {s.delta > 0 ? "+" : ""}{s.delta}%
+                            <span
+                              className={
+                                s.delta > 0
+                                  ? "text-green-600"
+                                  : s.delta < 0
+                                    ? "text-red-600"
+                                    : "text-gray-500"
+                              }
+                            >
+                              {s.delta > 0 ? "+" : ""}
+                              {s.delta}%
                             </span>
-                          ) : <span className="text-slate-300">—</span>}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                          ) : (
+                            "—"
+                          )}
+                        </span>
+                      </div>
+                      <div className="flex gap-1 h-4">
+                        <div
+                          className="flex-1 bg-gray-100 rounded-full overflow-hidden"
+                          title={`PRE: ${s.preCorrectRate ?? 0}%`}
+                        >
+                          <div
+                            className="h-full bg-blue-400 rounded-full"
+                            style={{ width: `${s.preCorrectRate ?? 0}%` }}
+                          />
+                        </div>
+                        <div
+                          className="flex-1 bg-gray-100 rounded-full overflow-hidden"
+                          title={`POST: ${s.postCorrectRate ?? 0}%`}
+                        >
+                          <div
+                            className="h-full bg-purple-400 rounded-full"
+                            style={{ width: `${s.postCorrectRate ?? 0}%` }}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex gap-1 mt-0.5">
+                        <span className="flex-1 text-[10px] text-blue-500">
+                          {t("teacher.benchmark.growth.pre")}{" "}
+                          {s.preCorrectRate ?? 0}%
+                        </span>
+                        <span className="flex-1 text-[10px] text-purple-500">
+                          {t("teacher.benchmark.growth.post")}{" "}
+                          {s.postCorrectRate ?? 0}%
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Waiting state: assignments exist but no attempts */}
-          {!growth.hasPreAttempts && !growth.hasPostAttempts && (
-            <p className="text-sm text-gray-400 italic">{t("teacher.benchmark.growth.waiting")}</p>
-          )}
-        </section>
-      )}
+            {/* Student Table */}
+            {growth.students.length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-slate-700 mb-3">
+                  {t("teacher.benchmark.growth.studentDetail")}
+                </h3>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-slate-500 border-b">
+                        <th className="py-2 px-2">
+                          {t("teacher.benchmark.growth.name")}
+                        </th>
+                        <th className="py-2 px-2 text-center">
+                          {t("teacher.benchmark.growth.pre")}
+                        </th>
+                        <th className="py-2 px-2 text-center">
+                          {t("teacher.benchmark.growth.post")}
+                        </th>
+                        <th className="py-2 px-2 text-center">
+                          {t("teacher.benchmark.growth.delta")}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {growth.students.map((s) => (
+                        <tr key={s.id} className="border-b hover:bg-gray-50">
+                          <td className="py-2 px-2 font-medium text-slate-700">
+                            {s.name}
+                          </td>
+                          <td className="py-2 px-2 text-center">
+                            {s.prePercent !== null ? (
+                              `${s.prePercent}%`
+                            ) : (
+                              <span className="text-slate-300">—</span>
+                            )}
+                          </td>
+                          <td className="py-2 px-2 text-center">
+                            {s.postPercent !== null ? (
+                              `${s.postPercent}%`
+                            ) : (
+                              <span className="text-slate-300">—</span>
+                            )}
+                          </td>
+                          <td className="py-2 px-2 text-center">
+                            {s.delta !== null ? (
+                              <span
+                                className={`font-medium ${s.delta > 0 ? "text-green-600" : s.delta < 0 ? "text-red-600" : "text-slate-500"}`}
+                              >
+                                {s.delta > 0 ? "+" : ""}
+                                {s.delta}%
+                              </span>
+                            ) : (
+                              <span className="text-slate-300">—</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {/* Waiting state: assignments exist but no attempts */}
+            {!growth.hasPreAttempts && !growth.hasPostAttempts && (
+              <p className="text-sm text-gray-400 italic">
+                {t("teacher.benchmark.growth.waiting")}
+              </p>
+            )}
+          </section>
+        )}
 
       {/* Empty state: no benchmark template selected */}
       {growth && !growth.templateId && benchmarks.length === 0 && (
         <section className="bg-white rounded-lg shadow p-6 text-center">
           <TrendingUp className="w-8 h-8 mx-auto mb-2 text-gray-300" />
-          <p className="text-sm text-gray-400">{t("teacher.benchmark.growth.assignFirst")}</p>
+          <p className="text-sm text-gray-400">
+            {t("teacher.benchmark.growth.assignFirst")}
+          </p>
         </section>
       )}
 
@@ -1021,7 +1279,9 @@ const TeacherClassDetail: React.FC = () => {
                 {t("teacher.classDetail.module")}
               </label>
               {modules.length === 0 ? (
-                <p className="text-sm text-gray-400 italic">{t("teacher.classDetail.loadingModules")}</p>
+                <p className="text-sm text-gray-400 italic">
+                  {t("teacher.classDetail.loadingModules")}
+                </p>
               ) : (
                 <select
                   value={selModule}
@@ -1031,7 +1291,9 @@ const TeacherClassDetail: React.FC = () => {
                   }}
                   className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brightboost-blue"
                 >
-                  <option value="">{t("teacher.classDetail.selectModule")}</option>
+                  <option value="">
+                    {t("teacher.classDetail.selectModule")}
+                  </option>
                   {modules.map((m) => (
                     <option key={m.slug} value={m.slug}>
                       {m.title}
@@ -1041,16 +1303,8 @@ const TeacherClassDetail: React.FC = () => {
               )}
             </div>
 
-            {/* Teacher Prep link */}
-            {selModule && (
-              <Link
-                to={`/teacher/prep/${selModule}`}
-                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 hover:underline"
-                target="_blank"
-              >
-                {t("teacher.classDetail.prepareSession")} &rarr;
-              </Link>
-            )}
+            {/* Teacher Prep link — only for modules that actually have prep data */}
+            <PrepareSessionLink slug={selModule} prepSlugs={prepSlugs} />
 
             {/* Activity picker */}
             {selModule && (
@@ -1072,7 +1326,9 @@ const TeacherClassDetail: React.FC = () => {
                       }`}
                     >
                       <div>
-                        <span className="text-xs text-gray-400 block">{a.breadcrumb}</span>
+                        <span className="text-xs text-gray-400 block">
+                          {a.breadcrumb}
+                        </span>
                         {a.title}
                       </div>
                       {selActivity?.id === a.id && (
@@ -1132,7 +1388,9 @@ const TeacherClassDetail: React.FC = () => {
               disabled={!selActivity || launching}
               className="px-4 py-2 text-sm text-white bg-brightboost-blue rounded-md hover:bg-brightboost-navy disabled:opacity-50"
             >
-              {launching ? t("teacher.classDetail.launching") : t("teacher.classDetail.launchBtn")}
+              {launching
+                ? t("teacher.classDetail.launching")
+                : t("teacher.classDetail.launchBtn")}
             </button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/TeacherResources.tsx
+++ b/src/pages/TeacherResources.tsx
@@ -320,22 +320,24 @@ const TeacherResources: React.FC = () => {
                 </button>
               </div>
             </div>
-            <div
-              className="p-6 overflow-y-auto flex-grow prose prose-sm max-w-none"
-              dangerouslySetInnerHTML={{
-                __html: previewResource.contentHtml || "",
-              }}
+            {/* Server-authored resource HTML renders in a fully sandboxed
+                iframe (no scripts, no same-origin) instead of being injected
+                into the app's DOM — the preview styles ship inside the doc. */}
+            <iframe
+              title={previewResource.title}
+              sandbox=""
+              className="flex-grow w-full min-h-[55vh] border-0 rounded-b-lg"
+              srcDoc={`<!doctype html><html><head><meta charset="utf-8"><style>
+                body { font-family: ui-sans-serif, system-ui, sans-serif; color: #111827; margin: 1.5rem; }
+                .k2-worksheet h2 { font-size: 1.35rem; margin: 1.2rem 0 0.5rem; }
+                .k2-worksheet h3 { font-size: 1.15rem; margin: 1rem 0 0.4rem; }
+                .k2-worksheet p, .k2-worksheet li { font-size: 1.1rem; line-height: 1.7; }
+                .k2-worksheet .worksheet-area { border: 1px dashed #d1d5db; padding: 1.5rem; margin: 0.75rem 0; min-height: 140px; border-radius: 4px; }
+                .k2-worksheet .line { border-bottom: 1px solid #d1d5db; margin: 1rem 0; min-height: 36px; }
+                .k2-worksheet td, .k2-worksheet th { padding: 0.75rem; font-size: 1.05rem; }
+                .k2-worksheet .match-table td { border: none; padding: 0.6rem 1.2rem; font-size: 1.15rem; }
+              </style></head><body>${previewResource.contentHtml || ""}</body></html>`}
             />
-            {/* K-2 worksheet preview styles */}
-            <style>{`
-              .k2-worksheet h2 { font-size: 1.35rem; margin: 1.2rem 0 0.5rem; }
-              .k2-worksheet h3 { font-size: 1.15rem; margin: 1rem 0 0.4rem; }
-              .k2-worksheet p, .k2-worksheet li { font-size: 1.1rem; line-height: 1.7; }
-              .k2-worksheet .worksheet-area { border: 1px dashed #d1d5db; padding: 1.5rem; margin: 0.75rem 0; min-height: 140px; border-radius: 4px; }
-              .k2-worksheet .line { border-bottom: 1px solid #d1d5db; margin: 1rem 0; min-height: 36px; }
-              .k2-worksheet td, .k2-worksheet th { padding: 0.75rem; font-size: 1.05rem; }
-              .k2-worksheet .match-table td { border: none; padding: 0.6rem 1.2rem; font-size: 1.15rem; }
-            `}</style>
           </div>
         </div>
       )}

--- a/src/pages/TeacherResources.tsx
+++ b/src/pages/TeacherResources.tsx
@@ -90,7 +90,10 @@ const TeacherResources: React.FC = () => {
 
   const handlePrint = (resource: Resource) => {
     const token = localStorage.getItem("bb_access_token");
-    const url = join(API_BASE, `/teacher/resources/${resource.id}/print?lang=${lang}`);
+    const url = join(
+      API_BASE,
+      `/teacher/resources/${resource.id}/print?lang=${lang}`,
+    );
     const printWindow = window.open("", "_blank");
     if (printWindow) {
       fetch(url, {
@@ -109,12 +112,37 @@ const TeacherResources: React.FC = () => {
       {/* Header */}
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-          <FolderOpen className="w-6 h-6 text-blue-600" /> {t("teacher.resources.title")}
+          <FolderOpen className="w-6 h-6 text-blue-600" />{" "}
+          {t("teacher.resources.title")}
         </h1>
         <p className="text-sm text-gray-500 mt-1">
           {t("teacher.resources.subtitle")}
         </p>
       </div>
+
+      {/* K-2 Facilitator Quick Start — same public guide the parents page
+          links to (/parents/guide); one source, no duplicated content. */}
+      <a
+        href="/parents/guide"
+        target="_blank"
+        rel="noreferrer"
+        className="block bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6 hover:bg-blue-100 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <Printer className="w-4 h-4 text-blue-600" aria-hidden="true" />
+          <span className="font-semibold text-sm text-gray-900">
+            {t("parentGuide.title", {
+              defaultValue: "K–2 Facilitator Quick Start",
+            })}
+          </span>
+        </div>
+        <p className="text-sm text-gray-600 mt-1">
+          {t("parentGuide.teacherCardDesc", {
+            defaultValue:
+              "Printable one-pager for parents and program volunteers — before, during, and after an activity.",
+          })}
+        </p>
+      </a>
 
       {/* Filters */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-6">
@@ -127,7 +155,9 @@ const TeacherResources: React.FC = () => {
             className="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-blue-500 focus:border-blue-500"
           >
             <option value="all">{t("teacher.resources.allModules")}</option>
-            <option value="general">{t("teacher.resources.generalResources")}</option>
+            <option value="general">
+              {t("teacher.resources.generalResources")}
+            </option>
             {Object.entries(MODULE_KEYS).map(([slug, key]) => (
               <option key={slug} value={slug}>
                 {t(key)}
@@ -185,7 +215,9 @@ const TeacherResources: React.FC = () => {
       {loading ? (
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
-          <span className="ml-2 text-gray-500">{t("teacher.resources.loading")}</span>
+          <span className="ml-2 text-gray-500">
+            {t("teacher.resources.loading")}
+          </span>
         </div>
       ) : filtered.length === 0 ? (
         <div className="text-center py-20 text-gray-400">
@@ -211,7 +243,9 @@ const TeacherResources: React.FC = () => {
                 </span>
               </div>
 
-              <p className="text-xs text-gray-500 mb-3">{resource.description}</p>
+              <p className="text-xs text-gray-500 mb-3">
+                {resource.description}
+              </p>
 
               <div className="flex items-center gap-2 mb-3">
                 {resource.moduleSlug && (
@@ -230,7 +264,8 @@ const TeacherResources: React.FC = () => {
                     onClick={() => setPreviewResource(resource)}
                     className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 transition-colors"
                   >
-                    <BookOpen className="w-3 h-3" /> {t("teacher.resources.preview")}
+                    <BookOpen className="w-3 h-3" />{" "}
+                    {t("teacher.resources.preview")}
                   </button>
                 )}
                 {resource.printable && resource.contentHtml && (
@@ -238,7 +273,8 @@ const TeacherResources: React.FC = () => {
                     onClick={() => handlePrint(resource)}
                     className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors"
                   >
-                    <Printer className="w-3 h-3" /> {t("teacher.resources.print")}
+                    <Printer className="w-3 h-3" />{" "}
+                    {t("teacher.resources.print")}
                   </button>
                 )}
                 {resource.contentUrl && (
@@ -248,7 +284,8 @@ const TeacherResources: React.FC = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-green-600 border border-green-200 rounded-md hover:bg-green-50 transition-colors"
                   >
-                    <ExternalLink className="w-3 h-3" /> {t("teacher.resources.openLink")}
+                    <ExternalLink className="w-3 h-3" />{" "}
+                    {t("teacher.resources.openLink")}
                   </a>
                 )}
               </div>
@@ -262,14 +299,17 @@ const TeacherResources: React.FC = () => {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] flex flex-col">
             <div className="flex items-center justify-between p-4 border-b border-gray-200">
-              <h2 className="text-lg font-semibold text-gray-900">{previewResource.title}</h2>
+              <h2 className="text-lg font-semibold text-gray-900">
+                {previewResource.title}
+              </h2>
               <div className="flex items-center gap-2">
                 {previewResource.printable && (
                   <button
                     onClick={() => handlePrint(previewResource)}
                     className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50"
                   >
-                    <Printer className="w-4 h-4" /> {t("teacher.resources.print")}
+                    <Printer className="w-4 h-4" />{" "}
+                    {t("teacher.resources.print")}
                   </button>
                 )}
                 <button
@@ -282,7 +322,9 @@ const TeacherResources: React.FC = () => {
             </div>
             <div
               className="p-6 overflow-y-auto flex-grow prose prose-sm max-w-none"
-              dangerouslySetInnerHTML={{ __html: previewResource.contentHtml || "" }}
+              dangerouslySetInnerHTML={{
+                __html: previewResource.contentHtml || "",
+              }}
             />
             {/* K-2 worksheet preview styles */}
             <style>{`

--- a/src/pages/__tests__/ParentGuide.test.tsx
+++ b/src/pages/__tests__/ParentGuide.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * /parents/guide — public printable K-2 Facilitator Quick Start.
+ * The Print button must be accessible and must NOT fire automatically.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import ParentGuide from "../ParentGuide";
+
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+describe("ParentGuide (public /parents/guide route)", () => {
+  let printSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    printSpy.mockRestore();
+  });
+
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={["/parents/guide"]}>
+        <ParentGuide />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders the before / during / after structure with usable prompts", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /k–2 facilitator quick start/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /before you start/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /while they play/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /afterwards/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/what do you notice\?/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/what do you think will happen if/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/explore on their own/i)).toBeInTheDocument();
+  });
+
+  it("does not auto-open the print dialog, and prints on button click", () => {
+    renderPage();
+    expect(printSpy).not.toHaveBeenCalled();
+    const button = screen.getByRole("button", { name: /print this guide/i });
+    fireEvent.click(button);
+    expect(printSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("links back to the parents page", () => {
+    renderPage();
+    expect(screen.getByRole("link", { name: /back/i })).toHaveAttribute(
+      "href",
+      "/parents",
+    );
+  });
+
+  it("makes no read-aloud/audio claims (see issue #625)", () => {
+    renderPage();
+    expect(screen.queryByText(/read.?aloud/i)).toBeNull();
+    expect(screen.queryByText(/audio/i)).toBeNull();
+  });
+});

--- a/src/pages/__tests__/Parents.test.tsx
+++ b/src/pages/__tests__/Parents.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * /parents public page — renders for a fully anonymous visitor with no
+ * AuthProvider and no fetch activity, and presents the curriculum honestly:
+ * Foundation available, Exploration gated behind Foundation, Mastery in
+ * development. Names come from the canonical stemSets constants.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import Parents from "../Parents";
+import {
+  STEM_SET_1_NAMES,
+  STEM_SET_2_NAMES,
+  SET_LABELS,
+} from "@/constants/stemSets";
+
+vi.mock("react-i18next", async () => {
+  const { enMock } = await import("@/test/i18nMock");
+  return enMock();
+});
+
+describe("Parents (public /parents route)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={["/parents"]}>
+        <Parents />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders without an AuthProvider and without any fetch calls", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /for parents & families/i }),
+    ).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows the three-stage progression with honest availability", () => {
+    renderPage();
+    for (const label of SET_LABELS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(screen.getByText("Available now")).toBeInTheDocument();
+    expect(screen.getByText("Opens after Foundation")).toBeInTheDocument();
+    expect(screen.getByText("In development")).toBeInTheDocument();
+  });
+
+  it("lists canonical game names and strands from the constants", () => {
+    renderPage();
+    expect(screen.getByText(STEM_SET_1_NAMES["tank-trek"])).toBeInTheDocument();
+    expect(screen.getByText(STEM_SET_2_NAMES["maze-maps"])).toBeInTheDocument();
+    // Placeholder Set 3 ids must never leak into parent-facing copy.
+    expect(screen.queryByText(/set3-game/i)).toBeNull();
+  });
+
+  it("wires the three CTAs and the guide link to existing routes", () => {
+    renderPage();
+    expect(
+      screen.getByRole("link", { name: /try a game — no signup/i }),
+    ).toHaveAttribute("href", "/try");
+    expect(
+      screen.getByRole("link", { name: /join with a class code/i }),
+    ).toHaveAttribute("href", "/student-login");
+    expect(
+      screen.getByRole("link", { name: /create a home group/i }),
+    ).toHaveAttribute("href", "/teacher/signup?intent=home");
+    expect(
+      screen.getByRole("link", { name: /open the guide/i }),
+    ).toHaveAttribute("href", "/parents/guide");
+  });
+
+  it("sets the shareable document title", () => {
+    renderPage();
+    expect(document.title).toMatch(/Parents & Families/);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation PR for K–2 adult support, covering the top three value/effort findings from **external K–2 user feedback**:

1. **Prepare Session no longer dead-ends.** The Launch Session dialog offered "Prepare Session" for *every* module, but prep data exists for only three active K–2 games — any other selection led teachers to the prep page's "not found" error. The link is now availability-gated by the existing `GET /teacher/prep` list endpoint (fetched once when the wizard opens): shown only when the selected module has prep data, hidden while availability is unknown or the request failed, so session launch is never affected. The archived `k2-stem-sequencing` entry is removed from the prep catalog (it's in `HIDDEN_MODULE_SLUGS` — students can't reach it).
2. **`/parents` is a real page.** Replaces the placeholder (Students/Teachers/Organizations placeholders untouched). Honest progression using canonical constants from `src/constants/stemSets.ts` — **Foundation: available**, **Exploration: opens after Foundation**, **Mastery: in development** (framed around Imagine → Create → Play → Share → Reflect). Explains classroom / after-school / home use, adults as optional guides (not proctors), CTAs to `/try`, `/student-login`, and `/teacher/signup?intent=home` (the existing home-group flow), and links the Quick Start guide. No efficacy/standards/availability claims beyond what ships.
3. **Printable K–2 Facilitator Quick Start at `/parents/guide`** (public). Before / during / after guidance, seven ready-to-use wondering prompts, and an explicit note that children can explore independently. Accessible Print button (`window.print()` on click — never automatic) with Tailwind `print:` styling. Surfaced from both the parents page and Teacher Resources as **one shared route** — no duplicated content.

## What changed

- `backend/src/routes/teacherPrep.ts` — archived catalog entry removed (+ comment pinning the invariant); `backend/src/routes/teacherPrep.test.ts` — catalog + endpoint contract (5 tests)
- `src/pages/TeacherClassDetail.tsx` + new `src/components/teacher/PrepareSessionLink.tsx` — availability state + gated link (5 tests)
- `src/pages/Parents.tsx`, `src/pages/ParentGuide.tsx`, `src/App.tsx` routes (9 tests across both pages, incl. no-fetch isolation, no-auto-print, and a guard that Set 3 placeholder ids never leak into parent copy)
- `src/pages/TeacherResources.tsx` — Quick Start card linking the shared guide
- `src/locales/{en,es}/common.json` — new `parents.*` / `parentGuide.*` blocks

## i18n disclosure

- **en + es** authored in this PR (es is AI-authored — please flag for human review per convention).
- **vi / zh-CN**: not authored; these locales fall back to English (`fallbackLng` + `defaultValue` convention as in `/try`). Human translation is a follow-up.

## Deliberate scope limits

- The **seven missing per-game prep guides** (tank-trek, quantum-quest, all of Set 2) are *not* authored here — the availability gate makes their absence honest instead of a 404; authoring them is the natural follow-up.
- The guide makes **no read-aloud/audio claims**; that limitation is tracked in #625.
- No schema/migration changes; no analytics changes.

## Verification

- `npm run lint` — zero warnings ✓
- `npm run typecheck` + `cd backend && npm run typecheck` ✓
- `npm run test:unit` — **547 passed / 20 skipped** (main: 528; all 19 new tests green) ✓
- `npm run build` ✓
- Locale JSON parse-validated ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Added during CI hardening (second commit)

The truthful PR review bot (#711) fails any changed file containing `dangerouslySetInnerHTML`. Touching Teacher Resources (required to surface the guide) tripped this on the **pre-existing** resource preview modal. Rather than bypass it, the preview now renders server-authored resource HTML in a **fully sandboxed `srcDoc` iframe** (`sandbox=""` — no scripts, no same-origin) with the worksheet styles shipped inside the framed document — strictly safer than the previous in-DOM injection. Reviewers: please eyeball the preview modal once with a seeded worksheet resource.
