### PR TITLE
fix(test): skip Storybook Vitest project on spaced paths (#707)

### DIFF
--- a/docs/repro/707-spaced-path.md
+++ b/docs/repro/707-spaced-path.md
@@ -184,3 +184,37 @@ Distinguishable — not the §15.2 row-11 proxy.
 ### C3-04 — Parity handoff (#740)
 
 Do **not** edit `scripts/verify-parity.mjs` here. #740 PR #742 ships `npm run verify` / `verify-parity.mjs` but does **not** yet include `verify:storybook-empty-suite` (script lives on #707). Wire after merge/rebase: add step to STEPS + `package.json` when both land.
+
+---
+
+## Q4 — Independent QA (2026-07-31)
+
+### Q4-02 — W-05 RED before fix (commit order)
+
+| Commit | SHA                                        | Timestamp (−0700)   | Message                                                       |
+| ------ | ------------------------------------------ | ------------------- | ------------------------------------------------------------- |
+| RED    | `14ca9c143236b85eeb3bdbfca5438bcdb743f1c8` | 2026-07-31 02:50:25 | `docs(test): capture #707 Storybook spaced-path RED evidence` |
+| Fix    | `7230890df8f6a391e07f86f2845f57c16626c8d5` | 2026-07-31 02:53:21 | `fix(test): skip Storybook Vitest project on spaced paths`    |
+
+`git merge-base --is-ancestor 14ca9c14 7230890d` → **OK**. RED was captured before the fix.
+
+### Q4-03 — W-06 independent re-run
+
+Command: `npm run verify:storybook-empty-suite` → **GUARD_EXIT=0**
+
+| Phase      | Result                                                                              |
+| ---------- | ----------------------------------------------------------------------------------- |
+| 1 Healthy  | exit 0; `[vitest.workspace] Skipping Storybook project (#707): …`                   |
+| 2 Sabotage | exit 1; Vitest `No test files found`; no `InvalidStoriesEntryError`; no skip marker |
+
+`.storybook/main.ts` clean after run. Skip vs collapse still distinguishable (C3-03).
+
+### Q4-04 — A3-06 include branch (simulation)
+
+Method: `BB_VITEST_PATH_HAS_SPACE=0` + `npm test -- --watch=false --project storybook` (no relocate).
+
+- No named skip line
+- `|storybook (chromium)|` registered — 5 files attempted, 0 tests (`#29572` on spaced path — expected)
+- EXIT_CODE=1
+
+True space-free Storybook green remains CI’s path (H-3).

--- a/docs/repro/707-spaced-path.md
+++ b/docs/repro/707-spaced-path.md
@@ -1,0 +1,70 @@
+# #707 RED evidence — Storybook on a spaced path
+
+Captured **before** any `vitest.workspace.ts` fix (A3-02 / A3-03).
+
+| Field             | Value                                                                    |
+| ----------------- | ------------------------------------------------------------------------ |
+| Date              | 2026-07-31                                                               |
+| Clone             | `brightboost-707`                                                        |
+| Branch            | `jack/fix-707-storybook-spaced-path`                                     |
+| Base SHA          | `6cc86a19`                                                               |
+| Working path      | `D:/Programming Projects/Bright Bots/brightboost-707` (contains a space) |
+| Command           | `npm test -- --watch=false`                                              |
+| Process exit code | **1**                                                                    |
+
+## Storybook project (defect under test)
+
+Vitest registered the `storybook` project and attempted five story files. Each failed with Storybook/Vitest issue **#29572** (“No test suite found” when the workspace path contains spaces).
+
+| Metric                               | Value                                    |
+| ------------------------------------ | ---------------------------------------- |
+| Storybook files attempted            | 5                                        |
+| Storybook tests collected / executed | **0** (each file: “No test suite found”) |
+| Storybook suites failed              | 5                                        |
+| Overall process exit code            | 1                                        |
+
+Note: overview §1.1 described an empty suite reporting green. On this tip the Storybook project fails loudly (exit 1) with zero executable tests — still dishonest relative to CI (space-free paths run Storybook successfully), and still owned by the path-conditional skip in #707.
+
+Unrelated to #707 (do not fix here): `backend/tests/security.test.ts` also failed (`@prisma/client` not generated — OQ-03).
+
+## Verbatim Storybook failure output
+
+```
+ Vitest  No browser "instances" were defined for the "storybook" project. Running tests in "chromium" browser. The "browser.name" field is deprecated since Vitest 3. Read more: https://vitest.dev/guide/browser/config#browser-instances
+
+ RUN  v3.2.4 D:/Programming Projects/Bright Bots/brightboost-707
+
+⎯⎯⎯⎯⎯⎯ Failed Suites 6 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  |storybook (chromium)| src/components/AvatarPicker.stories.tsx [ src/components/AvatarPicker.stories.tsx ]
+Error: No test suite found in file D:/Programming Projects/Bright
+Bots/brightboost-707/src/components/AvatarPicker.stories.tsx
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/6]⎯
+
+ FAIL  |storybook (chromium)| src/stories/Button.stories.ts [ src/stories/Button.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Button.stories.ts
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/6]⎯
+
+ FAIL  |storybook (chromium)| src/stories/Header.stories.ts [ src/stories/Header.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Header.stories.ts
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/6]⎯
+
+ FAIL  |storybook (chromium)| src/stories/Page.stories.ts [ src/stories/Page.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Page.stories.ts
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/6]⎯
+
+ FAIL  |storybook (chromium)| src/pages/QuantumDemo.stories.tsx [ src/pages/QuantumDemo.stories.tsx ]
+Error: No test suite found in file D:/Programming Projects/Bright
+Bots/brightboost-707/src/pages/QuantumDemo.stories.tsx
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/6]⎯
+
+ FAIL  |unit| backend/tests/security.test.ts [ backend/tests/security.test.ts ]
+Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
+
+ Test Files  6 failed | 97 passed | 7 skipped (110)
+      Tests  577 passed | 20 skipped (597)
+   Start at  02:47:37
+   Duration  87.06s (transform 20.92s, setup 257.66s, collect 147.82s, tests 36.47s, environment 684.12s, prepare 123.79s)
+```
+
+EXIT_CODE=1

--- a/docs/repro/707-spaced-path.md
+++ b/docs/repro/707-spaced-path.md
@@ -136,3 +136,49 @@ Command: unset `BB_VITEST_PATH_HAS_SPACE`; `npm test -- --watch=false`
 EXIT_CODE=0
 
 No `|storybook|` project in the run. W-05 satisfied via **explicit named skip**.
+
+---
+
+## C3 — W-06 empty-suite guard (two-phase)
+
+Guard: `scripts/verify-storybook-empty-suite.mjs` · npm script `verify:storybook-empty-suite`.
+Storybook project sets `passWithNoTests: false` in `vitest.workspace.ts`.
+
+Command: `npm run verify:storybook-empty-suite` → **GUARD_EXIT=0** (2026-07-31)
+
+### C3-02 — Two-phase proof
+
+| Phase      | What ran                                                                       | Result                                                                   |
+| ---------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| 1 Healthy  | `BB_VITEST_PATH_HAS_SPACE=1 npm test -- --watch=false`                         | exit **0**; named skip line present                                      |
+| 2 Sabotage | Empty `.storybook/main.ts` `stories: []`, force-include, `--project storybook` | exit **1**; `InvalidStoriesEntryError` (empty stories array) — not green |
+
+Phase 1 excerpt:
+
+```
+[vitest.workspace] Skipping Storybook project (#707): checkout path contains a space (storybookjs/storybook#29572). Reason: path-conditional project skip.
+PASS phase 1: exit 0 with named Storybook skip
+```
+
+Phase 2 excerpt:
+
+```
+SB_CORE-COMMON_0004 (InvalidStoriesEntryError): Storybook could not index your stories.
+Your main configuration somehow does not contain a 'stories' field, or it resolved to an empty array.
+PASS phase 2: empty collection exited non-zero (status=1)
+```
+
+`.storybook/main.ts` restored after sabotage (finally).
+
+### C3-03 — Explicit skip vs silent collapse
+
+| Mode                 | Observable                                                                                                   | Exit      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | --------- | --------- | ------------- |
+| **Explicit skip**    | Prints `[vitest.workspace] Skipping Storybook project (#707):… Reason: path-conditional project skip.`; no ` | storybook | ` project | 0 (unit only) |
+| **Empty collection** | No skip marker; Storybook fails indexing empty `stories` / non-zero (cannot report green)                    | non-zero  |
+
+Distinguishable — not the §15.2 row-11 proxy.
+
+### C3-04 — Parity handoff (#740)
+
+Do **not** edit `scripts/verify-parity.mjs` here. #740 must add `npm run verify:storybook-empty-suite` to `npm run verify` and the §15.3.2 parity table.

--- a/docs/repro/707-spaced-path.md
+++ b/docs/repro/707-spaced-path.md
@@ -68,3 +68,71 @@ Error: @prisma/client did not initialize yet. Please run "prisma generate" and t
 ```
 
 EXIT_CODE=1
+
+---
+
+## C2 — Independent W-05 verification (after A3-04)
+
+Captured independently of A3-02 on tip with the path-conditional skip already present. Method: `BB_VITEST_PATH_HAS_SPACE` override (same seam as A3-06). `npx prisma generate` run first so unit red from OQ-03 does not obscure Storybook results.
+
+| Field        | Value                                                                    |
+| ------------ | ------------------------------------------------------------------------ |
+| Date         | 2026-07-31                                                               |
+| Tip SHA      | `7230890d` (fix commit present)                                          |
+| Working path | `D:/Programming Projects/Bright Bots/brightboost-707` (contains a space) |
+
+### C2-01 / C2-02 — Failing state (force-include Storybook)
+
+Command: `$env:BB_VITEST_PATH_HAS_SPACE='0'; npm test -- --watch=false`
+
+Storybook project re-registered on the spaced path and hit storybookjs/storybook#29572 again.
+
+| Metric                               | Value                                    |
+| ------------------------------------ | ---------------------------------------- |
+| Storybook files attempted            | 5                                        |
+| Storybook tests collected / executed | **0** (each file: “No test suite found”) |
+| Storybook suites failed              | 5                                        |
+| Process exit code                    | **1**                                    |
+
+```
+ FAIL  |storybook (chromium)| src/components/AvatarPicker.stories.tsx [ src/components/AvatarPicker.stories.tsx ]
+Error: No test suite found in file D:/Programming Projects/Bright
+Bots/brightboost-707/src/components/AvatarPicker.stories.tsx
+
+ FAIL  |storybook (chromium)| src/pages/QuantumDemo.stories.tsx [ src/pages/QuantumDemo.stories.tsx ]
+Error: No test suite found in file D:/Programming Projects/Bright
+Bots/brightboost-707/src/pages/QuantumDemo.stories.tsx
+
+ FAIL  |storybook (chromium)| src/stories/Button.stories.ts [ src/stories/Button.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Button.stories.ts
+
+ FAIL  |storybook (chromium)| src/stories/Header.stories.ts [ src/stories/Header.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Header.stories.ts
+
+ FAIL  |storybook (chromium)| src/stories/Page.stories.ts [ src/stories/Page.stories.ts ]
+Error: No test suite found in file D:/Programming Projects/Bright Bots/brightboost-707/src/stories/Page.stories.ts
+
+ Test Files  5 failed | 98 passed | 7 skipped (110)
+      Tests  581 passed | 20 skipped (601)
+```
+
+EXIT_CODE=1
+
+### C2-03 — Isolate space as the cause
+
+Force-include on this spaced checkout reproduces #29572 (above). The include branch is therefore exercised; failure is path-space, not “Playwright / Chromium / Storybook config missing.” True space-free success remains CI’s checkout path (A3-06). No clone relocate used.
+
+### C2-04 — Prove W-05 (explicit named skip)
+
+Command: unset `BB_VITEST_PATH_HAS_SPACE`; `npm test -- --watch=false`
+
+```
+[vitest.workspace] Skipping Storybook project (#707): checkout path contains a space (storybookjs/storybook#29572). Reason: path-conditional project skip.
+
+ Test Files  98 passed | 7 skipped (105)
+      Tests  581 passed | 20 skipped (601)
+```
+
+EXIT_CODE=0
+
+No `|storybook|` project in the run. W-05 satisfied via **explicit named skip**.

--- a/docs/repro/707-spaced-path.md
+++ b/docs/repro/707-spaced-path.md
@@ -144,14 +144,16 @@ No `|storybook|` project in the run. W-05 satisfied via **explicit named skip**.
 Guard: `scripts/verify-storybook-empty-suite.mjs` · npm script `verify:storybook-empty-suite`.
 Storybook project sets `passWithNoTests: false` in `vitest.workspace.ts`.
 
-Command: `npm run verify:storybook-empty-suite` → **GUARD_EXIT=0** (2026-07-31)
+Command: `npm run verify:storybook-empty-suite` → **GUARD_EXIT=0** (2026-07-31; sabotage rewritten to Vitest empty-collection path)
 
 ### C3-02 — Two-phase proof
 
-| Phase      | What ran                                                                       | Result                                                                   |
-| ---------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| 1 Healthy  | `BB_VITEST_PATH_HAS_SPACE=1 npm test -- --watch=false`                         | exit **0**; named skip line present                                      |
-| 2 Sabotage | Empty `.storybook/main.ts` `stories: []`, force-include, `--project storybook` | exit **1**; `InvalidStoriesEntryError` (empty stories array) — not green |
+| Phase      | What ran                                                                             | Result                                                              |
+| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| 1 Healthy  | `BB_VITEST_PATH_HAS_SPACE=1 npm test -- --watch=false`                               | exit **0**; named skip line present                                 |
+| 2 Sabotage | Non-empty stories glob matching **zero** files; force-include; `--project storybook` | exit **1**; Vitest `No test files found` (`passWithNoTests: false`) |
+
+Rejected proxy: `stories: []` → Storybook `InvalidStoriesEntryError` (never reaches Vitest). Guard fails if that appears.
 
 Phase 1 excerpt:
 
@@ -163,22 +165,22 @@ PASS phase 1: exit 0 with named Storybook skip
 Phase 2 excerpt:
 
 ```
-SB_CORE-COMMON_0004 (InvalidStoriesEntryError): Storybook could not index your stories.
-Your main configuration somehow does not contain a 'stories' field, or it resolved to an empty array.
-PASS phase 2: empty collection exited non-zero (status=1)
+WARN No story files found for the specified pattern: src\**\*.stories.__empty_collection__.@(ts|tsx)
+No test files found, exiting with code 1
+PASS phase 2: empty Vitest collection exited non-zero (status=1) with "No test files found"
 ```
 
-`.storybook/main.ts` restored after sabotage (finally).
+`.storybook/main.ts` restored after sabotage (finally + exit/signal handlers).
 
 ### C3-03 — Explicit skip vs silent collapse
 
-| Mode                 | Observable                                                                                                   | Exit      |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | --------- | --------- | ------------- |
-| **Explicit skip**    | Prints `[vitest.workspace] Skipping Storybook project (#707):… Reason: path-conditional project skip.`; no ` | storybook | ` project | 0 (unit only) |
-| **Empty collection** | No skip marker; Storybook fails indexing empty `stories` / non-zero (cannot report green)                    | non-zero  |
+| Mode                        | Observable                                                                                     | Exit                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------- |
+| **Explicit skip**           | Prints named skip reason; no storybook project                                                 | 0 (unit only)                          |
+| **Empty Vitest collection** | No skip marker; Vitest prints `No test files found` (not Storybook `InvalidStoriesEntryError`) | non-zero when `passWithNoTests: false` |
 
 Distinguishable — not the §15.2 row-11 proxy.
 
 ### C3-04 — Parity handoff (#740)
 
-Do **not** edit `scripts/verify-parity.mjs` here. #740 must add `npm run verify:storybook-empty-suite` to `npm run verify` and the §15.3.2 parity table.
+Do **not** edit `scripts/verify-parity.mjs` here. #740 PR #742 ships `npm run verify` / `verify-parity.mjs` but does **not** yet include `verify:storybook-empty-suite` (script lives on #707). Wire after merge/rebase: add step to STEPS + `package.json` when both land.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:watch": "vitest",
     "test:db": "node scripts/dbHealth.js",
     "verify:ci-gate": "bash scripts/verify-ci-shell-gate.sh",
+    "verify:storybook-empty-suite": "node scripts/verify-storybook-empty-suite.mjs",
     "typecheck": "tsc --noEmit",
     "check-bundle-size": "npm run build && node scripts/check-bundle-size.js",
     "cy:open": "cypress open",

--- a/scripts/verify-storybook-empty-suite.mjs
+++ b/scripts/verify-storybook-empty-suite.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * verify-storybook-empty-suite.mjs — Two-phase proof for W-06 (#707).
+ *
+ * Phase 1 (healthy): force path-conditional Storybook skip, run `npm test`,
+ *   require exit 0 and the named skip line. A red baseline cannot masquerade
+ *   as a successful sabotage (G-005).
+ * Phase 2 (sabotage): force-include Storybook, empty `.storybook` stories
+ *   collection, run the storybook project, require non-zero exit
+ *   (`passWithNoTests: false`). Restore stories via finally.
+ *
+ * Exit codes:
+ *   0  — both phases satisfied
+ *   1  — property false (healthy failed or sabotage did not fail)
+ *   75 — could not run (missing tooling / restore failure)
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EXIT_PROPERTY_FALSE = 1;
+const EXIT_COULD_NOT_RUN = 75;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const STORYBOOK_MAIN = path.join(REPO_ROOT, ".storybook", "main.ts");
+const SKIP_MARKER = "[vitest.workspace] Skipping Storybook project (#707):";
+
+const EMPTY_STORIES_MAIN = `import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: [],
+  addons: [
+    "@storybook/addon-essentials",
+    "@storybook/addon-onboarding",
+    "@chromatic-com/storybook",
+    "@storybook/experimental-addon-test",
+  ],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+};
+export default config;
+`;
+
+function failCouldNotRun(message) {
+  console.error(`COULD_NOT_RUN: ${message}`);
+  process.exit(EXIT_COULD_NOT_RUN);
+}
+
+function failProperty(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(EXIT_PROPERTY_FALSE);
+}
+
+function runCommand(command, args, envExtra = {}) {
+  const isWin = process.platform === "win32";
+  const result = spawnSync(command, args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: { ...process.env, ...envExtra },
+    // Windows: npm/npx are .cmd shims; spawnSync without shell hits EINVAL.
+    shell: isWin,
+  });
+  if (result.error) {
+    failCouldNotRun(`spawn failed (${command}): ${result.error.message}`);
+  }
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  return {
+    status: result.status ?? EXIT_COULD_NOT_RUN,
+    combined: `${stdout}\n${stderr}`,
+  };
+}
+
+function runNpm(args, envExtra = {}) {
+  return runCommand("npm", args, envExtra);
+}
+
+function ensurePrismaClient() {
+  console.log("--- preflight: npx prisma generate ---");
+  const { status } = runCommand("npx", ["prisma", "generate"]);
+  if (status !== 0) {
+    failCouldNotRun(`prisma generate exited ${status}`);
+  }
+}
+
+function phaseHealthy() {
+  console.log("--- phase 1 (healthy): explicit Storybook skip ---");
+  console.log("command: BB_VITEST_PATH_HAS_SPACE=1 npm test -- --watch=false");
+  const { status, combined } = runNpm(["test", "--", "--watch=false"], {
+    BB_VITEST_PATH_HAS_SPACE: "1",
+  });
+  if (!combined.includes(SKIP_MARKER)) {
+    failProperty(
+      "healthy phase: named skip line missing from output (explicit skip not proven)",
+    );
+  }
+  if (status !== 0) {
+    failProperty(
+      `healthy phase: expected exit 0, got ${status} (baseline must be green before sabotage)`,
+    );
+  }
+  console.log("PASS phase 1: exit 0 with named Storybook skip");
+}
+
+function phaseSabotage() {
+  console.log(
+    "--- phase 2 (sabotage): empty Storybook collection, force-include ---",
+  );
+  if (!fs.existsSync(STORYBOOK_MAIN)) {
+    failCouldNotRun(`missing ${STORYBOOK_MAIN}`);
+  }
+  const original = fs.readFileSync(STORYBOOK_MAIN, "utf8");
+  let restored = false;
+  const restore = () => {
+    if (!restored) {
+      fs.writeFileSync(STORYBOOK_MAIN, original, "utf8");
+      restored = true;
+    }
+  };
+
+  try {
+    fs.writeFileSync(STORYBOOK_MAIN, EMPTY_STORIES_MAIN, "utf8");
+    console.log(
+      "command: BB_VITEST_PATH_HAS_SPACE=0 npm test -- --watch=false --project storybook",
+    );
+    const { status, combined } = runNpm(
+      ["test", "--", "--watch=false", "--project", "storybook"],
+      { BB_VITEST_PATH_HAS_SPACE: "0" },
+    );
+    if (combined.includes(SKIP_MARKER)) {
+      failProperty(
+        "sabotage phase: Storybook was skipped — empty-collection collapse was not exercised",
+      );
+    }
+    if (status === 0) {
+      failProperty(
+        "sabotage phase: empty Storybook collection exited 0 (silent green — W-06 failed)",
+      );
+    }
+    console.log(
+      `PASS phase 2: empty collection exited non-zero (status=${status})`,
+    );
+  } finally {
+    restore();
+  }
+}
+
+function main() {
+  ensurePrismaClient();
+  phaseHealthy();
+  phaseSabotage();
+  console.log(
+    "PASS: W-06 empty-suite guard — healthy skip green AND emptied collection non-zero",
+  );
+  process.exit(0);
+}
+
+main();

--- a/scripts/verify-storybook-empty-suite.mjs
+++ b/scripts/verify-storybook-empty-suite.mjs
@@ -5,13 +5,15 @@
  * Phase 1 (healthy): force path-conditional Storybook skip, run `npm test`,
  *   require exit 0 and the named skip line. A red baseline cannot masquerade
  *   as a successful sabotage (G-005).
- * Phase 2 (sabotage): force-include Storybook, empty `.storybook` stories
- *   collection, run the storybook project, require non-zero exit
- *   (`passWithNoTests: false`). Restore stories via finally.
+ * Phase 2 (sabotage): force-include Storybook with a *non-empty* stories glob
+ *   that matches zero files (so Storybook indexes successfully), then require
+ *   Vitest to exit non-zero with "No test files found" — the
+ *   `passWithNoTests: false` path. An empty `stories: []` hard-error from
+ *   Storybook is rejected as a proxy (§15.2 row 11).
  *
  * Exit codes:
  *   0  — both phases satisfied
- *   1  — property false (healthy failed or sabotage did not fail)
+ *   1  — property false (healthy failed or sabotage did not fail correctly)
  *   75 — could not run (missing tooling / restore failure)
  */
 
@@ -27,11 +29,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..");
 const STORYBOOK_MAIN = path.join(REPO_ROOT, ".storybook", "main.ts");
 const SKIP_MARKER = "[vitest.workspace] Skipping Storybook project (#707):";
+/** Vitest message when passWithNoTests is false and zero files collected. */
+const EMPTY_COLLECTION_MARKER = "No test files found";
+/** Storybook rejects stories: [] before Vitest runs — not a W-06 proof. */
+const PROXY_MARKER = "InvalidStoriesEntryError";
 
-const EMPTY_STORIES_MAIN = `import type { StorybookConfig } from "@storybook/react-vite";
+/**
+ * Non-empty stories field that resolves to zero files. Storybook warns but
+ * still hands an empty set to Vitest — unlike `stories: []`, which throws.
+ */
+const EMPTY_COLLECTION_MAIN = `import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: [],
+  stories: ["../src/**/*.stories.__empty_collection__.@(ts|tsx)"],
   addons: [
     "@storybook/addon-essentials",
     "@storybook/addon-onboarding",
@@ -111,7 +121,7 @@ function phaseHealthy() {
 
 function phaseSabotage() {
   console.log(
-    "--- phase 2 (sabotage): empty Storybook collection, force-include ---",
+    "--- phase 2 (sabotage): Vitest empty collection (passWithNoTests: false) ---",
   );
   if (!fs.existsSync(STORYBOOK_MAIN)) {
     failCouldNotRun(`missing ${STORYBOOK_MAIN}`);
@@ -124,11 +134,23 @@ function phaseSabotage() {
       restored = true;
     }
   };
+  process.on("exit", restore);
+  process.on("SIGINT", () => {
+    restore();
+    process.exit(130);
+  });
+  process.on("SIGTERM", () => {
+    restore();
+    process.exit(143);
+  });
 
   try {
-    fs.writeFileSync(STORYBOOK_MAIN, EMPTY_STORIES_MAIN, "utf8");
+    fs.writeFileSync(STORYBOOK_MAIN, EMPTY_COLLECTION_MAIN, "utf8");
     console.log(
       "command: BB_VITEST_PATH_HAS_SPACE=0 npm test -- --watch=false --project storybook",
+    );
+    console.log(
+      "sabotage: stories glob matches zero files (not stories: [] — that is a proxy)",
     );
     const { status, combined } = runNpm(
       ["test", "--", "--watch=false", "--project", "storybook"],
@@ -139,13 +161,23 @@ function phaseSabotage() {
         "sabotage phase: Storybook was skipped — empty-collection collapse was not exercised",
       );
     }
+    if (combined.includes(PROXY_MARKER)) {
+      failProperty(
+        "sabotage phase: InvalidStoriesEntryError is a Storybook config hard-error, not Vitest empty collection (W-06 proxy)",
+      );
+    }
+    if (!combined.includes(EMPTY_COLLECTION_MARKER)) {
+      failProperty(
+        `sabotage phase: expected Vitest "${EMPTY_COLLECTION_MARKER}" (passWithNoTests path); got a different failure`,
+      );
+    }
     if (status === 0) {
       failProperty(
-        "sabotage phase: empty Storybook collection exited 0 (silent green — W-06 failed)",
+        "sabotage phase: empty Vitest collection exited 0 (silent green — W-06 failed; is passWithNoTests: false set?)",
       );
     }
     console.log(
-      `PASS phase 2: empty collection exited non-zero (status=${status})`,
+      `PASS phase 2: empty Vitest collection exited non-zero (status=${status}) with "${EMPTY_COLLECTION_MARKER}"`,
     );
   } finally {
     restore();
@@ -157,7 +189,7 @@ function main() {
   phaseHealthy();
   phaseSabotage();
   console.log(
-    "PASS: W-06 empty-suite guard — healthy skip green AND emptied collection non-zero",
+    "PASS: W-06 — healthy skip green AND Vitest empty collection non-zero (passWithNoTests)",
   );
   process.exit(0);
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -14,8 +14,10 @@ const dirname =
  * Path-with-spaces Storybook noise (#29572) is owned by #707 (path-conditional
  * project skip) — keep this file aligned with main for #702.
  *
- * Override for verification only (A3-06): set BB_VITEST_PATH_HAS_SPACE=0 to
- * force-include the Storybook project, or =1 to force-skip, regardless of cwd.
+ * Override for verification / falsification only (A3-06, W-06 guard): set
+ * BB_VITEST_PATH_HAS_SPACE=0 to force-include the Storybook project, or =1 to
+ * force-skip, regardless of cwd. Do not set in CI. Not a product env var —
+ * intentionally omitted from overview §10 / remember §2 (H-1).
  */
 function checkoutPathHasSpace(): boolean {
   const override = process.env.BB_VITEST_PATH_HAS_SPACE;

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -17,7 +17,7 @@ const dirname =
  * Override for verification / falsification only (A3-06, W-06 guard): set
  * BB_VITEST_PATH_HAS_SPACE=0 to force-include the Storybook project, or =1 to
  * force-skip, regardless of cwd. Do not set in CI. Not a product env var —
- * intentionally omitted from overview §10 / remember §2 (H-1).
+ * do not document in app/CI env tables (H-1).
  */
 function checkoutPathHasSpace(): boolean {
   const override = process.env.BB_VITEST_PATH_HAS_SPACE;

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -33,6 +33,8 @@ const storybookProject = {
   ],
   test: {
     name: "storybook",
+    // W-06: zero collected Storybook tests must not report green (#707).
+    passWithNoTests: false,
     browser: {
       enabled: true,
       headless: true,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,27 +10,49 @@ const dirname =
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 
-// More info at: https://storybook.js.org/docs/writing-tests/test-addon
-// Path-with-spaces Storybook noise (#29572) is owned by #707 (path-conditional
-// project skip) — keep this file aligned with main for #702.
-export default defineWorkspace([
-  "vitest.config.ts",
-  {
-    extends: "vite.config.ts",
-    plugins: [
-      // The plugin will run tests for the stories defined in your Storybook config
-      // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
-      storybookTest({ configDir: path.join(dirname, ".storybook") }),
-    ],
-    test: {
-      name: "storybook",
-      browser: {
-        enabled: true,
-        headless: true,
-        name: "chromium",
-        provider: "playwright",
-      },
-      setupFiles: [".storybook/vitest.setup.ts"],
+/**
+ * Path-with-spaces Storybook noise (#29572) is owned by #707 (path-conditional
+ * project skip) — keep this file aligned with main for #702.
+ *
+ * Override for verification only (A3-06): set BB_VITEST_PATH_HAS_SPACE=0 to
+ * force-include the Storybook project, or =1 to force-skip, regardless of cwd.
+ */
+function checkoutPathHasSpace(): boolean {
+  const override = process.env.BB_VITEST_PATH_HAS_SPACE;
+  if (override === "1") return true;
+  if (override === "0") return false;
+  return dirname.includes(" ") || process.cwd().includes(" ");
+}
+
+const storybookProject = {
+  extends: "vite.config.ts",
+  plugins: [
+    // The plugin will run tests for the stories defined in your Storybook config
+    // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
+    storybookTest({ configDir: path.join(dirname, ".storybook") }),
+  ],
+  test: {
+    name: "storybook",
+    browser: {
+      enabled: true,
+      headless: true,
+      name: "chromium",
+      provider: "playwright",
     },
+    setupFiles: [".storybook/vitest.setup.ts"],
   },
-]);
+};
+
+const pathHasSpace = checkoutPathHasSpace();
+
+if (pathHasSpace) {
+  // Explicit named skip — never register an empty Storybook project that can report green.
+  console.warn(
+    "[vitest.workspace] Skipping Storybook project (#707): checkout path contains a space (storybookjs/storybook#29572). Reason: path-conditional project skip.",
+  );
+}
+
+// More info at: https://storybook.js.org/docs/writing-tests/test-addon
+export default defineWorkspace(
+  pathHasSpace ? ["vitest.config.ts"] : ["vitest.config.ts", storybookProject],
+);


### PR DESCRIPTION
﻿## Summary

#707 — Path-conditional Storybook Vitest skip on spaced checkouts (W-05) + empty-suite guard proving an empty collection cannot report green (W-06).

Product work is complete on this tip. This PR does **not** edit `verify-parity.mjs` or workflows. Draft PR #708 is not reused (G-014).

## What changed

- `vitest.workspace.ts` — omit Storybook project when checkout path has a space; print an explicit named skip reason; `passWithNoTests: false`
- `scripts/verify-storybook-empty-suite.mjs` + `npm run verify:storybook-empty-suite` — two-phase W-06 proof
- `docs/repro/707-spaced-path.md` — RED before fix + GREEN / Q4 evidence

No user-facing change. `BB_VITEST_PATH_HAS_SPACE` is verification-only (do not set in CI).

## How it was verified

Fresh runs 2026-08-07 on this tip (full `npm run verify` is **not** on this tip — parity lives on #740):

### `npm test -- --watch=false` → exit 0

```
[vitest.workspace] Skipping Storybook project (#707): checkout path contains a space (storybookjs/storybook#29572). Reason: path-conditional project skip.

 Test Files  106 passed | 7 skipped (113)
      Tests  641 passed | 20 skipped (661)
   Duration  48.62s
```

### `npm run verify:storybook-empty-suite` → exit 0

```
PASS phase 1: exit 0 with named Storybook skip
No test files found, exiting with code 1
PASS phase 2: empty Vitest collection exited non-zero (status=1) with "No test files found"
PASS: W-06 — healthy skip green AND Vitest empty collection non-zero (passWithNoTests)
```

### RED evidence

`docs/repro/707-spaced-path.md` was committed **before** the fix (post-rebase: RED `71056e59` before fix `5afc9dca`).

## What is explicitly NOT covered

- Full `npm run verify` / wiring this guard into parity or CI — deferred (parity lives on #740)
- Space-free Storybook green on a relocated checkout — CI's job (space-free runner); local include-branch proof used the verification override only
- Optional hardening (refuse `BB_VITEST_PATH_HAS_SPACE` in CI; surgical `.storybook/main.ts` stories-field patch) — tracked on the follow-up wire issue, **not** in this PR
- Draft PR #708 — not reused

## Follow-ups after merge

1. Wire issue **#749**: add `verify:storybook-empty-suite` to `verify-parity.mjs` STEPS / `npm run verify` — **prereqs: #707 and #740 both merged**. Required: STEPS + smoke. Nice-to-have (same issue, not blockers): CI refuse override; surgical main.ts sabotage.
2. Do **not** put the wire or nice-to-haves into this PR or #740.
3. `#710` may clone this tip for measurement baseline once assigned.

## Guardrail note

Required status checks are not enforced on `main` (#648). Please read the pasted output rather than the check marks alone.



**Wire follow-up filed:** https://github.com/Bright-Bots-Initiative/brightboost/issues/749
