### PR TITLE
chore(test-infra): local–CI parity, hooks, and guard wiring

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Run tests
         run: npm test -- --watch=false
 
+      # G-201 / W-10: two-phase sabotage proof that the CI shell gate has teeth
+      # (healthy-pass then sabotage-fail). Do not remove without replacing the
+      # causal proof — a guard file that is never invoked is not a guard.
+      - name: Verify CI shell gate
+        run: npm run verify:ci-gate
+
       - name: Start development server
         run: npm run dev &
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Check Prisma schema drift
         run: bash scripts/check-prisma-drift.sh
 
+      # G-205 / W-11: detect silent removal of required CI step invocations.
+      - name: Verify CI step presence
+        run: bash scripts/verify-ci-step-presence.sh
+
+      # G-008 / W-12: type-level guards must be inside the tsc program.
+      - name: Verify type-program membership
+        run: node scripts/verify-type-program-membership.mjs
+
       - name: Install Cypress dependencies
         run: sudo apt-get update && sudo apt-get install -y libxss1
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
+# pre-commit contract (#740): REJECT unformatted staged files.
+# Runs `prettier --check` via lint-staged — does NOT auto-write or re-stage.
+# Developers format locally (`npx prettier --write -- <paths>`) before commit.
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,8 @@
         "vite": "^5.4.21",
         "vite-plugin-compression": "^0.5.1",
         "vitest": "^3.1.3",
-        "wait-on": "^8.0.1"
+        "wait-on": "^8.0.1",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": "20.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,9 @@
         "eslint-plugin-storybook": "^0.12.0",
         "express": "^5.2.1",
         "globals": "^15.14.0",
+        "husky": "^9.1.7",
         "jsdom": "^26.1.0",
+        "lint-staged": "^16.4.0",
         "msw": "^2.8.4",
         "playwright": "^1.52.0",
         "postcss": "^8.4.31",
@@ -9673,6 +9675,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -11147,6 +11162,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11611,6 +11639,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {
@@ -13043,6 +13087,303 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lint-staged/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/listr2": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -13656,6 +13997,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -16142,6 +16496,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -16657,9 +17021,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -18658,6 +19022,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "test:watch": "vitest",
     "test:db": "node scripts/dbHealth.js",
     "verify:ci-gate": "bash scripts/verify-ci-shell-gate.sh",
+    "verify": "node scripts/verify-parity.mjs",
+    "verify:parity-selfcheck": "node scripts/verify-parity-selfcheck.mjs",
     "typecheck": "tsc --noEmit",
     "check-bundle-size": "npm run build && node scripts/check-bundle-size.js",
     "cy:open": "cypress open",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "check-bundle-size": "npm run build && node scripts/check-bundle-size.js",
     "cy:open": "cypress open",
     "cy:run": "cypress run --browser chrome",
-    "db:init": "prisma migrate deploy --schema prisma/schema.prisma && prisma db seed"
+    "db:init": "prisma migrate deploy --schema prisma/schema.prisma && prisma db seed",
+    "prepare": "husky"
   },
   "prisma": {
     "seed": "node prisma/seed.cjs"
@@ -148,7 +149,9 @@
     "eslint-plugin-storybook": "^0.12.0",
     "express": "^5.2.1",
     "globals": "^15.14.0",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
+    "lint-staged": "^16.4.0",
     "msw": "^2.8.4",
     "playwright": "^1.52.0",
     "postcss": "^8.4.31",
@@ -181,5 +184,8 @@
     "extends": [
       "plugin:storybook/recommended"
     ]
+  },
+  "lint-staged": {
+    "!(package-lock.json)": "prettier --check --ignore-unknown"
   }
 }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
     "vite": "^5.4.21",
     "vite-plugin-compression": "^0.5.1",
     "vitest": "^3.1.3",
-    "wait-on": "^8.0.1"
+    "wait-on": "^8.0.1",
+    "yaml": "^2.9.0"
   },
   "description": "BrightBoost Interactive Learning Platform - Connecting teachers and students through gamified educational experiences",
   "main": "src/main.tsx",

--- a/prompts/2026-07-31-ticket-740-parity-guards.md
+++ b/prompts/2026-07-31-ticket-740-parity-guards.md
@@ -1,0 +1,43 @@
+# Local–CI parity, hooks, and guard wiring (Issue #740)
+
+**Author:** Jack
+**Date:** 2026-07-31
+**Sprint:** —
+**Pod:** Build
+
+## Intent
+
+Ship infrastructure so local and CI verification mean the same thing: a parity runner, commit hooks, and wired two-phase guards for CI shell gate, required-step presence, and type-program membership — without changing classroom-facing product behavior.
+
+## Prompt
+
+```
+Followed the ticket spec and drove work in Cursor in a few passes: parity script and selfcheck, husky hooks, CI guard wiring, unit tests that execute gates, then QA falsification and PR prep.
+```
+
+## What Claude Code Did
+
+- Files created/modified: `scripts/verify-parity.mjs`, `scripts/verify-parity-selfcheck.mjs`, `scripts/verify-ci-step-presence.sh`, `scripts/verify-type-program-membership.mjs`, `scripts/ci-required-steps.json`, `scripts/type-guard-manifest.json`, `scripts/__tests__/*`, `.github/workflows/ci-cd.yml`, `.husky/*`, `package.json` / `package-lock.json` (verify scripts + husky)
+- Tests passed: `npm run test:unit` green after `npx prisma generate` (593 passed / 20 skipped)
+- Build clean: `npm run build` yes; `npm run lint` / `npm run typecheck` yes
+
+## What Worked
+
+- Extending the existing two-phase shell-gate pattern for new verifiers instead of inventing a parallel convention
+- Replacing source-text CI wiring assertions with process execution and exit codes
+- Keeping full `npm run verify` honesty: named local gaps rather than weakening steps
+
+## What Needed Editing
+
+- Vitest worker timeouts when spawning long shell-gate runs (async spawn / suite timeout)
+- Remapped Cypress base URL vs gate’s hardcoded Vite port when proving the shell gate locally
+- Git Bash vs broken WSL `bash` for npm scripts that invoke bare `bash`
+
+## Lessons
+
+- A correct guard that no workflow invokes is still a false green until wired and falsified
+- Clean `npm ci` without `prisma generate` can fail backend unit suites that import `@prisma/client` — document, don’t paper over in the parity table
+
+## Rating
+
+4/5 — strong for scaffolding scripts and tests; human still needed for environment gotchas (ports, bash, Prisma generate) and for deciding what stays out of scope (#707 Storybook, E2E seed).

--- a/scripts/__tests__/ciShellGateWiring.test.ts
+++ b/scripts/__tests__/ciShellGateWiring.test.ts
@@ -1,22 +1,38 @@
-import { readFileSync } from "node:fs";
+/* @vitest-environment node */
+
+/**
+ * U1-03: supersedes the prior YAML text-read (G-202).
+ * Proves `npm run verify:ci-gate` remains invoked in ci-cd.yml by *executing*
+ * the step-presence guard (manifest lists that substring). Full two-phase
+ * shell-gate execution lives in ciWiring.test.ts W-8/W-9 — do not duplicate it.
+ */
+import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { config as loadEnv } from "dotenv";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "../..");
+loadEnv({ path: path.join(repoRoot, ".env.local") });
+loadEnv({ path: path.join(repoRoot, ".env") });
 
-describe("CI shell gate wiring (G-201 / A7)", () => {
-  it("ci-cd.yml invokes verify-ci-shell-gate.sh (or npm run verify:ci-gate)", () => {
-    const workflow = readFileSync(
-      path.join(repoRoot, ".github/workflows/ci-cd.yml"),
-      "utf8",
-    );
-    const wired =
-      workflow.includes("verify-ci-shell-gate.sh") ||
-      workflow.includes("npm run verify:ci-gate");
+function resolveBash(): string {
+  return process.env.BB_BASH || "bash";
+}
+
+describe("CI shell gate wiring (G-201 / A7 / U1-03)", () => {
+  it("verify-ci-step-presence.sh exits 0 (manifest requires npm run verify:ci-gate)", () => {
+    const bash = resolveBash();
+    const result = spawnSync(bash, ["scripts/verify-ci-step-presence.sh"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 60_000,
+      env: process.env,
+    });
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     expect(
-      wired,
-      "ci-cd.yml must invoke scripts/verify-ci-shell-gate.sh (G-201). " +
-        "A guard that exists but is never run is not a guard.",
-    ).toBe(true);
-  });
+      result.status,
+      `step-presence must exit 0 — proves verify:ci-gate is still wired (got ${result.status}):\n${output}`,
+    ).toBe(0);
+    expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
+  }, 60_000);
 });

--- a/scripts/__tests__/ciShellGateWiring.test.ts
+++ b/scripts/__tests__/ciShellGateWiring.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+describe("CI shell gate wiring (G-201 / A7)", () => {
+  it("ci-cd.yml invokes verify-ci-shell-gate.sh (or npm run verify:ci-gate)", () => {
+    const workflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/ci-cd.yml"),
+      "utf8",
+    );
+    const wired =
+      workflow.includes("verify-ci-shell-gate.sh") ||
+      workflow.includes("npm run verify:ci-gate");
+    expect(
+      wired,
+      "ci-cd.yml must invoke scripts/verify-ci-shell-gate.sh (G-201). " +
+        "A guard that exists but is never run is not a guard.",
+    ).toBe(true);
+  });
+});

--- a/scripts/__tests__/ciShellGateWiring.test.ts
+++ b/scripts/__tests__/ciShellGateWiring.test.ts
@@ -5,8 +5,10 @@
  * Proves `npm run verify:ci-gate` remains invoked in ci-cd.yml by *executing*
  * the step-presence guard (manifest lists that substring). Full two-phase
  * shell-gate execution lives in ciWiring.test.ts W-8/W-9 — do not duplicate it.
+ *
+ * Uses async spawn so Vitest's worker RPC is not blocked (birpc onTaskUpdate).
  */
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { config as loadEnv } from "dotenv";
 import { describe, expect, it } from "vitest";
@@ -19,19 +21,44 @@ function resolveBash(): string {
   return process.env.BB_BASH || "bash";
 }
 
-describe("CI shell gate wiring (G-201 / A7 / U1-03)", () => {
-  it("verify-ci-step-presence.sh exits 0 (manifest requires npm run verify:ci-gate)", () => {
-    const bash = resolveBash();
-    const result = spawnSync(bash, ["scripts/verify-ci-step-presence.sh"], {
+function runStepPresenceAsync(): Promise<{
+  status: number | null;
+  output: string;
+}> {
+  return new Promise((resolve) => {
+    const child = spawn(resolveBash(), ["scripts/verify-ci-step-presence.sh"], {
       cwd: repoRoot,
-      encoding: "utf8",
-      timeout: 60_000,
       env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
     });
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ status: 124, output: output + "\nspawn timeout\n" });
+    }, 60_000);
+    child.stdout?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.stderr?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ status: 2, output: output + `\n${err.message}` });
+    });
+  });
+}
+
+describe("CI shell gate wiring (G-201 / A7 / U1-03)", () => {
+  it("verify-ci-step-presence.sh exits 0 (manifest requires npm run verify:ci-gate)", async () => {
+    const { status, output } = await runStepPresenceAsync();
     expect(
-      result.status,
-      `step-presence must exit 0 — proves verify:ci-gate is still wired (got ${result.status}):\n${output}`,
+      status,
+      `step-presence must exit 0 — proves verify:ci-gate is still wired (got ${status}):\n${output}`,
     ).toBe(0);
     expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
   }, 60_000);

--- a/scripts/__tests__/ciWiring.test.ts
+++ b/scripts/__tests__/ciWiring.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { config as loadEnv } from "dotenv";
@@ -33,23 +33,43 @@ function resolveBash(): string {
 }
 
 /**
- * Spawn a bash script with BB_BASH on Windows (G-011). Returns status + combined output.
+ * Async bash spawn — spawnSync blocks the Vitest worker thread and trips
+ * birpc "Timeout calling onTaskUpdate" on long gates (~60s+).
  */
-function runBashScript(
+function runBashScriptAsync(
   scriptRel: string,
   opts: { timeoutMs?: number; env?: NodeJS.ProcessEnv } = {},
-): { status: number | null; output: string } {
+): Promise<{ status: number | null; output: string }> {
   const bash = resolveBash();
-  const result = spawnSync(bash, [scriptRel], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    timeout: opts.timeoutMs ?? 60_000,
-    env: opts.env ?? process.env,
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  return new Promise((resolve) => {
+    const child = spawn(bash, [scriptRel], {
+      cwd: repoRoot,
+      env: opts.env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      output += `\nspawn timeout after ${timeoutMs}ms\n`;
+      resolve({ status: 124, output });
+    }, timeoutMs);
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      output += String(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      output += String(chunk);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      output += `\nspawn error: ${err.message}\n`;
+      resolve({ status: 2, output });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
   });
-  const output = `${result.stdout ?? ""}${result.stderr ?? ""}${
-    result.error ? `\nspawn error: ${result.error.message}` : ""
-  }`;
-  return { status: result.status, output };
 }
 
 describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
@@ -90,9 +110,8 @@ describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
   });
 
   // U1-03 / G-202: execute the step-presence guard instead of reading ci-cd.yml text.
-  // Manifest requires "npm run test:e2e:ci" among other steps (W-5/W-6 property).
-  it("W-5/W-6: verify-ci-step-presence.sh exits 0 (required steps including test:e2e:ci)", () => {
-    const { status, output } = runBashScript(
+  it("W-5: verify-ci-step-presence.sh exits 0 (required steps including test:e2e:ci)", async () => {
+    const { status, output } = await runBashScriptAsync(
       "scripts/verify-ci-step-presence.sh",
       { timeoutMs: 60_000 },
     );
@@ -102,6 +121,12 @@ describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
     ).toBe(0);
     expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
   }, 60_000);
+
+  // Restored from pre-U1 W-6: step-presence does not cover this negative.
+  it('W-6: ci-cd.yml does not contain --spec "cypress/e2e/smoke.cy.ts"', () => {
+    const workflow = readText(".github/workflows/ci-cd.yml");
+    expect(workflow).not.toContain('--spec "cypress/e2e/smoke.cy.ts"');
+  });
 
   it("W-7: cypress/e2e/staging/smoke.cy.ts exists and imports requireEnv", () => {
     const stagingSmoke = path.join(repoRoot, "cypress/e2e/staging/smoke.cy.ts");
@@ -113,13 +138,11 @@ describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
   });
 
   // U1-03 / G-202: execute the shell gate (healthy + sabotage inside the script).
-  // Do not read verify-ci-shell-gate.sh source — existence ≠ execution (G-201/G-202).
-  // Gate boots Vite on :5173 (script contract). Unset remapped CYPRESS_SWA_URL so
-  // Cypress baseUrl falls back to http://localhost:5173 like CI (G-007 seam).
-  it("W-8/W-9: verify-ci-shell-gate.sh exits 0 (two-phase healthy then sabotage)", () => {
+  // Unset remapped CYPRESS_SWA_URL so Cypress matches Vite on :5173 (gate contract).
+  it("W-8/W-9: verify-ci-shell-gate.sh exits 0 (two-phase healthy then sabotage)", async () => {
     const gateEnv: NodeJS.ProcessEnv = { ...process.env };
     delete gateEnv.CYPRESS_SWA_URL;
-    const { status, output } = runBashScript(
+    const { status, output } = await runBashScriptAsync(
       "scripts/verify-ci-shell-gate.sh",
       { timeoutMs: 180_000, env: gateEnv },
     );
@@ -127,12 +150,12 @@ describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
       status,
       `CI shell gate must exit 0 (got ${status}):\n${output}`,
     ).toBe(0);
-    expect(output).toMatch(/Healthy baseline GREEN|PASS/i);
+    expect(output).toMatch(/Healthy baseline GREEN/);
+    expect(output).toMatch(/PASS/i);
   }, 180_000);
 
   // Live POSIX proof: nested bash→mid node→:5173 listener must die with the
-  // tree. Skips on Windows/taskkill (that path uses //T). Static source reads
-  // alone would pass against one-level `pkill -P` — W-10 is the teeth (G-202).
+  // tree. Skips on Windows/taskkill (that path uses //T).
   it.skipIf(process.platform === "win32")(
     "W-10: kill_pid_tree reaps nested descendants holding :5173",
     ({ skip }) => {

--- a/scripts/__tests__/ciWiring.test.ts
+++ b/scripts/__tests__/ciWiring.test.ts
@@ -1,9 +1,15 @@
+/* @vitest-environment node */
+
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { config as loadEnv } from "dotenv";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "../..");
+
+loadEnv({ path: path.join(repoRoot, ".env.local") });
+loadEnv({ path: path.join(repoRoot, ".env") });
 
 function readText(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
@@ -22,7 +28,31 @@ function extractCiSpecPath(testE2eCiScript: string): string {
 /** Matches one-liner `cy.wrap({}).log(` and multiline `cy\n  .wrap({})\n  .log(` (overview.md §5.7). */
 const SILENT_SKIP_PATTERN = /cy\s*\.wrap\(\{\}\)[\s\S]*?\.log\(/;
 
-describe("CI wiring guard (#677)", () => {
+function resolveBash(): string {
+  return process.env.BB_BASH || "bash";
+}
+
+/**
+ * Spawn a bash script with BB_BASH on Windows (G-011). Returns status + combined output.
+ */
+function runBashScript(
+  scriptRel: string,
+  opts: { timeoutMs?: number; env?: NodeJS.ProcessEnv } = {},
+): { status: number | null; output: string } {
+  const bash = resolveBash();
+  const result = spawnSync(bash, [scriptRel], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: opts.timeoutMs ?? 60_000,
+    env: opts.env ?? process.env,
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}${
+    result.error ? `\nspawn error: ${result.error.message}` : ""
+  }`;
+  return { status: result.status, output };
+}
+
+describe("CI wiring guard (#677 / U1-03)", () => {
   it('W-1: package.json has scripts["test:e2e:ci"]', () => {
     const pkg = JSON.parse(readText("package.json")) as {
       scripts?: Record<string, string>;
@@ -59,65 +89,50 @@ describe("CI wiring guard (#677)", () => {
     expect(source).not.toMatch(/Cypress\.env\(/);
   });
 
-  it("W-5: ci-cd.yml text contains npm run test:e2e:ci", () => {
-    const workflow = readText(".github/workflows/ci-cd.yml");
-    expect(workflow).toContain("npm run test:e2e:ci");
-  });
-
-  it('W-6: ci-cd.yml text does not contain --spec "cypress/e2e/smoke.cy.ts"', () => {
-    const workflow = readText(".github/workflows/ci-cd.yml");
-    expect(workflow).not.toContain('--spec "cypress/e2e/smoke.cy.ts"');
-  });
+  // U1-03 / G-202: execute the step-presence guard instead of reading ci-cd.yml text.
+  // Manifest requires "npm run test:e2e:ci" among other steps (W-5/W-6 property).
+  it("W-5/W-6: verify-ci-step-presence.sh exits 0 (required steps including test:e2e:ci)", () => {
+    const { status, output } = runBashScript(
+      "scripts/verify-ci-step-presence.sh",
+      { timeoutMs: 60_000 },
+    );
+    expect(
+      status,
+      `step-presence guard must exit 0 (got ${status}):\n${output}`,
+    ).toBe(0);
+    expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
+  }, 60_000);
 
   it("W-7: cypress/e2e/staging/smoke.cy.ts exists and imports requireEnv", () => {
     const stagingSmoke = path.join(repoRoot, "cypress/e2e/staging/smoke.cy.ts");
     expect(existsSync(stagingSmoke)).toBe(true);
     const source = readFileSync(stagingSmoke, "utf8");
-    // overview.md §5.7: "imports requireEnv" (stronger than a bare reference)
     expect(source).toMatch(
       /import\s*\{[^}]*\brequireEnv\b[^}]*\}\s*from\s*["'][^"']+["']/,
     );
   });
 
-  // ── verify-ci-shell-gate.sh contracts (review r3598393451 / r3598393457) ──
-
-  it("W-8: the sabotage verifier runs a HEALTHY baseline before injecting sabotage", () => {
-    const script = readText("scripts/verify-ci-shell-gate.sh");
-    const healthyGate = script.indexOf("HEALTHY_EC=$CYPRESS_EC");
-    const healthyCheck = script.indexOf('"$HEALTHY_EC" -ne 0');
-    const sabotageInjection = script.indexOf("SABOTAGE #677");
-    // All three exist…
-    expect(healthyGate).toBeGreaterThan(-1);
-    expect(healthyCheck).toBeGreaterThan(-1);
-    expect(sabotageInjection).toBeGreaterThan(-1);
-    // …and the healthy run + its exit-0 requirement come BEFORE the sabotage,
-    // so a missing binary / broken config / already-red baseline can never
-    // masquerade as a successful sabotage (causality, r3598393451).
-    expect(healthyGate).toBeLessThan(sabotageInjection);
-    expect(healthyCheck).toBeLessThan(sabotageInjection);
-  });
-
-  it("W-9: the sabotage verifier never sweeps arbitrary PIDs on :5173", () => {
-    const script = readText("scripts/verify-ci-shell-gate.sh");
-    const killLib = readText("scripts/lib/kill-pid-tree.sh");
-    // No port-wide PID harvesting (r3598393457): cleanup must be scoped to
-    // the process tree this script spawned (DEV_PID), never "whoever is on
-    // the port".
-    for (const source of [script, killLib]) {
-      expect(source).not.toMatch(/lsof\s+-ti/);
-      expect(source).not.toMatch(/netstat[^\n]*5173/);
-      expect(source).not.toMatch(/sweep_port/);
-    }
-    // The only kill target is the tracked DEV_PID tree.
-    expect(script).toMatch(/kill_pid_tree\s+"\$DEV_PID"/);
-    expect(script).toMatch(/source\s+"\$SCRIPT_DIR\/lib\/kill-pid-tree\.sh"/);
-  });
+  // U1-03 / G-202: execute the shell gate (healthy + sabotage inside the script).
+  // Do not read verify-ci-shell-gate.sh source — existence ≠ execution (G-201/G-202).
+  // Gate boots Vite on :5173 (script contract). Unset remapped CYPRESS_SWA_URL so
+  // Cypress baseUrl falls back to http://localhost:5173 like CI (G-007 seam).
+  it("W-8/W-9: verify-ci-shell-gate.sh exits 0 (two-phase healthy then sabotage)", () => {
+    const gateEnv: NodeJS.ProcessEnv = { ...process.env };
+    delete gateEnv.CYPRESS_SWA_URL;
+    const { status, output } = runBashScript(
+      "scripts/verify-ci-shell-gate.sh",
+      { timeoutMs: 180_000, env: gateEnv },
+    );
+    expect(
+      status,
+      `CI shell gate must exit 0 (got ${status}):\n${output}`,
+    ).toBe(0);
+    expect(output).toMatch(/Healthy baseline GREEN|PASS/i);
+  }, 180_000);
 
   // Live POSIX proof: nested bash→mid node→:5173 listener must die with the
-  // tree. Skips on Windows/taskkill (that path uses //T). Static W-9 alone
-  // would pass against one-level `pkill -P` — W-10 is the teeth (G-202).
-  // Mid is a signal-ignoring node (not bash) so one-level pkill cannot falsely
-  // green by relying on bash job cleanup.
+  // tree. Skips on Windows/taskkill (that path uses //T). Static source reads
+  // alone would pass against one-level `pkill -P` — W-10 is the teeth (G-202).
   it.skipIf(process.platform === "win32")(
     "W-10: kill_pid_tree reaps nested descendants holding :5173",
     ({ skip }) => {
@@ -125,13 +140,12 @@ describe("CI wiring guard (#677)", () => {
         repoRoot,
         "scripts/__tests__/kill-pid-tree-live.sh",
       );
-      const result = spawnSync("bash", [harness], {
+      const result = spawnSync(resolveBash(), [harness], {
         cwd: repoRoot,
         encoding: "utf8",
         timeout: 60_000,
       });
       const combined = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-      // 77 = harness skip (busy port / missing tools) — not a failure.
       if (result.status === 77) {
         skip();
         return;

--- a/scripts/__tests__/ciWiring.test.ts
+++ b/scripts/__tests__/ciWiring.test.ts
@@ -52,7 +52,7 @@ function runBashScript(
   return { status: result.status, output };
 }
 
-describe("CI wiring guard (#677 / U1-03)", () => {
+describe("CI wiring guard (#677 / U1-03)", { timeout: 300_000 }, () => {
   it('W-1: package.json has scripts["test:e2e:ci"]', () => {
     const pkg = JSON.parse(readText("package.json")) as {
       scripts?: Record<string, string>;

--- a/scripts/__tests__/verify-ci-step-presence.test.ts
+++ b/scripts/__tests__/verify-ci-step-presence.test.ts
@@ -1,0 +1,97 @@
+/* @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { config as loadEnv } from "dotenv";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+loadEnv({ path: path.join(repoRoot, ".env.local") });
+loadEnv({ path: path.join(repoRoot, ".env") });
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function resolveBash(): string {
+  return process.env.BB_BASH || "bash";
+}
+
+function runStepPresence(env: NodeJS.ProcessEnv = process.env): {
+  status: number | null;
+  output: string;
+} {
+  const result = spawnSync(
+    resolveBash(),
+    ["scripts/verify-ci-step-presence.sh"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 60_000,
+      env,
+    },
+  );
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("verify-ci-step-presence.sh (U1-04)", () => {
+  it("healthy: real workflow + manifest exits 0", () => {
+    const { status, output } = runStepPresence();
+    expect(status, `expected exit 0:\n${output}`).toBe(0);
+    expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
+  });
+
+  it("property false: manifest names a step that does not exist in the workflow (exit 1)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ci-step-presence-"));
+    tempDirs.push(dir);
+
+    const realWorkflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/ci-cd.yml"),
+      "utf8",
+    );
+    const workflowPath = path.join(dir, "ci-cd.yml");
+    // Remove prisma-drift invocation so a real required substring is absent.
+    const sabotaged = realWorkflow
+      .split(/\r?\n/)
+      .filter((line) => !line.includes("check-prisma-drift.sh"))
+      .join("\n");
+    writeFileSync(workflowPath, sabotaged, "utf8");
+
+    const manifestPath = path.join(dir, "ci-required-steps.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        requiredSubstrings: [
+          "scripts/check-prisma-drift.sh",
+          "this-step-definitely-does-not-exist-in-workflow",
+        ],
+      }),
+      "utf8",
+    );
+
+    const { status, output } = runStepPresence({
+      ...process.env,
+      CI_STEP_PRESENCE_WORKFLOW: workflowPath,
+      CI_STEP_PRESENCE_MANIFEST: manifestPath,
+    });
+
+    expect(
+      status,
+      `manifest entry naming a missing step must exit 1 (property false), got ${status}:\n${output}`,
+    ).toBe(1);
+    expect(output).toMatch(/MISSING required step substring/);
+    expect(output).toMatch(
+      /this-step-definitely-does-not-exist-in-workflow|check-prisma-drift\.sh/,
+    );
+  });
+});

--- a/scripts/__tests__/verify-ci-step-presence.test.ts
+++ b/scripts/__tests__/verify-ci-step-presence.test.ts
@@ -55,14 +55,54 @@ function runStepPresence(
   });
 }
 
-describe("verify-ci-step-presence.sh (U1-04)", () => {
+describe("verify-ci-step-presence.sh (U1-04 + review Bug A)", () => {
   it("healthy: real workflow + manifest exits 0", async () => {
     const { status, output } = await runStepPresence();
     expect(status, `expected exit 0:\n${output}`).toBe(0);
     expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
   });
 
-  it("property false: manifest names a step that does not exist in the workflow (exit 1)", async () => {
+  it("property false: required step commented out → exit 1 (Bug A regression)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ci-step-presence-"));
+    tempDirs.push(dir);
+
+    const realWorkflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/ci-cd.yml"),
+      "utf8",
+    );
+    const workflowPath = path.join(dir, "ci-cd-commented.yml");
+    const commented = realWorkflow
+      .split(/\r?\n/)
+      .map((line) =>
+        line.includes("check-prisma-drift.sh") ? `# ${line}` : line,
+      )
+      .join("\n");
+    writeFileSync(workflowPath, commented, "utf8");
+
+    const manifestPath = path.join(dir, "ci-required-steps.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        requiredSubstrings: ["scripts/check-prisma-drift.sh"],
+      }),
+      "utf8",
+    );
+
+    const { status, output } = await runStepPresence({
+      ...process.env,
+      CI_STEP_PRESENCE_WORKFLOW: workflowPath,
+      CI_STEP_PRESENCE_MANIFEST: manifestPath,
+    });
+
+    expect(
+      status,
+      `commented-out drift step must exit 1 (property false), got ${status}:\n${output}`,
+    ).toBe(1);
+    expect(output).toMatch(/MISSING required step substring/);
+    expect(output).toContain("scripts/check-prisma-drift.sh");
+  });
+
+  it("property false: required step deleted entirely → exit 1", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "ci-step-presence-"));
     tempDirs.push(dir);
 

--- a/scripts/__tests__/verify-ci-step-presence.test.ts
+++ b/scripts/__tests__/verify-ci-step-presence.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -24,34 +24,45 @@ function resolveBash(): string {
   return process.env.BB_BASH || "bash";
 }
 
-function runStepPresence(env: NodeJS.ProcessEnv = process.env): {
-  status: number | null;
-  output: string;
-} {
-  const result = spawnSync(
-    resolveBash(),
-    ["scripts/verify-ci-step-presence.sh"],
-    {
+function runStepPresence(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ status: number | null; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(resolveBash(), ["scripts/verify-ci-step-presence.sh"], {
       cwd: repoRoot,
-      encoding: "utf8",
-      timeout: 60_000,
       env,
-    },
-  );
-  return {
-    status: result.status,
-    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
-  };
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ status: 124, output: output + "\nspawn timeout\n" });
+    }, 60_000);
+    child.stdout?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.stderr?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ status: 2, output: output + `\n${err.message}` });
+    });
+  });
 }
 
 describe("verify-ci-step-presence.sh (U1-04)", () => {
-  it("healthy: real workflow + manifest exits 0", () => {
-    const { status, output } = runStepPresence();
+  it("healthy: real workflow + manifest exits 0", async () => {
+    const { status, output } = await runStepPresence();
     expect(status, `expected exit 0:\n${output}`).toBe(0);
     expect(output).toMatch(/PASS: CI step-presence guard has teeth/);
   });
 
-  it("property false: manifest names a step that does not exist in the workflow (exit 1)", () => {
+  it("property false: manifest names a step that does not exist in the workflow (exit 1)", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "ci-step-presence-"));
     tempDirs.push(dir);
 
@@ -60,7 +71,6 @@ describe("verify-ci-step-presence.sh (U1-04)", () => {
       "utf8",
     );
     const workflowPath = path.join(dir, "ci-cd.yml");
-    // Remove prisma-drift invocation so a real required substring is absent.
     const sabotaged = realWorkflow
       .split(/\r?\n/)
       .filter((line) => !line.includes("check-prisma-drift.sh"))
@@ -79,7 +89,7 @@ describe("verify-ci-step-presence.sh (U1-04)", () => {
       "utf8",
     );
 
-    const { status, output } = runStepPresence({
+    const { status, output } = await runStepPresence({
       ...process.env,
       CI_STEP_PRESENCE_WORKFLOW: workflowPath,
       CI_STEP_PRESENCE_MANIFEST: manifestPath,
@@ -90,8 +100,7 @@ describe("verify-ci-step-presence.sh (U1-04)", () => {
       `manifest entry naming a missing step must exit 1 (property false), got ${status}:\n${output}`,
     ).toBe(1);
     expect(output).toMatch(/MISSING required step substring/);
-    expect(output).toMatch(
-      /this-step-definitely-does-not-exist-in-workflow|check-prisma-drift\.sh/,
-    );
+    expect(output).toContain("this-step-definitely-does-not-exist-in-workflow");
+    expect(output).toContain("scripts/check-prisma-drift.sh");
   });
 });

--- a/scripts/__tests__/verify-exit-codes.test.ts
+++ b/scripts/__tests__/verify-exit-codes.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -24,13 +24,33 @@ function resolveBash(): string {
   return process.env.BB_BASH || "bash";
 }
 
+/** Absolute bash path so PATH can be stripped of node without losing the shell. */
+function resolveAbsoluteBash(): string {
+  const candidate = resolveBash();
+  if (path.isAbsolute(candidate)) {
+    return candidate;
+  }
+  const probed = spawnSync(candidate, ["-c", "command -v bash"], {
+    encoding: "utf8",
+    env: process.env,
+  });
+  const found = (probed.stdout || "").trim().split(/\r?\n/)[0];
+  if (probed.status === 0 && found && path.isAbsolute(found)) {
+    return found;
+  }
+  throw new Error(
+    `Could not resolve absolute bash path from ${JSON.stringify(candidate)}`,
+  );
+}
+
 function runBash(
   args: string[],
   env: NodeJS.ProcessEnv,
   timeoutMs = 30_000,
+  bashPath = resolveBash(),
 ): Promise<{ status: number | null; output: string }> {
   return new Promise((resolve) => {
-    const child = spawn(resolveBash(), args, {
+    const child = spawn(bashPath, args, {
       cwd: repoRoot,
       env,
       stdio: ["ignore", "pipe", "pipe"],
@@ -138,15 +158,17 @@ describe("reserved exit codes (§7 / U1-06)", () => {
   });
 
   it("step-presence: PATH without node exits 2 (could not run)", async () => {
-    // U1-06 letter: falsify by removing a required binary from PATH.
-    // Git Bash on Windows still needs a usable PATH for bash builtins; strip
-    // only entries that typically hold node, keep System32 / Git.
+    // U1-06: remove node from PATH. On Linux node often shares /usr/bin with
+    // bash, so spawn via an absolute bash path and use a minimal PATH that
+    // cannot resolve node (empty bin + win32 System32 when present).
     const emptyBin = mkdtempSync(path.join(tmpdir(), "no-node-bin-"));
     tempDirs.push(emptyBin);
-    const gitDir = path.dirname(resolveBash());
-    const slimPath = [emptyBin, gitDir, process.env.SystemRoot + "\\System32"]
-      .filter(Boolean)
-      .join(path.delimiter);
+    const bashAbs = resolveAbsoluteBash();
+    const slimParts = [emptyBin];
+    if (process.env.SystemRoot) {
+      slimParts.push(path.join(process.env.SystemRoot, "System32"));
+    }
+    const slimPath = slimParts.join(path.delimiter);
 
     const { status, output } = await runBash(
       ["scripts/verify-ci-step-presence.sh"],
@@ -155,6 +177,8 @@ describe("reserved exit codes (§7 / U1-06)", () => {
         PATH: slimPath,
         Path: slimPath,
       },
+      30_000,
+      bashAbs,
     );
     expect(
       status,

--- a/scripts/__tests__/verify-exit-codes.test.ts
+++ b/scripts/__tests__/verify-exit-codes.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -24,33 +24,92 @@ function resolveBash(): string {
   return process.env.BB_BASH || "bash";
 }
 
+function runBash(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 30_000,
+): Promise<{ status: number | null; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(resolveBash(), args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ status: 124, output: output + "\nspawn timeout\n" });
+    }, timeoutMs);
+    child.stdout?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.stderr?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ status: 2, output: output + `\n${err.message}` });
+    });
+  });
+}
+
+function runNode(
+  scriptRel: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 30_000,
+): Promise<{ status: number | null; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptRel], {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ status: 124, output: output + "\nspawn timeout\n" });
+    }, timeoutMs);
+    child.stdout?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.stderr?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ status: 2, output: output + `\n${err.message}` });
+    });
+  });
+}
+
 describe("reserved exit codes (§7 / U1-06)", () => {
-  it("step-presence: missing manifest exits 2 (could not run), not 1", () => {
+  it("step-presence: missing manifest exits 2 (could not run), not 1", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "ci-step-exit-"));
     tempDirs.push(dir);
     const missingManifest = path.join(dir, "does-not-exist.json");
-    const result = spawnSync(
-      resolveBash(),
+    const { status, output } = await runBash(
       ["scripts/verify-ci-step-presence.sh"],
       {
-        cwd: repoRoot,
-        encoding: "utf8",
-        timeout: 30_000,
-        env: {
-          ...process.env,
-          CI_STEP_PRESENCE_MANIFEST: missingManifest,
-        },
+        ...process.env,
+        CI_STEP_PRESENCE_MANIFEST: missingManifest,
       },
     );
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     expect(
-      result.status,
-      `missing manifest must be exit 2 (could not run), got ${result.status}:\n${output}`,
+      status,
+      `missing manifest must be exit 2 (could not run), got ${status}:\n${output}`,
     ).toBe(2);
     expect(output).toMatch(/ERROR: missing manifest/);
   });
 
-  it("step-presence: property false (missing step) exits 1, distinct from 2", () => {
+  it("step-presence: property false (missing step) exits 1, distinct from 2", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "ci-step-prop-"));
     tempDirs.push(dir);
     const workflowPath = path.join(dir, "empty.yml");
@@ -63,49 +122,61 @@ describe("reserved exit codes (§7 / U1-06)", () => {
       }),
       "utf8",
     );
-    const result = spawnSync(
-      resolveBash(),
+    const { status, output } = await runBash(
       ["scripts/verify-ci-step-presence.sh"],
       {
-        cwd: repoRoot,
-        encoding: "utf8",
-        timeout: 30_000,
-        env: {
-          ...process.env,
-          CI_STEP_PRESENCE_WORKFLOW: workflowPath,
-          CI_STEP_PRESENCE_MANIFEST: manifestPath,
-        },
+        ...process.env,
+        CI_STEP_PRESENCE_WORKFLOW: workflowPath,
+        CI_STEP_PRESENCE_MANIFEST: manifestPath,
       },
     );
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     expect(
-      result.status,
-      `absent required step must be exit 1 (property false), got ${result.status}:\n${output}`,
+      status,
+      `absent required step must be exit 1 (property false), got ${status}:\n${output}`,
     ).toBe(1);
-    expect(result.status).not.toBe(2);
+    expect(status).not.toBe(2);
   });
 
-  it("type-program: missing manifest exits 2 (could not run)", () => {
+  it("step-presence: PATH without node exits 2 (could not run)", async () => {
+    // U1-06 letter: falsify by removing a required binary from PATH.
+    // Git Bash on Windows still needs a usable PATH for bash builtins; strip
+    // only entries that typically hold node, keep System32 / Git.
+    const emptyBin = mkdtempSync(path.join(tmpdir(), "no-node-bin-"));
+    tempDirs.push(emptyBin);
+    const gitDir = path.dirname(resolveBash());
+    const slimPath = [emptyBin, gitDir, process.env.SystemRoot + "\\System32"]
+      .filter(Boolean)
+      .join(path.delimiter);
+
+    const { status, output } = await runBash(
+      ["scripts/verify-ci-step-presence.sh"],
+      {
+        ...process.env,
+        PATH: slimPath,
+        Path: slimPath,
+      },
+    );
+    expect(
+      status,
+      `PATH without node must be exit 2 (could not run), got ${status}:\n${output}`,
+    ).toBe(2);
+    expect(output).toMatch(/ERROR: node is required|ERROR: missing/);
+  });
+
+  it("type-program: missing manifest exits 2 (could not run)", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "type-guard-exit-"));
     tempDirs.push(dir);
     const missing = path.join(dir, "no-such-manifest.json");
-    const result = spawnSync(
-      process.execPath,
-      ["scripts/verify-type-program-membership.mjs"],
+    const { status, output } = await runNode(
+      "scripts/verify-type-program-membership.mjs",
       {
-        cwd: repoRoot,
-        encoding: "utf8",
-        timeout: 30_000,
-        env: {
-          ...process.env,
-          TYPE_GUARD_MANIFEST: missing,
-        },
+        ...process.env,
+        TYPE_GUARD_MANIFEST: missing,
       },
     );
-    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     expect(
-      result.status,
-      `missing type-guard manifest must be exit 2, got ${result.status}:\n${output}`,
+      status,
+      `missing type-guard manifest must be exit 2, got ${status}:\n${output}`,
     ).toBe(2);
     expect(output).toMatch(/ERROR: missing manifest/);
   });

--- a/scripts/__tests__/verify-exit-codes.test.ts
+++ b/scripts/__tests__/verify-exit-codes.test.ts
@@ -1,0 +1,124 @@
+/* @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { config as loadEnv } from "dotenv";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+loadEnv({ path: path.join(repoRoot, ".env.local") });
+loadEnv({ path: path.join(repoRoot, ".env") });
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function resolveBash(): string {
+  return process.env.BB_BASH || "bash";
+}
+
+describe("reserved exit codes (§7 / U1-06)", () => {
+  it("step-presence: missing manifest exits 2 (could not run), not 1", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ci-step-exit-"));
+    tempDirs.push(dir);
+    const missingManifest = path.join(dir, "does-not-exist.json");
+    const result = spawnSync(
+      resolveBash(),
+      ["scripts/verify-ci-step-presence.sh"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          CI_STEP_PRESENCE_MANIFEST: missingManifest,
+        },
+      },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(
+      result.status,
+      `missing manifest must be exit 2 (could not run), got ${result.status}:\n${output}`,
+    ).toBe(2);
+    expect(output).toMatch(/ERROR: missing manifest/);
+  });
+
+  it("step-presence: property false (missing step) exits 1, distinct from 2", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ci-step-prop-"));
+    tempDirs.push(dir);
+    const workflowPath = path.join(dir, "empty.yml");
+    writeFileSync(workflowPath, "name: empty\njobs: {}\n", "utf8");
+    const manifestPath = path.join(dir, "manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        requiredSubstrings: ["scripts/check-prisma-drift.sh"],
+      }),
+      "utf8",
+    );
+    const result = spawnSync(
+      resolveBash(),
+      ["scripts/verify-ci-step-presence.sh"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          CI_STEP_PRESENCE_WORKFLOW: workflowPath,
+          CI_STEP_PRESENCE_MANIFEST: manifestPath,
+        },
+      },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(
+      result.status,
+      `absent required step must be exit 1 (property false), got ${result.status}:\n${output}`,
+    ).toBe(1);
+    expect(result.status).not.toBe(2);
+  });
+
+  it("type-program: missing manifest exits 2 (could not run)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "type-guard-exit-"));
+    tempDirs.push(dir);
+    const missing = path.join(dir, "no-such-manifest.json");
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/verify-type-program-membership.mjs"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          TYPE_GUARD_MANIFEST: missing,
+        },
+      },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(
+      result.status,
+      `missing type-guard manifest must be exit 2, got ${result.status}:\n${output}`,
+    ).toBe(2);
+    expect(output).toMatch(/ERROR: missing manifest/);
+  });
+
+  it("type-program: EXIT_PROPERTY and EXIT_CANNOT_RUN are distinct exports", async () => {
+    const { pathToFileURL } = await import("node:url");
+    const mod = await import(
+      pathToFileURL(
+        path.join(repoRoot, "scripts/verify-type-program-membership.mjs"),
+      ).href
+    );
+    expect(mod.EXIT_PROPERTY).toBe(1);
+    expect(mod.EXIT_CANNOT_RUN).toBe(2);
+    expect(mod.EXIT_PROPERTY).not.toBe(mod.EXIT_CANNOT_RUN);
+  });
+});

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -3,23 +3,53 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "../..");
 
-describe("verify-parity.mjs (A5)", () => {
-  it("exports STEPS in CI order matching ci-cd.yml build-and-test then db-check", async () => {
+/**
+ * Exact CI order from overview.md §15.3.2 / verify-parity.mjs STEPS.
+ * U1-01 RED used a deliberately wrong list (CI-02 before CI-01) so the
+ * failure named the order property; U1-02 locks the real sequence.
+ */
+/**
+ * Exact CI order from overview.md §15.3.2 / verify-parity.mjs STEPS.
+ * U1-01 RED used a deliberately wrong list (CI-02 before CI-01); failure
+ * named the order property. U1-02 locks the real sequence below.
+ */
+const EXPECTED_STEP_IDS = [
+  "CI-01",
+  "CI-02",
+  "CI-03",
+  "CI-04",
+  "CI-05",
+  "CI-06",
+  "CI-24",
+  "CI-25",
+  "CI-07",
+  "CI-08",
+  "CI-09",
+  "CI-23",
+  "CI-10",
+  "CI-11",
+  "CI-12",
+  "CI-13",
+  "CI-14",
+  "CI-15",
+  "CI-16",
+  "CI-17",
+  "CI-21",
+  "CI-22",
+  "CI-26",
+];
+
+describe("verify-parity.mjs (A5 / U1)", () => {
+  it("exports STEPS in exact CI order (not merely presence)", async () => {
     const mod = await import(
       pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
     );
     expect(mod.STEPS, "STEPS export must exist").toBeDefined();
     const ids = mod.STEPS.map((s: { id: string }) => s.id);
-    expect(ids.indexOf("CI-01")).toBeLessThan(ids.indexOf("CI-02"));
-    expect(ids.indexOf("CI-06")).toBeLessThan(ids.indexOf("CI-24"));
-    expect(ids.indexOf("CI-24")).toBeLessThan(ids.indexOf("CI-25"));
-    expect(ids.indexOf("CI-25")).toBeLessThan(ids.indexOf("CI-07"));
-    expect(ids.indexOf("CI-07")).toBeLessThan(ids.indexOf("CI-09"));
-    expect(ids.indexOf("CI-09")).toBeLessThan(ids.indexOf("CI-23"));
-    expect(ids.indexOf("CI-23")).toBeLessThan(ids.indexOf("CI-13"));
-    expect(ids.indexOf("CI-13")).toBeLessThan(ids.indexOf("CI-14"));
-    expect(ids.indexOf("CI-14")).toBeLessThan(ids.indexOf("CI-16"));
-    expect(ids.indexOf("CI-26")).toBeGreaterThan(ids.indexOf("CI-16"));
+    expect(
+      ids,
+      "STEPS order must match CI build-and-test then db-check then extras",
+    ).toEqual(EXPECTED_STEP_IDS);
   });
 
   it("parseArgs recognizes --allow-skips and --inject-fail", async () => {

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -1,7 +1,11 @@
+/* @vitest-environment node */
+
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "../..");
+const parityScript = path.join(repoRoot, "scripts/verify-parity.mjs");
 
 /**
  * Exact CI order from overview.md §15.3.2 / verify-parity.mjs STEPS.
@@ -34,6 +38,53 @@ const EXPECTED_STEP_IDS = [
   "CI-26",
 ];
 
+function pathToFileUrl(p: string): string {
+  const resolved = path.resolve(p);
+  const withSlashes = resolved.replace(/\\/g, "/");
+  return withSlashes.startsWith("/")
+    ? `file://${withSlashes}`
+    : `file:///${withSlashes}`;
+}
+
+function runParityCli(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 30_000,
+): Promise<{ status: number | null; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [parityScript, ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let output = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ status: 124, output: output + "\nspawn timeout\n" });
+    }, timeoutMs);
+    child.stdout?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.stderr?.on("data", (c: Buffer | string) => {
+      output += String(c);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ status: code, output });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ status: 2, output: output + `\n${err.message}` });
+    });
+  });
+}
+
+/** Count step executions that actually spawned a child (not inject-fail / SKIP). */
+function countRunLines(output: string): number {
+  return (output.match(/^\[RUN\] /gm) || []).length;
+}
+
 describe("verify-parity.mjs (A5 / U1)", () => {
   it("exports STEPS in exact CI order (not merely presence)", async () => {
     const mod = await import(
@@ -61,13 +112,86 @@ describe("verify-parity.mjs (A5 / U1)", () => {
     expect(opts.allowSkips).toBe(true);
     expect(opts.injectFail).toBe("CI-06");
     expect(opts.only).toEqual(["CI-06", "CI-26"]);
+    expect(opts.usageError).toBeNull();
   });
 });
 
-function pathToFileUrl(p: string): string {
-  const resolved = path.resolve(p);
-  const withSlashes = resolved.replace(/\\/g, "/");
-  return withSlashes.startsWith("/")
-    ? `file://${withSlashes}`
-    : `file:///${withSlashes}`;
-}
+describe("verify-parity --only selection integrity (Bug F / #740)", () => {
+  it("rejects unknown ID --only CI-99 with exit 2 naming CI-99", async () => {
+    const { status, output } = await runParityCli(["--only", "CI-99"]);
+    expect(status, output).toBe(2);
+    expect(output).toMatch(/CI-99/);
+    expect(output).toMatch(/Valid IDs:/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("rejects --only with no value (exit 2)", async () => {
+    const { status, output } = await runParityCli(["--only"]);
+    expect(status, output).toBe(2);
+    expect(output).toMatch(/--only requires/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("rejects --only --allow-skips as flag-as-value (exit 2)", async () => {
+    const { status, output } = await runParityCli(["--only", "--allow-skips"]);
+    expect(status, output).toBe(2);
+    expect(output).toMatch(/--only requires/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it('rejects --only "" as empty entry (exit 2)', async () => {
+    const { status, output } = await runParityCli(["--only", ""]);
+    expect(status, output).toBe(2);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("rejects partial --only CI-02,CI-99 without running CI-02 (exit 2)", async () => {
+    const { status, output } = await runParityCli(["--only", "CI-02,CI-99"]);
+    expect(status, output).toBe(2);
+    expect(output).toMatch(/CI-99/);
+    expect(output).not.toMatch(/\[RUN\] CI-02/);
+    expect(output).not.toMatch(/\[PASS\] CI-02/);
+    expect(output).not.toMatch(/\[FAIL\] CI-02/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("runs exactly one step for --only CI-02 (inject-fail, no other steps)", async () => {
+    const { status, output } = await runParityCli([
+      "--only",
+      "CI-02",
+      "--inject-fail",
+      "CI-02",
+    ]);
+    expect(status, output).toBe(1);
+    expect(output).toMatch(/Selected 1 of \d+ steps: CI-02/);
+    expect(output).toMatch(/\[FAIL\] CI-02/);
+    expect(output).not.toMatch(/\[RUN\] CI-/);
+    expect(output).not.toMatch(/\[FAIL\] CI-(?!02\b)/);
+    expect(output).not.toMatch(/\[PASS\] CI-/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("exits 1 when selection is all SKIP (zero executable steps)", async () => {
+    // CI-26 always SKIPs locally (OQ-10 reverse gap).
+    const { status, output } = await runParityCli(["--only", "CI-26"]);
+    expect(status, output).toBe(1);
+    expect(output).toMatch(/Selected 1 of \d+ steps: CI-26/);
+    expect(output).toMatch(/\[SKIP\] CI-26/);
+    expect(output).toMatch(/Required step\(s\) were SKIPPED/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("validateStepSelection lists valid IDs for unknown --only", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    const opts = mod.parseArgs(["--only", "CI-99"]);
+    const result = mod.validateStepSelection(mod.STEPS, opts);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(2);
+      expect(result.message).toMatch(/CI-99/);
+      expect(result.message).toMatch(/CI-02/);
+    }
+  });
+});

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -1,18 +1,20 @@
-import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(__dirname, "../..");
 
 describe("verify-parity.mjs (A5)", () => {
-  it("exports STEPS in CI order with required build-and-test ids before db-check", async () => {
+  it("exports STEPS in CI order matching ci-cd.yml build-and-test then db-check", async () => {
     const mod = await import(
       pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
     );
     expect(mod.STEPS, "STEPS export must exist").toBeDefined();
     const ids = mod.STEPS.map((s: { id: string }) => s.id);
     expect(ids.indexOf("CI-01")).toBeLessThan(ids.indexOf("CI-02"));
-    expect(ids.indexOf("CI-02")).toBeLessThan(ids.indexOf("CI-09"));
+    expect(ids.indexOf("CI-06")).toBeLessThan(ids.indexOf("CI-24"));
+    expect(ids.indexOf("CI-24")).toBeLessThan(ids.indexOf("CI-25"));
+    expect(ids.indexOf("CI-25")).toBeLessThan(ids.indexOf("CI-07"));
+    expect(ids.indexOf("CI-07")).toBeLessThan(ids.indexOf("CI-09"));
     expect(ids.indexOf("CI-09")).toBeLessThan(ids.indexOf("CI-23"));
     expect(ids.indexOf("CI-23")).toBeLessThan(ids.indexOf("CI-13"));
     expect(ids.indexOf("CI-13")).toBeLessThan(ids.indexOf("CI-14"));
@@ -44,6 +46,3 @@ function pathToFileUrl(p: string): string {
     ? `file://${withSlashes}`
     : `file:///${withSlashes}`;
 }
-
-// Keep spawnSync import used if we add execution tests later (U1).
-void spawnSync;

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -195,3 +195,147 @@ describe("verify-parity --only selection integrity (Bug F / #740)", () => {
     }
   });
 });
+
+describe("verify-parity DB gate (Bug G / #740)", () => {
+  const secretUrl =
+    "postgresql://user:s3cret-password@db.prod.example.com:5432/brightboost";
+  const decoyAmbient =
+    "postgresql://ambient:decoy@db.ambient.example.com:5432/production";
+  const designatedLocal =
+    "postgresql://user:localpass@127.0.0.1:5432/brightboost_test";
+
+  it("skips CI-14 and CI-16 when TEST_DATABASE_URL unset (exit 1 without --allow-skips)", async () => {
+    const env = { ...process.env };
+    delete env.TEST_DATABASE_URL;
+    delete env.DATABASE_URL;
+    delete env.POSTGRES_URL;
+    delete env.BB_ALLOW_NON_TEST_DB;
+    const { status, output } = await runParityCli(
+      ["--only", "CI-14,CI-16"],
+      env,
+    );
+    expect(status, output).toBe(1);
+    expect(output).toMatch(/\[SKIP\] CI-14/);
+    expect(output).toMatch(/\[SKIP\] CI-16/);
+    expect(output).toMatch(/TEST_DATABASE_URL unset/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("allows required SKIPs with --allow-skips when TEST_DATABASE_URL unset", async () => {
+    const env = { ...process.env };
+    delete env.TEST_DATABASE_URL;
+    delete env.DATABASE_URL;
+    delete env.POSTGRES_URL;
+    delete env.BB_ALLOW_NON_TEST_DB;
+    const { status, output } = await runParityCli(
+      ["--only", "CI-14,CI-16", "--allow-skips"],
+      env,
+    );
+    expect(status, output).toBe(0);
+    expect(output).toMatch(/\[SKIP\] CI-14/);
+    expect(output).toMatch(/\[SKIP\] CI-16/);
+  });
+
+  it("refuses production-shaped TEST_DATABASE_URL with zero spawns", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    let spawnCount = 0;
+    const prev = process.env.TEST_DATABASE_URL;
+    const prevAllow = process.env.BB_ALLOW_NON_TEST_DB;
+    process.env.TEST_DATABASE_URL = secretUrl;
+    delete process.env.BB_ALLOW_NON_TEST_DB;
+    try {
+      const code = await mod.runParity(
+        mod.STEPS,
+        mod.parseArgs(["--only", "CI-14,CI-16"]),
+        {
+          runCommand: async () => {
+            spawnCount += 1;
+            return { code: 0, output: "" };
+          },
+        },
+      );
+      expect(code).toBe(1);
+      expect(spawnCount, "refusal must happen before any child spawn").toBe(0);
+    } finally {
+      if (prev === undefined) delete process.env.TEST_DATABASE_URL;
+      else process.env.TEST_DATABASE_URL = prev;
+      if (prevAllow === undefined) delete process.env.BB_ALLOW_NON_TEST_DB;
+      else process.env.BB_ALLOW_NON_TEST_DB = prevAllow;
+    }
+  });
+
+  it("BB_ALLOW_NON_TEST_DB=1 proceeds with warning naming host and database", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    const gate = mod.resolveParityDbGate({
+      TEST_DATABASE_URL: secretUrl,
+      BB_ALLOW_NON_TEST_DB: "1",
+    });
+    expect(gate.action).toBe("run");
+    if (gate.action === "run") {
+      expect(gate.warning).toMatch(/db\.prod\.example\.com/);
+      expect(gate.warning).toMatch(/brightboost/);
+      expect(gate.warning).not.toMatch(/s3cret-password/);
+    }
+  });
+
+  it("passes the same designated URL in every DB env var to both steps", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    const captured: Array<Record<string, string | undefined> | undefined> = [];
+    const prev = process.env.TEST_DATABASE_URL;
+    const prevDb = process.env.DATABASE_URL;
+    process.env.TEST_DATABASE_URL = designatedLocal;
+    process.env.DATABASE_URL = decoyAmbient;
+    delete process.env.BB_ALLOW_NON_TEST_DB;
+    try {
+      const code = await mod.runParity(
+        mod.STEPS,
+        mod.parseArgs(["--only", "CI-14,CI-16"]),
+        {
+          runCommand: async (_argv, opts) => {
+            captured.push(opts?.env);
+            return { code: 0, output: "" };
+          },
+        },
+      );
+      expect(code).toBe(0);
+      expect(captured).toHaveLength(2);
+      for (const env of captured) {
+        expect(env?.DATABASE_URL).toBe(designatedLocal);
+        expect(env?.TEST_DATABASE_URL).toBe(designatedLocal);
+        expect(env?.POSTGRES_URL).toBe(designatedLocal);
+        expect(env?.DATABASE_URL).not.toBe(decoyAmbient);
+      }
+    } finally {
+      if (prev === undefined) delete process.env.TEST_DATABASE_URL;
+      else process.env.TEST_DATABASE_URL = prev;
+      if (prevDb === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = prevDb;
+    }
+  });
+
+  it("never prints the password on the refusal path", async () => {
+    const env = { ...process.env, TEST_DATABASE_URL: secretUrl };
+    delete env.BB_ALLOW_NON_TEST_DB;
+    const { status, output } = await runParityCli(["--only", "CI-14"], env);
+    expect(status, output).toBe(1);
+    expect(output).not.toMatch(/s3cret-password/);
+    expect(output).toMatch(/db\.prod\.example\.com/);
+    expect(countRunLines(output)).toBe(0);
+  });
+
+  it("buildParityDbChildEnv keeps all three DB vars identical", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    const env = mod.buildParityDbChildEnv(designatedLocal);
+    expect(env.DATABASE_URL).toBe(designatedLocal);
+    expect(env.TEST_DATABASE_URL).toBe(designatedLocal);
+    expect(env.POSTGRES_URL).toBe(designatedLocal);
+  });
+});

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -5,11 +5,6 @@ const repoRoot = path.resolve(__dirname, "../..");
 
 /**
  * Exact CI order from overview.md §15.3.2 / verify-parity.mjs STEPS.
- * U1-01 RED used a deliberately wrong list (CI-02 before CI-01) so the
- * failure named the order property; U1-02 locks the real sequence.
- */
-/**
- * Exact CI order from overview.md §15.3.2 / verify-parity.mjs STEPS.
  * U1-01 RED used a deliberately wrong list (CI-02 before CI-01); failure
  * named the order property. U1-02 locks the real sequence below.
  */

--- a/scripts/__tests__/verify-parity.test.ts
+++ b/scripts/__tests__/verify-parity.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+describe("verify-parity.mjs (A5)", () => {
+  it("exports STEPS in CI order with required build-and-test ids before db-check", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    expect(mod.STEPS, "STEPS export must exist").toBeDefined();
+    const ids = mod.STEPS.map((s: { id: string }) => s.id);
+    expect(ids.indexOf("CI-01")).toBeLessThan(ids.indexOf("CI-02"));
+    expect(ids.indexOf("CI-02")).toBeLessThan(ids.indexOf("CI-09"));
+    expect(ids.indexOf("CI-09")).toBeLessThan(ids.indexOf("CI-23"));
+    expect(ids.indexOf("CI-23")).toBeLessThan(ids.indexOf("CI-13"));
+    expect(ids.indexOf("CI-13")).toBeLessThan(ids.indexOf("CI-14"));
+    expect(ids.indexOf("CI-14")).toBeLessThan(ids.indexOf("CI-16"));
+    expect(ids.indexOf("CI-26")).toBeGreaterThan(ids.indexOf("CI-16"));
+  });
+
+  it("parseArgs recognizes --allow-skips and --inject-fail", async () => {
+    const mod = await import(
+      pathToFileUrl(path.join(repoRoot, "scripts/verify-parity.mjs"))
+    );
+    const opts = mod.parseArgs([
+      "--allow-skips",
+      "--inject-fail",
+      "CI-06",
+      "--only",
+      "CI-06,CI-26",
+    ]);
+    expect(opts.allowSkips).toBe(true);
+    expect(opts.injectFail).toBe("CI-06");
+    expect(opts.only).toEqual(["CI-06", "CI-26"]);
+  });
+});
+
+function pathToFileUrl(p: string): string {
+  const resolved = path.resolve(p);
+  const withSlashes = resolved.replace(/\\/g, "/");
+  return withSlashes.startsWith("/")
+    ? `file://${withSlashes}`
+    : `file:///${withSlashes}`;
+}
+
+// Keep spawnSync import used if we add execution tests later (U1).
+void spawnSync;

--- a/scripts/__tests__/verify-type-program-membership.test.ts
+++ b/scripts/__tests__/verify-type-program-membership.test.ts
@@ -1,0 +1,50 @@
+/* @vitest-environment node */
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+async function loadMod() {
+  return import(
+    pathToFileURL(
+      path.join(repoRoot, "scripts/verify-type-program-membership.mjs"),
+    ).href
+  );
+}
+
+describe("verify-type-program-membership.mjs listFiles parsing (U1-05)", () => {
+  it("isListed: present path is found in fixture --listFiles output", async () => {
+    const mod = await loadMod();
+    const fixture = [
+      "/repo/node_modules/typescript/lib/lib.es5.d.ts",
+      "/repo/src/vite-env.d.ts",
+      "/repo/src/main.tsx",
+    ].join("\n");
+    expect(mod.isListed(fixture, "src/vite-env.d.ts")).toBe(true);
+    expect(mod.assertPresent(fixture, ["src/vite-env.d.ts"])).toEqual([]);
+  });
+
+  it("isListed: excluded-style path is absent and named by assertPresent", async () => {
+    const mod = await loadMod();
+    const fixture = ["/repo/src/vite-env.d.ts", "/repo/src/main.tsx"].join(
+      "\n",
+    );
+    const excluded = "src/test/__type_guard_sabotage__.ts";
+    expect(
+      mod.isListed(fixture, excluded),
+      "excluded path must not appear in listFiles fixture",
+    ).toBe(false);
+    expect(
+      mod.assertPresent(fixture, ["src/vite-env.d.ts", excluded]),
+      "assertPresent must name the absent excluded file",
+    ).toEqual([excluded]);
+  });
+
+  it("normalizeRel converts backslashes for Windows list output", async () => {
+    const mod = await loadMod();
+    const fixture = "D:\\repo\\src\\vite-env.d.ts\n";
+    expect(mod.isListed(fixture, "src/vite-env.d.ts")).toBe(true);
+  });
+});

--- a/scripts/ci-required-steps.json
+++ b/scripts/ci-required-steps.json
@@ -1,0 +1,15 @@
+{
+  "description": "Required CI step invocations in .github/workflows/ci-cd.yml (W-11 / G-205)",
+  "workflow": ".github/workflows/ci-cd.yml",
+  "requiredSubstrings": [
+    "scripts/check-prisma-drift.sh",
+    "npm run verify:ci-gate",
+    "scripts/verify-ci-step-presence.sh",
+    "scripts/verify-type-program-membership.mjs",
+    "npm run lint",
+    "npm run typecheck",
+    "npm test -- --watch=false",
+    "npm run test:e2e:ci",
+    "npm run build"
+  ]
+}

--- a/scripts/type-guard-manifest.json
+++ b/scripts/type-guard-manifest.json
@@ -1,4 +1,7 @@
 {
-  "description": "Compile-time guard files that must appear in tsc --listFiles (W-12 / G-008)",
-  "guardFiles": ["src/vite-env.d.ts"]
+  "description": "Compile-time guard files that must appear in tsc --listFiles (W-12 / G-008). src/components/games/dataDashAttrsExhaustiveness.ts is the real exhaustiveness guard. src/vite-env.d.ts is a smoke entry (Vite ambient decl), not a behavioral guard.",
+  "guardFiles": [
+    "src/components/games/dataDashAttrsExhaustiveness.ts",
+    "src/vite-env.d.ts"
+  ]
 }

--- a/scripts/type-guard-manifest.json
+++ b/scripts/type-guard-manifest.json
@@ -1,0 +1,4 @@
+{
+  "description": "Compile-time guard files that must appear in tsc --listFiles (W-12 / G-008)",
+  "guardFiles": ["src/vite-env.d.ts"]
+}

--- a/scripts/verify-ci-step-presence-core.mjs
+++ b/scripts/verify-ci-step-presence-core.mjs
@@ -1,0 +1,231 @@
+/**
+ * Core logic for verify-ci-step-presence.sh (W-11 / G-205).
+ * Parses active workflow steps (YAML), not raw text — commented-out lines
+ * must not count as present.
+ *
+ * Exit codes (process.exit when run as CLI):
+ *   0 = healthy OK (+ sabotage OK when --sabotage-all)
+ *   1 = property false
+ *   2 = could not run
+ */
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+export const EXIT_OK = 0;
+export const EXIT_PROPERTY = 1;
+export const EXIT_CANNOT_RUN = 2;
+
+/**
+ * @param {unknown} doc
+ * @returns {{ jobId: string, stepIndex: number, name: string, values: string[] }[]}
+ */
+export function collectActiveStepCommands(doc) {
+  /** @type {{ jobId: string, stepIndex: number, name: string, values: string[] }[]} */
+  const out = [];
+  if (!doc || typeof doc !== "object" || !("jobs" in doc)) return out;
+  const jobs = /** @type {Record<string, unknown>} */ (doc).jobs;
+  if (!jobs || typeof jobs !== "object") return out;
+
+  for (const [jobId, job] of Object.entries(jobs)) {
+    if (!job || typeof job !== "object") continue;
+    const steps = /** @type {{ steps?: unknown }} */ (job).steps;
+    if (!Array.isArray(steps)) continue;
+    steps.forEach((step, stepIndex) => {
+      if (!step || typeof step !== "object") return;
+      const s = /** @type {Record<string, unknown>} */ (step);
+      /** @type {string[]} */
+      const values = [];
+      if (typeof s.run === "string") values.push(s.run);
+      if (typeof s.uses === "string") values.push(s.uses);
+      if (values.length === 0) return;
+      out.push({
+        jobId,
+        stepIndex,
+        name: typeof s.name === "string" ? s.name : `(step ${stepIndex})`,
+        values,
+      });
+    });
+  }
+  return out;
+}
+
+/**
+ * @param {string} workflowText
+ * @param {string[]} requiredSubstrings
+ * @returns {{ ok: boolean, missing: string[], matches: { substring: string, jobId: string, stepName: string }[] }}
+ */
+export function checkRequiredPresent(workflowText, requiredSubstrings) {
+  let doc;
+  try {
+    doc = parseYaml(workflowText);
+  } catch (err) {
+    throw new Error(
+      `YAML parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const active = collectActiveStepCommands(doc);
+  /** @type {string[]} */
+  const missing = [];
+  /** @type {{ substring: string, jobId: string, stepName: string }[]} */
+  const matches = [];
+
+  for (const substring of requiredSubstrings) {
+    const hit = active.find((step) =>
+      step.values.some((v) => v.includes(substring)),
+    );
+    if (!hit) {
+      missing.push(substring);
+    } else {
+      matches.push({
+        substring,
+        jobId: hit.jobId,
+        stepName: hit.name,
+      });
+    }
+  }
+  return { ok: missing.length === 0, missing, matches };
+}
+
+/**
+ * Remove every step whose run/uses contains substring; return new YAML text.
+ * (A substring may appear in more than one job/step — e.g. frontend + backend
+ * `npm run typecheck` — so sabotage must clear all matches.)
+ * @param {string} workflowText
+ * @param {string} substring
+ * @returns {{ text: string, removed: boolean }}
+ */
+export function removeStepContaining(workflowText, substring) {
+  const doc = parseYaml(workflowText);
+  if (!doc || typeof doc !== "object" || !("jobs" in doc)) {
+    return { text: workflowText, removed: false };
+  }
+  const jobs = /** @type {Record<string, { steps?: unknown[] }>} */ (doc).jobs;
+  let removed = false;
+  for (const job of Object.values(jobs || {})) {
+    if (!job || !Array.isArray(job.steps)) continue;
+    const next = job.steps.filter((step) => {
+      if (!step || typeof step !== "object") return true;
+      const s = /** @type {Record<string, unknown>} */ (step);
+      const run = typeof s.run === "string" ? s.run : "";
+      const uses = typeof s.uses === "string" ? s.uses : "";
+      const hit = run.includes(substring) || uses.includes(substring);
+      if (hit) removed = true;
+      return !hit;
+    });
+    job.steps = next;
+  }
+  return { text: stringifyYaml(doc), removed };
+}
+
+/**
+ * @param {string} manifestPath
+ * @returns {string[]}
+ */
+export function loadRequiredSubstrings(manifestPath) {
+  const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (!Array.isArray(raw.requiredSubstrings)) {
+    throw new Error("manifest missing requiredSubstrings array");
+  }
+  return raw.requiredSubstrings.map(String);
+}
+
+function main(argv) {
+  const mode = argv[0] || "check";
+  const workflowPath = process.env.CI_STEP_PRESENCE_WORKFLOW;
+  const manifestPath = process.env.CI_STEP_PRESENCE_MANIFEST;
+  if (!workflowPath || !manifestPath) {
+    console.error(
+      "ERROR: CI_STEP_PRESENCE_WORKFLOW and CI_STEP_PRESENCE_MANIFEST required",
+    );
+    process.exit(EXIT_CANNOT_RUN);
+  }
+
+  let required;
+  let workflowText;
+  try {
+    required = loadRequiredSubstrings(manifestPath);
+    workflowText = readFileSync(workflowPath, "utf8");
+  } catch (err) {
+    console.error(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(EXIT_CANNOT_RUN);
+  }
+
+  if (mode === "check") {
+    let result;
+    try {
+      result = checkRequiredPresent(workflowText, required);
+    } catch (err) {
+      console.error(
+        `ERROR: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(EXIT_CANNOT_RUN);
+    }
+    for (const m of result.matches) {
+      console.log(
+        `  present: ${m.substring}  (job=${m.jobId} step="${m.stepName}")`,
+      );
+    }
+    for (const miss of result.missing) {
+      console.error(`[check] MISSING required step substring: ${miss}`);
+    }
+    process.exit(result.ok ? EXIT_OK : EXIT_PROPERTY);
+  }
+
+  if (mode === "sabotage-all") {
+    // Phase-2 exhaustive: each entry removed in turn must make check fail.
+    for (const substring of required) {
+      const { text, removed } = removeStepContaining(workflowText, substring);
+      if (!removed) {
+        console.error(
+          `FAIL: could not remove step containing ${substring} from parsed workflow`,
+        );
+        process.exit(EXIT_PROPERTY);
+      }
+      const tmp = path.join(
+        tmpdir(),
+        `ci-step-sabotage-${Date.now()}-${Math.random().toString(36).slice(2)}.yml`,
+      );
+      try {
+        writeFileSync(tmp, text, "utf8");
+        const result = checkRequiredPresent(text, required);
+        if (result.ok) {
+          console.error(
+            `FAIL: after removing "${substring}", check still passed — guard has no teeth`,
+          );
+          process.exit(EXIT_PROPERTY);
+        }
+        if (!result.missing.includes(substring)) {
+          console.error(
+            `FAIL: after removing "${substring}", missing list did not name it: ${result.missing.join(", ")}`,
+          );
+          process.exit(EXIT_PROPERTY);
+        }
+        console.log(`  sabotage OK: removed "${substring}" → missing detected`);
+      } finally {
+        try {
+          unlinkSync(tmp);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    console.log(
+      `PASS: exhaustive sabotage — ${required.length} manifest entries falsified`,
+    );
+    process.exit(EXIT_OK);
+  }
+
+  console.error(`ERROR: unknown mode ${mode}`);
+  process.exit(EXIT_CANNOT_RUN);
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  main(process.argv.slice(2));
+}

--- a/scripts/verify-ci-step-presence.sh
+++ b/scripts/verify-ci-step-presence.sh
@@ -2,9 +2,12 @@
 # verify-ci-step-presence.sh — Two-phase proof that required CI steps remain
 # invoked in ci-cd.yml (W-11 / G-205).
 #
-# Phase 1 (healthy): parse the real workflow; every manifest substring must appear.
-# Phase 2 (sabotage): copy the workflow, delete one required invocation, re-run
-#   against the copy, require non-zero.
+# Matches against *active* workflow commands (parsed YAML jobs.*.steps[]),
+# not raw file text — a commented-out `run:` line must not count as present.
+#
+# Phase 1 (healthy): every manifest substring must appear in an active run:/uses:.
+# Phase 2 (sabotage): for each manifest entry, remove that step from the parsed
+#   document and require the check to fail (exhaustive falsification).
 #
 # Exit 0 = both phases OK.
 # Exit 1 = property false (missing step / sabotage did not fail).
@@ -17,6 +20,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # U1-04: injectable paths for unit tests (default = production locations).
 MANIFEST="${CI_STEP_PRESENCE_MANIFEST:-$SCRIPT_DIR/ci-required-steps.json}"
 WORKFLOW="${CI_STEP_PRESENCE_WORKFLOW:-$REPO_ROOT/.github/workflows/ci-cd.yml}"
+CORE="$SCRIPT_DIR/verify-ci-step-presence-core.mjs"
 
 if [[ ! -f "$MANIFEST" ]]; then
   echo "ERROR: missing manifest $MANIFEST" >&2
@@ -26,65 +30,42 @@ if [[ ! -f "$WORKFLOW" ]]; then
   echo "ERROR: missing workflow $WORKFLOW" >&2
   exit 2
 fi
+if [[ ! -f "$CORE" ]]; then
+  echo "ERROR: missing core module $CORE" >&2
+  exit 2
+fi
 if ! command -v node >/dev/null 2>&1; then
-  echo "ERROR: node is required to parse the manifest" >&2
+  echo "ERROR: node is required to parse the workflow YAML" >&2
   exit 2
 fi
 
-# Read required substrings from JSON via node (no jq dependency).
-mapfile -t REQUIRED < <(node -e '
-  const m = require(process.argv[1]);
-  for (const s of m.requiredSubstrings) process.stdout.write(s + "\n");
-' "$MANIFEST")
-
-check_workflow() {
-  local file="$1"
-  local label="$2"
-  local missing=0
-  local s
-  for s in "${REQUIRED[@]}"; do
-    if ! grep -Fq -- "$s" "$file"; then
-      echo "[$label] MISSING required step substring: $s" >&2
-      missing=1
-    fi
-  done
-  return "$missing"
-}
+export CI_STEP_PRESENCE_MANIFEST="$MANIFEST"
+export CI_STEP_PRESENCE_WORKFLOW="$WORKFLOW"
 
 echo "[verify-ci-step-presence] Phase 1/2 — healthy workflow (expect PASS)…"
-if ! check_workflow "$WORKFLOW" "healthy"; then
-  echo "FAIL: healthy workflow is missing required step(s)." >&2
-  exit 1
+set +e
+node "$CORE" check
+phase1=$?
+set -e
+if [[ "$phase1" -ne 0 ]]; then
+  echo "FAIL: healthy workflow is missing required step(s) (or could not check)." >&2
+  exit "$phase1"
 fi
 echo "[verify-ci-step-presence] Healthy workflow PASS."
 
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
-cp "$WORKFLOW" "$TMP"
-
-# Sabotage: remove the prisma-drift invocation line (G-205 exemplar).
-# Use a portable sed-free approach via node.
-node -e '
-  const fs = require("fs");
-  const p = process.argv[1];
-  let t = fs.readFileSync(p, "utf8");
-  const next = t.split(/\r?\n/).filter((line) => !line.includes("check-prisma-drift.sh")).join("\n");
-  if (next === t) {
-    console.error("sabotage failed: check-prisma-drift.sh line not found");
-    process.exit(2);
-  }
-  fs.writeFileSync(p, next);
-' "$TMP"
-
-echo "[verify-ci-step-presence] Phase 2/2 — sabotaged copy missing drift invocation (expect FAIL)…"
-if check_workflow "$TMP" "sabotage"; then
-  echo "FAIL: sabotaged workflow still passed — guard has no teeth." >&2
-  exit 1
+echo "[verify-ci-step-presence] Phase 2/2 — exhaustive sabotage per manifest entry (expect each FAIL)…"
+set +e
+node "$CORE" sabotage-all
+phase2=$?
+set -e
+if [[ "$phase2" -ne 0 ]]; then
+  echo "FAIL: exhaustive sabotage phase did not prove every entry." >&2
+  exit "$phase2"
 fi
 
 echo "============================================================"
 echo "  PASS: CI step-presence guard has teeth."
-echo "  Healthy:   all required substrings present"
-echo "  Sabotaged: missing check-prisma-drift.sh detected"
+echo "  Healthy:   all required substrings present in active steps"
+echo "  Sabotaged: every manifest entry falsified via YAML parse"
 echo "============================================================"
 exit 0

--- a/scripts/verify-ci-step-presence.sh
+++ b/scripts/verify-ci-step-presence.sh
@@ -6,8 +6,9 @@
 # not raw file text — a commented-out `run:` line must not count as present.
 #
 # Phase 1 (healthy): every manifest substring must appear in an active run:/uses:.
-# Phase 2 (sabotage): for each manifest entry, remove that step from the parsed
-#   document and require the check to fail (exhaustive falsification).
+# Phase 2 (sabotage): for EACH manifest entry, remove matching steps from the
+#   parsed document and require failure (exhaustive — always on in CI; not
+#   gated behind --exhaustive).
 #
 # Exit 0 = both phases OK.
 # Exit 1 = property false (missing step / sabotage did not fail).

--- a/scripts/verify-ci-step-presence.sh
+++ b/scripts/verify-ci-step-presence.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# verify-ci-step-presence.sh — Two-phase proof that required CI steps remain
+# invoked in ci-cd.yml (W-11 / G-205).
+#
+# Phase 1 (healthy): parse the real workflow; every manifest substring must appear.
+# Phase 2 (sabotage): copy the workflow, delete one required invocation, re-run
+#   against the copy, require non-zero.
+#
+# Exit 0 = both phases OK.
+# Exit 1 = property false (missing step / sabotage did not fail).
+# Exit 2 = could not run (missing files / bash tools).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MANIFEST="$SCRIPT_DIR/ci-required-steps.json"
+WORKFLOW="$REPO_ROOT/.github/workflows/ci-cd.yml"
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "ERROR: missing manifest $MANIFEST" >&2
+  exit 2
+fi
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "ERROR: missing workflow $WORKFLOW" >&2
+  exit 2
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: node is required to parse the manifest" >&2
+  exit 2
+fi
+
+# Read required substrings from JSON via node (no jq dependency).
+mapfile -t REQUIRED < <(node -e '
+  const m = require(process.argv[1]);
+  for (const s of m.requiredSubstrings) process.stdout.write(s + "\n");
+' "$MANIFEST")
+
+check_workflow() {
+  local file="$1"
+  local label="$2"
+  local missing=0
+  local s
+  for s in "${REQUIRED[@]}"; do
+    if ! grep -Fq -- "$s" "$file"; then
+      echo "[$label] MISSING required step substring: $s" >&2
+      missing=1
+    fi
+  done
+  return "$missing"
+}
+
+echo "[verify-ci-step-presence] Phase 1/2 — healthy workflow (expect PASS)…"
+if ! check_workflow "$WORKFLOW" "healthy"; then
+  echo "FAIL: healthy workflow is missing required step(s)." >&2
+  exit 1
+fi
+echo "[verify-ci-step-presence] Healthy workflow PASS."
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+cp "$WORKFLOW" "$TMP"
+
+# Sabotage: remove the prisma-drift invocation line (G-205 exemplar).
+# Use a portable sed-free approach via node.
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1];
+  let t = fs.readFileSync(p, "utf8");
+  const next = t.split(/\r?\n/).filter((line) => !line.includes("check-prisma-drift.sh")).join("\n");
+  if (next === t) {
+    console.error("sabotage failed: check-prisma-drift.sh line not found");
+    process.exit(2);
+  }
+  fs.writeFileSync(p, next);
+' "$TMP"
+
+echo "[verify-ci-step-presence] Phase 2/2 — sabotaged copy missing drift invocation (expect FAIL)…"
+if check_workflow "$TMP" "sabotage"; then
+  echo "FAIL: sabotaged workflow still passed — guard has no teeth." >&2
+  exit 1
+fi
+
+echo "============================================================"
+echo "  PASS: CI step-presence guard has teeth."
+echo "  Healthy:   all required substrings present"
+echo "  Sabotaged: missing check-prisma-drift.sh detected"
+echo "============================================================"
+exit 0

--- a/scripts/verify-ci-step-presence.sh
+++ b/scripts/verify-ci-step-presence.sh
@@ -14,8 +14,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-MANIFEST="$SCRIPT_DIR/ci-required-steps.json"
-WORKFLOW="$REPO_ROOT/.github/workflows/ci-cd.yml"
+# U1-04: injectable paths for unit tests (default = production locations).
+MANIFEST="${CI_STEP_PRESENCE_MANIFEST:-$SCRIPT_DIR/ci-required-steps.json}"
+WORKFLOW="${CI_STEP_PRESENCE_WORKFLOW:-$REPO_ROOT/.github/workflows/ci-cd.yml}"
 
 if [[ ! -f "$MANIFEST" ]]; then
   echo "ERROR: missing manifest $MANIFEST" >&2

--- a/scripts/verify-parity-selfcheck.mjs
+++ b/scripts/verify-parity-selfcheck.mjs
@@ -1,0 +1,59 @@
+/**
+ * Two-phase proof that verify-parity fails when a step fails (§5.5.2).
+ * Phase 1: run a known-green subset (CI-06 drift) and require exit 0.
+ * Phase 2: --inject-fail that step and require non-zero.
+ * Exit 1 = proof failed; exit 2 = could not run.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const parity = path.join(repoRoot, "scripts", "verify-parity.mjs");
+
+function run(args) {
+  return spawnSync(process.execPath, [parity, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
+console.log(
+  "[parity-selfcheck] Phase 1/2 — healthy subset (CI-06) expect exit 0…",
+);
+const healthy = run(["--only", "CI-06", "--skip-install"]);
+process.stdout.write(healthy.stdout ?? "");
+process.stderr.write(healthy.stderr ?? "");
+if (healthy.status !== 0) {
+  console.error(
+    `FAIL: healthy phase exited ${healthy.status} (expected 0). Cannot prove sabotage causality.`,
+  );
+  process.exit(1);
+}
+console.log("[parity-selfcheck] Healthy phase GREEN.");
+
+console.log(
+  "[parity-selfcheck] Phase 2/2 — inject-fail CI-06 expect non-zero…",
+);
+const sabotaged = run([
+  "--only",
+  "CI-06",
+  "--skip-install",
+  "--inject-fail",
+  "CI-06",
+]);
+process.stdout.write(sabotaged.stdout ?? "");
+process.stderr.write(sabotaged.stderr ?? "");
+if (sabotaged.status === 0) {
+  console.error("FAIL: sabotaged phase exited 0 — parity runner has no teeth.");
+  process.exit(1);
+}
+
+console.log("============================================================");
+console.log("  PASS: parity selfcheck has teeth.");
+console.log(`  Healthy:   exit=${healthy.status}`);
+console.log(`  Sabotaged: exit=${sabotaged.status}`);
+console.log("============================================================");
+process.exit(0);

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -39,6 +39,7 @@ function resolveCmd(cmd) {
  *   required?: boolean,
  *   kind?: 'run' | 'not-local',
  *   skipIf?: () => string | null,
+ *   env?: Record<string, string | undefined>,
  * }} Step
  */
 
@@ -125,6 +126,9 @@ export const STEPS = [
     name: "CI shell gate",
     argv: ["npm", "run", "verify:ci-gate"],
     required: true,
+    // Gate boots Vite on hardcoded :5173 (same as CI). Unset remapped
+    // CYPRESS_SWA_URL so Cypress hits the gate's server (remember.md §8 #19).
+    env: { CYPRESS_SWA_URL: undefined },
   },
   {
     id: "CI-10",
@@ -244,6 +248,9 @@ Documented setup (from repo root):
 Then:
   npm run verify -- --skip-install
   # env-dependent / out-of-scope steps SKIP; use --allow-skips for exit 0
+  # If CYPRESS_SWA_URL points at a remapped FE, that server must be listening
+  # or unset the var so CI-10/11/12 SKIP. CI-23 unsets remapped URL itself
+  # (shell gate uses CI's :5173).
 
 Skip contract:
   Required SKIP without --allow-skips → exit 1 (never silent green).
@@ -275,9 +282,16 @@ export function runCommand(argv, opts = {}) {
     // npm/npx/bare bash need shell resolution on Windows; an absolute BB_BASH path must not
     // go through shell:true (spaces in "Program Files" break unquoted spawn).
     const needsShell = cmd === "npm" || cmd === "npx" || cmd === "bash";
+    const childEnv = { ...process.env, ...(opts.env || {}) };
+    // Explicit undefined in opts.env means "unset" (cannot rely on spread alone).
+    if (opts.env) {
+      for (const [k, v] of Object.entries(opts.env)) {
+        if (v === undefined) delete childEnv[k];
+      }
+    }
     const child = spawn(cmd, args, {
       cwd: opts.cwd ? path.join(REPO_ROOT, opts.cwd) : REPO_ROOT,
-      env: { ...process.env, ...opts.env },
+      env: childEnv,
       shell: needsShell,
       windowsHide: true,
     });
@@ -388,7 +402,10 @@ export async function runParity(steps, opts) {
 
     console.log(`[RUN] ${step.id} ${step.name}`);
     console.log(`command: ${cmdStr}`);
-    const { code, output } = await runCommand(step.argv, { cwd: step.cwd });
+    const { code, output } = await runCommand(step.argv, {
+      cwd: step.cwd,
+      env: step.env,
+    });
     if (code !== 0) {
       console.log(`[FAIL] ${step.id} ${step.name}`);
       console.log(`command: ${cmdStr}`);

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -8,7 +8,6 @@
  * Ports from env only (G-007). No && chaining (G-013).
  */
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { config as loadEnv } from "dotenv";
@@ -44,7 +43,8 @@ function resolveCmd(cmd) {
  */
 
 /**
- * CI order: build-and-test (with CI-23 after unit tests), then db-check, then extras.
+ * CI order mirrors ci-cd.yml: build-and-test (drift → CI-24/25 → installs →
+ * tests → CI-23 → smoke → build), then db-check, then extras (bundle / format).
  * @type {Step[]}
  */
 export const STEPS = [
@@ -84,6 +84,18 @@ export const STEPS = [
     id: "CI-06",
     name: "Prisma schema drift",
     argv: ["bash", "scripts/check-prisma-drift.sh"],
+    required: true,
+  },
+  {
+    id: "CI-24",
+    name: "Required-step presence",
+    argv: ["bash", "scripts/verify-ci-step-presence.sh"],
+    required: true,
+  },
+  {
+    id: "CI-25",
+    name: "Type-program membership",
+    argv: ["node", "scripts/verify-type-program-membership.mjs"],
     required: true,
   },
   {
@@ -203,28 +215,6 @@ export const STEPS = [
     argv: [],
     kind: "not-local",
     required: false,
-  },
-  {
-    id: "CI-24",
-    name: "Required-step presence",
-    argv: ["bash", "scripts/verify-ci-step-presence.sh"],
-    required: true,
-    skipIf: () =>
-      existsSync(path.join(REPO_ROOT, "scripts/verify-ci-step-presence.sh"))
-        ? null
-        : "scripts/verify-ci-step-presence.sh not present yet (A7-04)",
-  },
-  {
-    id: "CI-25",
-    name: "Type-program membership",
-    argv: ["node", "scripts/verify-type-program-membership.mjs"],
-    required: true,
-    skipIf: () =>
-      existsSync(
-        path.join(REPO_ROOT, "scripts/verify-type-program-membership.mjs"),
-      )
-        ? null
-        : "scripts/verify-type-program-membership.mjs not present yet (A7-06)",
   },
   {
     id: "CI-26",

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -115,6 +115,10 @@ export const STEPS = [
     name: "Unit + Storybook tests",
     argv: ["npm", "test", "--", "--watch=false"],
     required: true,
+    skipIf: () =>
+      REPO_ROOT.includes(" ")
+        ? "checkout path contains a space — Storybook Vitest project owned by #707"
+        : null,
   },
   {
     id: "CI-23",
@@ -221,8 +225,43 @@ export const STEPS = [
     name: "Prettier format check",
     argv: ["npm", "run", "format:check"],
     required: true,
+    skipIf: () =>
+      "whole-tree format:check is a reverse gap (OQ-10); Prettier is enforced reject-only on staged files via husky — not mass-fixed in #740",
   },
 ];
+
+/**
+ * Documented local setup and skip contract (Bug E / nwalker review).
+ * Printed by `node scripts/verify-parity.mjs --help`.
+ */
+export const HELP_TEXT = `npm run verify — local–CI parity runner (#740)
+
+Documented setup (from repo root):
+  npm ci
+  cd backend && npm ci
+  # optional: npx prisma generate  (usually supplied by @prisma/client postinstall)
+
+Then:
+  npm run verify -- --skip-install
+  # env-dependent / out-of-scope steps SKIP; use --allow-skips for exit 0
+
+Skip contract:
+  Required SKIP without --allow-skips → exit 1 (never silent green).
+  Known local SKIPs (named + linked):
+    CI-09  spaced path → #707 Storybook Vitest
+    CI-10/11/12  CYPRESS_SWA_URL unset
+    CI-14/16  DATABASE_URL unset
+    CI-26  whole-tree Prettier reverse gap (OQ-10); hooks cover staged files
+  NOT-LOCAL: CI-21 deploy, CI-22 prod-smoke
+  Do not fix backend pre-existing tsc / Prisma gaps here (OQ-03 residual / B5-02).
+
+Flags:
+  --skip-install   omit CI-01/04/07/08
+  --allow-skips    treat required SKIPs as non-fatal
+  --only CI-0X     run a subset (comma-separated)
+  --inject-fail ID sabotage one step (parity-selfcheck)
+  --help           this text
+`;
 
 /**
  * @param {string[]} argv
@@ -380,6 +419,10 @@ const isMain =
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isMain) {
+  if (process.argv.slice(2).includes("--help")) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
   const opts = parseArgs(process.argv.slice(2));
   runParity(STEPS, opts).then((code) => {
     process.exit(code);

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -265,10 +265,47 @@ Skip contract:
 Flags:
   --skip-install   omit CI-01/04/07/08
   --allow-skips    treat required SKIPs as non-fatal
-  --only CI-0X     run a subset (comma-separated)
-  --inject-fail ID sabotage one step (parity-selfcheck)
+  --only CI-0X     run a subset (comma-separated; unknown/empty IDs → exit 2)
+  --inject-fail ID sabotage one step (parity-selfcheck; unknown ID → exit 2)
   --help           this text
 `;
+
+/**
+ * @typedef {{
+ *   allowSkips: boolean,
+ *   only: string[] | null,
+ *   injectFail: string | null,
+ *   skipInstall: boolean,
+ *   usageError: string | null,
+ * }} ParsedArgs
+ */
+
+/**
+ * Parse a comma-separated ID list flag (`--only`, future selectors).
+ * Missing value, flag-as-value, or empty/whitespace entries → usageError.
+ * @param {string[]} argvCli
+ * @param {string} flag
+ * @returns {{ values: string[] | null, usageError: string | null }}
+ */
+export function parseIdListFlag(argvCli, flag) {
+  const idx = argvCli.indexOf(flag);
+  if (idx < 0) return { values: null, usageError: null };
+  const raw = argvCli[idx + 1];
+  if (raw === undefined || raw.startsWith("--")) {
+    return {
+      values: null,
+      usageError: `${flag} requires a comma-separated list of step IDs`,
+    };
+  }
+  const parts = raw.split(",").map((s) => s.trim());
+  if (parts.length === 0 || parts.some((p) => !p)) {
+    return {
+      values: null,
+      usageError: `${flag} contains an empty step ID (check commas / quotes)`,
+    };
+  }
+  return { values: parts, usageError: null };
+}
 
 /**
  * @param {string[]} argv
@@ -320,32 +357,76 @@ export function runCommand(argv, opts = {}) {
 
 /**
  * @param {string[]} argvCli
+ * @returns {ParsedArgs}
  */
 export function parseArgs(argvCli) {
   const allowSkips = argvCli.includes("--allow-skips");
-  const onlyIdx = argvCli.indexOf("--only");
-  const only =
-    onlyIdx >= 0 && argvCli[onlyIdx + 1]
-      ? argvCli[onlyIdx + 1].split(",").map((s) => s.trim())
-      : null;
-  const injectIdx = argvCli.indexOf("--inject-fail");
-  const injectFail =
-    injectIdx >= 0 && argvCli[injectIdx + 1]
-      ? argvCli[injectIdx + 1].trim()
-      : null;
   const skipInstall = argvCli.includes("--skip-install");
-  return { allowSkips, only, injectFail, skipInstall };
+
+  const onlyParsed = parseIdListFlag(argvCli, "--only");
+  let usageError = onlyParsed.usageError;
+  const only = onlyParsed.values;
+
+  const injectIdx = argvCli.indexOf("--inject-fail");
+  let injectFail = null;
+  if (injectIdx >= 0) {
+    const raw = argvCli[injectIdx + 1];
+    if (raw === undefined || raw.startsWith("--")) {
+      usageError =
+        usageError ?? "--inject-fail requires a step ID (e.g. CI-06)";
+    } else if (!raw.trim()) {
+      usageError = usageError ?? "--inject-fail requires a non-empty step ID";
+    } else {
+      injectFail = raw.trim();
+    }
+  }
+
+  return { allowSkips, only, injectFail, skipInstall, usageError };
 }
 
 /**
+ * Validate selection flags against the step registry.
+ * Unknown IDs → exit 2 (usage); do not run a partial selection.
  * @param {Step[]} steps
- * @param {ReturnType<typeof parseArgs>} opts
+ * @param {ParsedArgs} opts
+ * @returns {{ ok: true } | { ok: false, code: number, message: string }}
  */
-export async function runParity(steps, opts) {
-  let failed = false;
-  let skippedRequired = false;
+export function validateStepSelection(steps, opts) {
+  if (opts.usageError) {
+    return { ok: false, code: 2, message: opts.usageError };
+  }
+  const validIds = steps.map((s) => s.id);
+  const validList = validIds.join(", ");
 
-  const selected = steps.filter((step) => {
+  if (opts.only) {
+    const unknown = opts.only.filter((id) => !validIds.includes(id));
+    if (unknown.length > 0) {
+      return {
+        ok: false,
+        code: 2,
+        message: `Unknown step ID(s): ${unknown.join(", ")}. Valid IDs: ${validList}`,
+      };
+    }
+  }
+
+  if (opts.injectFail && !validIds.includes(opts.injectFail)) {
+    return {
+      ok: false,
+      code: 2,
+      message: `Unknown step ID for --inject-fail: ${opts.injectFail}. Valid IDs: ${validList}`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Filter steps by --only / --skip-install (and any future selectors).
+ * @param {Step[]} steps
+ * @param {ParsedArgs} opts
+ */
+export function selectSteps(steps, opts) {
+  return steps.filter((step) => {
     if (opts.only && !opts.only.includes(step.id)) return false;
     if (
       opts.skipInstall &&
@@ -358,6 +439,36 @@ export async function runParity(steps, opts) {
     }
     return true;
   });
+}
+
+/**
+ * @param {Step[]} steps
+ * @param {ParsedArgs} opts
+ */
+export async function runParity(steps, opts) {
+  let failed = false;
+  let skippedRequired = false;
+
+  const selection = validateStepSelection(steps, opts);
+  if (!selection.ok) {
+    console.error(selection.message);
+    return selection.code;
+  }
+
+  const selected = selectSteps(steps, opts);
+
+  if (opts.only || opts.skipInstall) {
+    const ids = selected.map((s) => s.id).join(", ") || "(none)";
+    console.log(`Selected ${selected.length} of ${steps.length} steps: ${ids}`);
+  }
+
+  // Terminal invariant: a narrowing filter must never silently verify nothing.
+  if (selected.length === 0) {
+    console.error(
+      "No steps selected after filtering. Refusing to exit 0 with an empty run.",
+    );
+    return 1;
+  }
 
   // Rebuild wait-on argv with live env (STEPS is evaluated at import time).
   const liveSteps = selected.map((step) => {

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -1,0 +1,397 @@
+/**
+ * Local–CI parity runner (§5.5).
+ * Single source of truth for step order: export `STEPS`.
+ * Exit 1 = a required step failed or was skipped without --allow-skips.
+ * Exit 2 = could not run (bad args / unreadable config).
+ *
+ * Node ESM, no OS-conditional branches in the step list (G-004).
+ * Ports from env only (G-007). No && chaining (G-013).
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { config as loadEnv } from "dotenv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..");
+
+// Load git-ignored local env (ports, BB_BASH) without committing secrets (G-001).
+loadEnv({ path: path.join(REPO_ROOT, ".env.local") });
+loadEnv({ path: path.join(REPO_ROOT, ".env") });
+
+/**
+ * Resolve `bash` via BB_BASH when set (Windows Git Bash vs WSL alias). No hardcoded ports.
+ * @param {string} cmd
+ */
+function resolveCmd(cmd) {
+  if (cmd === "bash" && process.env.BB_BASH) {
+    return process.env.BB_BASH;
+  }
+  return cmd;
+}
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   name: string,
+ *   argv: string[],
+ *   cwd?: string,
+ *   required?: boolean,
+ *   kind?: 'run' | 'not-local',
+ *   skipIf?: () => string | null,
+ * }} Step
+ */
+
+/**
+ * CI order: build-and-test (with CI-23 after unit tests), then db-check, then extras.
+ * @type {Step[]}
+ */
+export const STEPS = [
+  {
+    id: "CI-01",
+    name: "Install root deps",
+    argv: ["npm", "ci"],
+    required: true,
+  },
+  {
+    id: "CI-02",
+    name: "Lint",
+    argv: ["npm", "run", "lint"],
+    required: true,
+  },
+  {
+    id: "CI-03",
+    name: "Typecheck frontend",
+    argv: ["npm", "run", "typecheck"],
+    required: true,
+  },
+  {
+    id: "CI-04",
+    name: "Install backend deps",
+    argv: ["npm", "ci"],
+    cwd: "backend",
+    required: true,
+  },
+  {
+    id: "CI-05",
+    name: "Typecheck backend",
+    argv: ["npm", "run", "typecheck"],
+    cwd: "backend",
+    required: true,
+  },
+  {
+    id: "CI-06",
+    name: "Prisma schema drift",
+    argv: ["bash", "scripts/check-prisma-drift.sh"],
+    required: true,
+  },
+  {
+    id: "CI-07",
+    name: "Cypress binary install",
+    argv: ["npx", "cypress", "install"],
+    required: true,
+  },
+  {
+    id: "CI-08",
+    name: "Playwright Chromium install",
+    argv: ["npx", "playwright", "install", "--with-deps", "chromium"],
+    required: true,
+  },
+  {
+    id: "CI-09",
+    name: "Unit + Storybook tests",
+    argv: ["npm", "test", "--", "--watch=false"],
+    required: true,
+  },
+  {
+    id: "CI-23",
+    name: "CI shell gate",
+    argv: ["npm", "run", "verify:ci-gate"],
+    required: true,
+  },
+  {
+    id: "CI-10",
+    name: "Dev server up (external or remapped)",
+    argv: [
+      "node",
+      "-e",
+      "console.log('CI-10: expect FE already listening at CYPRESS_SWA_URL')",
+    ],
+    required: true,
+    skipIf: () => {
+      if (!process.env.CYPRESS_SWA_URL) {
+        return "CYPRESS_SWA_URL unset — start FE (workspace port-remap) and set env (G-007)";
+      }
+      return null;
+    },
+  },
+  {
+    id: "CI-11",
+    name: "Wait for server",
+    argv: [
+      "npx",
+      "wait-on",
+      process.env.CYPRESS_SWA_URL || "env://CYPRESS_SWA_URL",
+      "--timeout",
+      "60000",
+    ],
+    required: true,
+    skipIf: () =>
+      process.env.CYPRESS_SWA_URL
+        ? null
+        : "CYPRESS_SWA_URL unset (G-007 — no hardcoded port)",
+  },
+  {
+    id: "CI-12",
+    name: "Cypress shell smoke",
+    argv: ["npm", "run", "test:e2e:ci"],
+    required: true,
+    skipIf: () =>
+      process.env.CYPRESS_SWA_URL
+        ? null
+        : "CYPRESS_SWA_URL unset (G-007 — no hardcoded port)",
+  },
+  {
+    id: "CI-13",
+    name: "Frontend build",
+    argv: ["npm", "run", "build"],
+    required: true,
+  },
+  {
+    id: "CI-14",
+    name: "Prisma migrate deploy",
+    argv: ["npx", "prisma", "migrate", "deploy"],
+    required: true,
+    skipIf: () =>
+      process.env.DATABASE_URL
+        ? null
+        : "DATABASE_URL unset (db-check not locally runnable)",
+  },
+  {
+    id: "CI-15",
+    name: "Prisma generate",
+    argv: ["npx", "prisma", "generate"],
+    required: true,
+  },
+  {
+    id: "CI-16",
+    name: "DB connectivity",
+    argv: ["npm", "run", "test:db"],
+    required: true,
+    skipIf: () =>
+      process.env.DATABASE_URL
+        ? null
+        : "DATABASE_URL unset (db-check not locally runnable)",
+  },
+  {
+    id: "CI-17",
+    name: "Bundle size budget",
+    argv: ["npm", "run", "check-bundle-size"],
+    required: true,
+  },
+  {
+    id: "CI-21",
+    name: "Deploy",
+    argv: [],
+    kind: "not-local",
+    required: false,
+  },
+  {
+    id: "CI-22",
+    name: "Production smoke",
+    argv: [],
+    kind: "not-local",
+    required: false,
+  },
+  {
+    id: "CI-24",
+    name: "Required-step presence",
+    argv: ["bash", "scripts/verify-ci-step-presence.sh"],
+    required: true,
+    skipIf: () =>
+      existsSync(path.join(REPO_ROOT, "scripts/verify-ci-step-presence.sh"))
+        ? null
+        : "scripts/verify-ci-step-presence.sh not present yet (A7-04)",
+  },
+  {
+    id: "CI-25",
+    name: "Type-program membership",
+    argv: ["node", "scripts/verify-type-program-membership.mjs"],
+    required: true,
+    skipIf: () =>
+      existsSync(
+        path.join(REPO_ROOT, "scripts/verify-type-program-membership.mjs"),
+      )
+        ? null
+        : "scripts/verify-type-program-membership.mjs not present yet (A7-06)",
+  },
+  {
+    id: "CI-26",
+    name: "Prettier format check",
+    argv: ["npm", "run", "format:check"],
+    required: true,
+  },
+];
+
+/**
+ * @param {string[]} argv
+ * @param {{ cwd?: string, env?: NodeJS.ProcessEnv }} [opts]
+ * @returns {Promise<{ code: number, output: string }>}
+ */
+export function runCommand(argv, opts = {}) {
+  return new Promise((resolve) => {
+    const [rawCmd, ...args] = argv;
+    const cmd = resolveCmd(rawCmd);
+    // npm/npx/bare bash need shell resolution on Windows; an absolute BB_BASH path must not
+    // go through shell:true (spaces in "Program Files" break unquoted spawn).
+    const needsShell = cmd === "npm" || cmd === "npx" || cmd === "bash";
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd ? path.join(REPO_ROOT, opts.cwd) : REPO_ROOT,
+      env: { ...process.env, ...opts.env },
+      shell: needsShell,
+      windowsHide: true,
+    });
+    let output = "";
+    child.stdout?.on("data", (chunk) => {
+      const text = String(chunk);
+      output += text;
+      process.stdout.write(text);
+    });
+    child.stderr?.on("data", (chunk) => {
+      const text = String(chunk);
+      output += text;
+      process.stderr.write(text);
+    });
+    child.on("error", (err) => {
+      const text = `spawn error: ${err.message}\n`;
+      output += text;
+      process.stderr.write(text);
+      resolve({ code: 2, output });
+    });
+    child.on("close", (code) => {
+      resolve({ code: code ?? 1, output });
+    });
+  });
+}
+
+/**
+ * @param {string[]} argvCli
+ */
+export function parseArgs(argvCli) {
+  const allowSkips = argvCli.includes("--allow-skips");
+  const onlyIdx = argvCli.indexOf("--only");
+  const only =
+    onlyIdx >= 0 && argvCli[onlyIdx + 1]
+      ? argvCli[onlyIdx + 1].split(",").map((s) => s.trim())
+      : null;
+  const injectIdx = argvCli.indexOf("--inject-fail");
+  const injectFail =
+    injectIdx >= 0 && argvCli[injectIdx + 1]
+      ? argvCli[injectIdx + 1].trim()
+      : null;
+  const skipInstall = argvCli.includes("--skip-install");
+  return { allowSkips, only, injectFail, skipInstall };
+}
+
+/**
+ * @param {Step[]} steps
+ * @param {ReturnType<typeof parseArgs>} opts
+ */
+export async function runParity(steps, opts) {
+  let failed = false;
+  let skippedRequired = false;
+
+  const selected = steps.filter((step) => {
+    if (opts.only && !opts.only.includes(step.id)) return false;
+    if (
+      opts.skipInstall &&
+      (step.id === "CI-01" ||
+        step.id === "CI-04" ||
+        step.id === "CI-07" ||
+        step.id === "CI-08")
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  // Rebuild wait-on argv with live env (STEPS is evaluated at import time).
+  const liveSteps = selected.map((step) => {
+    if (step.id !== "CI-11") return step;
+    const url = process.env.CYPRESS_SWA_URL;
+    if (!url) return step;
+    return {
+      ...step,
+      argv: ["npx", "wait-on", url, "--timeout", "60000"],
+    };
+  });
+
+  for (const step of liveSteps) {
+    const cmdStr =
+      step.kind === "not-local"
+        ? "(not locally reproducible)"
+        : step.argv.join(" ");
+
+    if (step.kind === "not-local") {
+      console.log(`[NOT-LOCAL] ${step.id} ${step.name}`);
+      continue;
+    }
+
+    const skipReason = step.skipIf?.() ?? null;
+    if (skipReason) {
+      console.log(`[SKIP] ${step.id} ${step.name} — ${skipReason}`);
+      if (step.required !== false) {
+        skippedRequired = true;
+      }
+      continue;
+    }
+
+    if (opts.injectFail === step.id) {
+      console.log(`[FAIL] ${step.id} ${step.name}`);
+      console.log(`command: ${cmdStr}`);
+      console.log(
+        `injected failure via --inject-fail ${step.id} (parity selfcheck sabotage)`,
+      );
+      failed = true;
+      break;
+    }
+
+    console.log(`[RUN] ${step.id} ${step.name}`);
+    console.log(`command: ${cmdStr}`);
+    const { code, output } = await runCommand(step.argv, { cwd: step.cwd });
+    if (code !== 0) {
+      console.log(`[FAIL] ${step.id} ${step.name}`);
+      console.log(`command: ${cmdStr}`);
+      console.log(`exit: ${code}`);
+      console.log("--- full output above (untruncated) ---");
+      if (!output) {
+        console.log("(no captured output)");
+      }
+      failed = true;
+      break;
+    }
+    console.log(`[PASS] ${step.id} ${step.name}`);
+  }
+
+  if (failed) return 1;
+  if (skippedRequired && !opts.allowSkips) {
+    console.log(
+      "Required step(s) were SKIPPED. Re-run with --allow-skips to treat skips as non-fatal, or provide the missing env.",
+    );
+    return 1;
+  }
+  console.log("Parity verify complete.");
+  return 0;
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const opts = parseArgs(process.argv.slice(2));
+  runParity(STEPS, opts).then((code) => {
+    process.exit(code);
+  });
+}

--- a/scripts/verify-parity.mjs
+++ b/scripts/verify-parity.mjs
@@ -183,10 +183,10 @@ export const STEPS = [
     name: "Prisma migrate deploy",
     argv: ["npx", "prisma", "migrate", "deploy"],
     required: true,
-    skipIf: () =>
-      process.env.DATABASE_URL
-        ? null
-        : "DATABASE_URL unset (db-check not locally runnable)",
+    skipIf: () => {
+      const gate = resolveParityDbGate();
+      return gate.action === "skip" ? gate.reason : null;
+    },
   },
   {
     id: "CI-15",
@@ -199,10 +199,10 @@ export const STEPS = [
     name: "DB connectivity",
     argv: ["npm", "run", "test:db"],
     required: true,
-    skipIf: () =>
-      process.env.DATABASE_URL
-        ? null
-        : "DATABASE_URL unset (db-check not locally runnable)",
+    skipIf: () => {
+      const gate = resolveParityDbGate();
+      return gate.action === "skip" ? gate.reason : null;
+    },
   },
   {
     id: "CI-17",
@@ -257,7 +257,7 @@ Skip contract:
   Known local SKIPs (named + linked):
     CI-09  spaced path → #707 Storybook Vitest
     CI-10/11/12  CYPRESS_SWA_URL unset
-    CI-14/16  DATABASE_URL unset
+    CI-14/16  TEST_DATABASE_URL unset
     CI-26  whole-tree Prettier reverse gap (OQ-10); hooks cover staged files
   NOT-LOCAL: CI-21 deploy, CI-22 prod-smoke
   Do not fix backend pre-existing tsc / Prisma gaps here (OQ-03 residual / B5-02).
@@ -268,7 +268,110 @@ Flags:
   --only CI-0X     run a subset (comma-separated; unknown/empty IDs → exit 2)
   --inject-fail ID sabotage one step (parity-selfcheck; unknown ID → exit 2)
   --help           this text
+
+DB safety (CI-14 / CI-16):
+  Requires TEST_DATABASE_URL (never falls back to DATABASE_URL).
+  Target must look designated (db name ~/test|e2e/i or host localhost/127.0.0.1).
+  Override: BB_ALLOW_NON_TEST_DB=1 (warns with host + database name only; never prints the URL).
 `;
+
+/**
+ * Host + database only — never echo credentials (parity logs are pasted into PRs).
+ * @param {string} url
+ * @returns {{ host: string, database: string } | null}
+ */
+export function describeDbUrl(url) {
+  try {
+    const u = new URL(url);
+    const database = decodeURIComponent(u.pathname.replace(/^\//, "")).split(
+      "/",
+    )[0];
+    return { host: u.hostname, database: database || "" };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Designated test DB: localhost / 127.0.0.1, or database name matching /test|e2e/i.
+ * @param {string} url
+ * @returns {{ ok: true, host: string, database: string } | { ok: false, reason: string, host?: string, database?: string }}
+ */
+export function isDesignatedTestDbUrl(url) {
+  const info = describeDbUrl(url);
+  if (!info) {
+    return { ok: false, reason: "TEST_DATABASE_URL is not a parseable URL" };
+  }
+  const hostOk = info.host === "localhost" || info.host === "127.0.0.1";
+  const nameOk = /test|e2e/i.test(info.database);
+  if (hostOk || nameOk) {
+    return { ok: true, host: info.host, database: info.database };
+  }
+  return {
+    ok: false,
+    reason: `TEST_DATABASE_URL is not a designated test target (host=${info.host}, database=${info.database}); require localhost/127.0.0.1 or a database name matching /test|e2e/i, or set BB_ALLOW_NON_TEST_DB=1`,
+    host: info.host,
+    database: info.database,
+  };
+}
+
+/**
+ * Pass the same designated URL to every DB variable the child steps read.
+ * @param {string} designatedUrl
+ */
+export function buildParityDbChildEnv(designatedUrl) {
+  return {
+    DATABASE_URL: designatedUrl,
+    TEST_DATABASE_URL: designatedUrl,
+    POSTGRES_URL: designatedUrl,
+  };
+}
+
+/**
+ * Gate CI-14 / CI-16 on an explicitly designated test database (G-002).
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ action: 'skip', reason: string } | { action: 'refuse', reason: string, host?: string, database?: string } | { action: 'run', env: Record<string, string>, host: string, database: string, warning: string | null }}
+ */
+export function resolveParityDbGate(env = process.env) {
+  const url = env.TEST_DATABASE_URL;
+  if (!url || !String(url).trim()) {
+    return {
+      action: "skip",
+      reason: "TEST_DATABASE_URL unset (db-check not locally runnable)",
+    };
+  }
+  const check = isDesignatedTestDbUrl(String(url).trim());
+  const allow = env.BB_ALLOW_NON_TEST_DB === "1";
+  if (!check.ok) {
+    // Unparseable URLs are never overridable — we cannot name the target safely.
+    if (!("host" in check) || check.host === undefined) {
+      return { action: "refuse", reason: check.reason };
+    }
+    if (!allow) {
+      return {
+        action: "refuse",
+        reason: check.reason,
+        host: check.host,
+        database: check.database,
+      };
+    }
+    const warning = `WARNING: BB_ALLOW_NON_TEST_DB=1 — proceeding against non-test DB host=${check.host} database=${check.database}`;
+    return {
+      action: "run",
+      env: buildParityDbChildEnv(String(url).trim()),
+      host: check.host,
+      database: check.database ?? "",
+      warning,
+    };
+  }
+  return {
+    action: "run",
+    env: buildParityDbChildEnv(String(url).trim()),
+    host: check.host,
+    database: check.database,
+    warning: null,
+  };
+}
 
 /**
  * @typedef {{
@@ -444,8 +547,10 @@ export function selectSteps(steps, opts) {
 /**
  * @param {Step[]} steps
  * @param {ParsedArgs} opts
+ * @param {{ runCommand?: typeof runCommand }} [deps]
  */
-export async function runParity(steps, opts) {
+export async function runParity(steps, opts, deps = {}) {
+  const run = deps.runCommand ?? runCommand;
   let failed = false;
   let skippedRequired = false;
 
@@ -501,6 +606,25 @@ export async function runParity(steps, opts) {
       continue;
     }
 
+    /** @type {Record<string, string | undefined> | undefined} */
+    let stepEnv = step.env;
+    if (step.id === "CI-14" || step.id === "CI-16") {
+      const gate = resolveParityDbGate();
+      if (gate.action === "refuse") {
+        console.log(`[FAIL] ${step.id} ${step.name}`);
+        console.log(`command: ${cmdStr}`);
+        console.error(gate.reason);
+        failed = true;
+        break;
+      }
+      if (gate.action === "run") {
+        if (gate.warning) {
+          console.warn(gate.warning);
+        }
+        stepEnv = { ...step.env, ...gate.env };
+      }
+    }
+
     if (opts.injectFail === step.id) {
       console.log(`[FAIL] ${step.id} ${step.name}`);
       console.log(`command: ${cmdStr}`);
@@ -513,9 +637,9 @@ export async function runParity(steps, opts) {
 
     console.log(`[RUN] ${step.id} ${step.name}`);
     console.log(`command: ${cmdStr}`);
-    const { code, output } = await runCommand(step.argv, {
+    const { code, output } = await run(step.argv, {
       cwd: step.cwd,
-      env: step.env,
+      env: stepEnv,
     });
     if (code !== 0) {
       console.log(`[FAIL] ${step.id} ${step.name}`);

--- a/scripts/verify-type-program-membership.mjs
+++ b/scripts/verify-type-program-membership.mjs
@@ -22,11 +22,34 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, "..");
-const MANIFEST = path.join(__dirname, "type-guard-manifest.json");
+export const REPO_ROOT = path.resolve(__dirname, "..");
+export const MANIFEST = path.join(__dirname, "type-guard-manifest.json");
 
-const EXIT_PROPERTY = 1;
-const EXIT_CANNOT_RUN = 2;
+export const EXIT_PROPERTY = 1;
+export const EXIT_CANNOT_RUN = 2;
+
+/** @param {string} listOutput @param {string} rel */
+export function normalizeRel(rel) {
+  return rel.replace(/\\/g, "/");
+}
+
+/** @param {string} listOutput @param {string} rel */
+export function isListed(listOutput, rel) {
+  return listOutput.replace(/\\/g, "/").includes(normalizeRel(rel));
+}
+
+/**
+ * @param {string} listOutput
+ * @param {string[]} files
+ * @returns {string[]} missing relative paths
+ */
+export function assertPresent(listOutput, files) {
+  const missing = [];
+  for (const rel of files) {
+    if (!isListed(listOutput, rel)) missing.push(rel);
+  }
+  return missing;
+}
 
 function failCannotRun(msg) {
   console.error(`ERROR: ${msg}`);
@@ -38,23 +61,13 @@ function failProperty(msg) {
   process.exit(EXIT_PROPERTY);
 }
 
-if (!existsSync(MANIFEST)) {
-  failCannotRun(`missing manifest ${MANIFEST}`);
-}
-
-const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
-const guardFiles = manifest.guardFiles;
-if (!Array.isArray(guardFiles) || guardFiles.length === 0) {
-  failCannotRun("type-guard-manifest.json has no guardFiles");
-}
-
-function listFiles() {
-  const tscJs = path.join(REPO_ROOT, "node_modules/typescript/bin/tsc");
+export function listFiles(repoRoot = REPO_ROOT) {
+  const tscJs = path.join(repoRoot, "node_modules/typescript/bin/tsc");
   const result = spawnSync(
     process.execPath,
     [tscJs, "--noEmit", "--listFiles"],
     {
-      cwd: REPO_ROOT,
+      cwd: repoRoot,
       encoding: "utf8",
       env: process.env,
     },
@@ -68,68 +81,71 @@ function listFiles() {
   return out.replace(/\\/g, "/");
 }
 
-function normalizeRel(rel) {
-  return rel.replace(/\\/g, "/");
-}
-
-function isListed(listOutput, rel) {
-  return listOutput.includes(normalizeRel(rel));
-}
-
-function assertPresent(listOutput, files, label) {
-  const missing = [];
-  for (const rel of files) {
-    if (!isListed(listOutput, rel)) missing.push(rel);
+export function runTypeProgramMembership() {
+  const manifestPath = process.env.TYPE_GUARD_MANIFEST || MANIFEST;
+  if (!existsSync(manifestPath)) {
+    failCannotRun(`missing manifest ${manifestPath}`);
   }
-  return missing;
-}
 
-console.log(
-  "[verify-type-program-membership] Phase 1/2 — healthy manifest files (expect present)…",
-);
-const list = listFiles();
-const healthyMissing = assertPresent(list, guardFiles, "healthy");
-if (healthyMissing.length > 0) {
-  failProperty(
-    `guard file(s) absent from tsc program: ${healthyMissing.join(", ")} (check tsconfig include/exclude)`,
-  );
-}
-for (const rel of guardFiles) {
-  console.log(`  present: ${rel}`);
-}
-console.log("[verify-type-program-membership] Healthy phase PASS.");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const guardFiles = manifest.guardFiles;
+  if (!Array.isArray(guardFiles) || guardFiles.length === 0) {
+    failCannotRun("type-guard-manifest.json has no guardFiles");
+  }
 
-// Sabotage: create a file under an excluded path and require it to be reported absent.
-const excludingPattern = "src/test (root tsconfig.json exclude)";
-const sabotageRel = "src/test/__type_guard_sabotage__.ts";
-const sabotageAbs = path.join(REPO_ROOT, sabotageRel);
-mkdirSync(path.dirname(sabotageAbs), { recursive: true });
-writeFileSync(
-  sabotageAbs,
-  "// intentional excluded-path probe for verify-type-program-membership\nexport {};\n",
-);
-
-try {
   console.log(
-    "[verify-type-program-membership] Phase 2/2 — excluded-path guard (expect ABSENT / non-zero)…",
+    "[verify-type-program-membership] Phase 1/2 — healthy manifest files (expect present)…",
   );
-  const list2 = listFiles();
-  if (isListed(list2, sabotageRel)) {
+  const list = listFiles();
+  const healthyMissing = assertPresent(list, guardFiles);
+  if (healthyMissing.length > 0) {
     failProperty(
-      `excluded guard unexpectedly present in tsc program: ${sabotageRel}`,
+      `guard file(s) absent from tsc program: ${healthyMissing.join(", ")} (check tsconfig include/exclude)`,
     );
   }
-  // Property under test: a guard placed where tsconfig excludes it is detected absent.
-  console.log(
-    `ABSENT (expected): ${sabotageRel} — excluding pattern: ${excludingPattern}`,
+  for (const rel of guardFiles) {
+    console.log(`  present: ${rel}`);
+  }
+  console.log("[verify-type-program-membership] Healthy phase PASS.");
+
+  const excludingPattern = "src/test (root tsconfig.json exclude)";
+  const sabotageRel = "src/test/__type_guard_sabotage__.ts";
+  const sabotageAbs = path.join(REPO_ROOT, sabotageRel);
+  mkdirSync(path.dirname(sabotageAbs), { recursive: true });
+  writeFileSync(
+    sabotageAbs,
+    "// intentional excluded-path probe for verify-type-program-membership\nexport {};\n",
   );
-  console.log("============================================================");
-  console.log("  PASS: type-program membership guard has teeth.");
-  console.log("  Healthy:   manifest files present in tsc --listFiles");
-  console.log(`  Sabotage:  ${sabotageRel} absent (${excludingPattern})`);
-  console.log("============================================================");
-} finally {
-  rmSync(sabotageAbs, { force: true });
+
+  try {
+    console.log(
+      "[verify-type-program-membership] Phase 2/2 — excluded-path guard (expect ABSENT / non-zero)…",
+    );
+    const list2 = listFiles();
+    if (isListed(list2, sabotageRel)) {
+      failProperty(
+        `excluded guard unexpectedly present in tsc program: ${sabotageRel}`,
+      );
+    }
+    console.log(
+      `ABSENT (expected): ${sabotageRel} — excluding pattern: ${excludingPattern}`,
+    );
+    console.log("============================================================");
+    console.log("  PASS: type-program membership guard has teeth.");
+    console.log("  Healthy:   manifest files present in tsc --listFiles");
+    console.log(`  Sabotage:  ${sabotageRel} absent (${excludingPattern})`);
+    console.log("============================================================");
+  } finally {
+    rmSync(sabotageAbs, { force: true });
+  }
+
+  process.exit(0);
 }
 
-process.exit(0);
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  runTypeProgramMembership();
+}

--- a/scripts/verify-type-program-membership.mjs
+++ b/scripts/verify-type-program-membership.mjs
@@ -120,7 +120,7 @@ try {
     );
   }
   // Property under test: a guard placed where tsconfig excludes it is detected absent.
-  console.error(
+  console.log(
     `ABSENT (expected): ${sabotageRel} — excluding pattern: ${excludingPattern}`,
   );
   console.log("============================================================");

--- a/scripts/verify-type-program-membership.mjs
+++ b/scripts/verify-type-program-membership.mjs
@@ -1,0 +1,135 @@
+/**
+ * verify-type-program-membership.mjs — Prove type-level guards are inside the
+ * root tsc program (W-12 / G-008 / §5.8).
+ *
+ * Phase 1 (healthy): `tsc --noEmit --listFiles` must list every manifest path.
+ * Phase 2 (sabotage): treat an excluded-path file as a required guard; require
+ *   non-zero naming the file and the excluding pattern.
+ *
+ * Exit 0 = both phases OK.
+ * Exit 1 = property false.
+ * Exit 2 = could not run.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const MANIFEST = path.join(__dirname, "type-guard-manifest.json");
+
+const EXIT_PROPERTY = 1;
+const EXIT_CANNOT_RUN = 2;
+
+function failCannotRun(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(EXIT_CANNOT_RUN);
+}
+
+function failProperty(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(EXIT_PROPERTY);
+}
+
+if (!existsSync(MANIFEST)) {
+  failCannotRun(`missing manifest ${MANIFEST}`);
+}
+
+const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+const guardFiles = manifest.guardFiles;
+if (!Array.isArray(guardFiles) || guardFiles.length === 0) {
+  failCannotRun("type-guard-manifest.json has no guardFiles");
+}
+
+function listFiles() {
+  const tscJs = path.join(REPO_ROOT, "node_modules/typescript/bin/tsc");
+  const result = spawnSync(
+    process.execPath,
+    [tscJs, "--noEmit", "--listFiles"],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: process.env,
+    },
+  );
+  const out = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  if (!out.trim()) {
+    failCannotRun(
+      `tsc --listFiles produced no output (status=${result.status})`,
+    );
+  }
+  return out.replace(/\\/g, "/");
+}
+
+function normalizeRel(rel) {
+  return rel.replace(/\\/g, "/");
+}
+
+function isListed(listOutput, rel) {
+  return listOutput.includes(normalizeRel(rel));
+}
+
+function assertPresent(listOutput, files, label) {
+  const missing = [];
+  for (const rel of files) {
+    if (!isListed(listOutput, rel)) missing.push(rel);
+  }
+  return missing;
+}
+
+console.log(
+  "[verify-type-program-membership] Phase 1/2 — healthy manifest files (expect present)…",
+);
+const list = listFiles();
+const healthyMissing = assertPresent(list, guardFiles, "healthy");
+if (healthyMissing.length > 0) {
+  failProperty(
+    `guard file(s) absent from tsc program: ${healthyMissing.join(", ")} (check tsconfig include/exclude)`,
+  );
+}
+for (const rel of guardFiles) {
+  console.log(`  present: ${rel}`);
+}
+console.log("[verify-type-program-membership] Healthy phase PASS.");
+
+// Sabotage: create a file under an excluded path and require it to be reported absent.
+const excludingPattern = "src/test (root tsconfig.json exclude)";
+const sabotageRel = "src/test/__type_guard_sabotage__.ts";
+const sabotageAbs = path.join(REPO_ROOT, sabotageRel);
+mkdirSync(path.dirname(sabotageAbs), { recursive: true });
+writeFileSync(
+  sabotageAbs,
+  "// intentional excluded-path probe for verify-type-program-membership\nexport {};\n",
+);
+
+try {
+  console.log(
+    "[verify-type-program-membership] Phase 2/2 — excluded-path guard (expect ABSENT / non-zero)…",
+  );
+  const list2 = listFiles();
+  if (isListed(list2, sabotageRel)) {
+    failProperty(
+      `excluded guard unexpectedly present in tsc program: ${sabotageRel}`,
+    );
+  }
+  // Property under test: a guard placed where tsconfig excludes it is detected absent.
+  console.error(
+    `ABSENT (expected): ${sabotageRel} — excluding pattern: ${excludingPattern}`,
+  );
+  console.log("============================================================");
+  console.log("  PASS: type-program membership guard has teeth.");
+  console.log("  Healthy:   manifest files present in tsc --listFiles");
+  console.log(`  Sabotage:  ${sabotageRel} absent (${excludingPattern})`);
+  console.log("============================================================");
+} finally {
+  rmSync(sabotageAbs, { force: true });
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds a local–CI parity runner (`npm run verify`), Husky commit hooks (Prettier reject-only on staged files + commitlint), and wires two-phase CI guards so green checks mean something: the existing shell-gate script now runs in CI, plus new step-presence and type-program membership verifiers.

**Review round 1:** A–E accepted.  
**Review round 2:** selection integrity (F), designated test DB for parity DB steps (G), one push for a complete PR-attached check rollup.

No user-facing product behavior changes.

Closes #740  
Refs #739 (parent), #738 (residual ACs only — not re-implemented here)

## What changed

**For architecture / CI reviewers**

- `scripts/verify-parity.mjs` + `npm run verify` / `verify:parity-selfcheck` — runs CI-mirrored steps in `ci-cd.yml` order; selfcheck is healthy-then-sabotage.
- `.github/workflows/ci-cd.yml` — wires `npm run verify:ci-gate`, step-presence, and type-program membership (with guardrail comments).
- `scripts/verify-ci-step-presence.sh` + `verify-ci-step-presence-core.mjs` + `scripts/ci-required-steps.json` — **YAML-parsed** active `run:`/`uses:` (not raw text); exhaustive per-entry sabotage.
- `scripts/verify-type-program-membership.mjs` + `scripts/type-guard-manifest.json` — registers real compile-time guard `dataDashAttrsExhaustiveness.ts` (+ `vite-env.d.ts` smoke entry).
- `.husky/pre-commit` / `.husky/commit-msg` — reject-only Prettier `--check` on staged files; commitlint.
- Unit tests under `scripts/__tests__/` — execute gates (exit codes); Bug A / F / G regressions.

**For experience reviewers**

- No UI, copy, or classroom-facing behavior changes.

**For the next implementer**

- After this lands (or from this tip), the Cypress E2E rebuild issue may branch from `jack/chore-740-parity-guards` so it appends to `ci-cd.yml`. Shared-engine spike (#730 / #743) remains parallel from `main` — no fixed review order between #742 and #743.

## Review fixes (round 1 — accepted)

**A — step-presence matched raw YAML text** — YAML-parsed active steps.  
**B — sabotage only proved one manifest entry** — exhaustive per-entry sabotage.  
**C — type manifest had no real guard** — `dataDashAttrsExhaustiveness.ts`.  
**D — pre-commit contract ambiguous** — reject-only documented.  
**E — verify scope undeclared** — SKIP / `--allow-skips` contract.

## Round 2 fixes

**F — `--only` could select zero steps and exit 0**  
Unknown / missing / empty / flag-as-value / partial-invalid `--only` → **exit 2** (names unknown IDs + valid list). Empty selection after filter → **exit 1**. Prints `Selected N of M steps: …`. All-SKIP selection (e.g. CI-26) → exit 1 without `--allow-skips`. Regression tests in `scripts/__tests__/verify-parity.test.ts` (spawn count / no `[RUN]` on refusal paths).

**G — CI-14/16 gated on `DATABASE_URL` while `test:db` uses `TEST_DATABASE_URL`**  
Gate on **`TEST_DATABASE_URL` only** (never fall back to ambient `DATABASE_URL`). Child env sets `DATABASE_URL` / `POSTGRES_URL` / `TEST_DATABASE_URL` to the same designated URL. Refuse non-test targets before spawn (host localhost/127.0.0.1 or db name `/test|e2e/i`); override `BB_ALLOW_NON_TEST_DB=1` with host+db warning only (URL redacted). Refusal-path tests assert **spawn count 0**.

**AI-use / environment-setup guide** — dropped for this round (not on #742; no separate docs PR).

**Check rollup**  
Single push after these fixes; confirm `build-only`, `build-and-test`, and `db-check` attach to the PR. (`ci-cd.yml` has no `concurrency: cancel-in-progress`.)

## How it was tested

Round 2 (parity selection + DB gate):

- `npx vitest run --project unit "scripts/__tests__/verify-parity.test.ts"` — **17** passed
- Evidence excerpts (verbatim):

```
# F — unknown ID
Unknown step ID(s): CI-99. Valid IDs: CI-01, CI-02, …

# F — empty selection / all SKIP
Selected 1 of 23 steps: CI-26
[SKIP] CI-26 …
Required step(s) were SKIPPED.

# G — production-shaped URL (zero spawns)
Selected 2 of 23 steps: CI-14, CI-16
[FAIL] CI-14 Prisma migrate deploy
TEST_DATABASE_URL is not a designated test target (host=db.prod.example.com, database=brightboost); …
```

Open question for Jack (not decided unilaterally): should a production-host denylist be **non**-overridable even with `BB_ALLOW_NON_TEST_DB=1`?

## What is explicitly NOT covered

- `docs/guards.md` / #738 residual
- OQ-03 / B5-02 backend tsc debt
- #707 Storybook spaced path
- #648 required status checks
- #730 / PR #743 shared-engine (parallel; no wait)
- Rewrites of `scripts/dbHealth.js`

## Notes for reviewers

- Round 1 A–E left intact.
- Required status checks still **not** enforced on `main` (#648).
- Pod: **Build** (Alice Lin). Re-request **nwalker** + **Alice Lin**.

## Prompt log

`prompts/2026-07-31-ticket-740-parity-guards.md`

